### PR TITLE
Fixes Issue open5e/open5e-api#85, Tome of Beasts invalid Senses for Monsters

### DIFF
--- a/data/tome_of_beasts/monsters.json
+++ b/data/tome_of_beasts/monsters.json
@@ -226,7 +226,7 @@
         "performance": 12,
         "persuasion": 12,
         "damage_immunities": "fire",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 17",
         "languages": "Common, Draconic, Elven, Sylvan",
         "challenge_rating": "11",
         "special_abilities": [
@@ -1428,7 +1428,7 @@
         "damage_resistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
         "damage_immunities": "cold, lightning, poison",
         "condition_immunities": "exhaustion, paralyzed, poisoned",
-        "senses": "passive Perception $1",
+        "senses": "Devil's Sight 120ft, passive Perception 18",
         "languages": "Celestial, Common, Infernal; telepathy 100 ft.",
         "challenge_rating": "11",
         "special_abilities": [
@@ -1591,7 +1591,7 @@
         "damage_resistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
         "damage_immunities": "fire, lightning, poison",
         "condition_immunities": "blinded, charmed, exhaustion, frightened, paralyzed, poisoned",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 18",
         "languages": "Celestial, Common, Infernal; telepathy 100 ft.",
         "challenge_rating": "11",
         "special_abilities": [
@@ -3326,7 +3326,7 @@
         "perception": 5,
         "stealth": 9,
         "damage_resistances": "acid, fire, poison",
-        "senses": "passive Perception $1",
+        "senses": "darkvision 60 ft., passive Perception 15",
         "languages": "understands Common; telepathy (touch)",
         "challenge_rating": "1/8",
         "special_abilities": [
@@ -3930,7 +3930,7 @@
         "charisma": 5,
         "damage_resistances": "bludgeoning, piercing, slashing",
         "condition_immunities": "charmed, frightened, paralyzed, petrified, prone, stunned",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 11",
         "languages": "-",
         "challenge_rating": "2",
         "special_abilities": [
@@ -6296,7 +6296,7 @@
         "damage_resistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
         "damage_immunities": "fire, poison",
         "condition_immunities": "poisoned",
-        "senses": "passive Perception $1",
+        "senses": "darkvision 120 ft., passive Perception 12",
         "languages": "Common, Infernal; telepathy 100 ft.",
         "challenge_rating": "10",
         "special_abilities": [
@@ -6542,7 +6542,7 @@
         "damage_resistances": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
         "damage_immunities": "fire, poison",
         "condition_immunities": "poisoned",
-        "senses": "passive Perception $1",
+        "senses": "darkvision 60ft, passive Perception 14",
         "languages": "Celestial, Common, Draconic, Infernal; telepathy (120 ft.)",
         "challenge_rating": "7",
         "special_abilities": [
@@ -7033,7 +7033,7 @@
         "wisdom": 12,
         "charisma": 6,
         "perception": 3,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 13",
         "languages": "-",
         "challenge_rating": "3",
         "special_abilities": [
@@ -7080,7 +7080,7 @@
         "wisdom": 9,
         "charisma": 6,
         "perception": 5,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 15",
         "languages": "-",
         "challenge_rating": "5",
         "special_abilities": [
@@ -7137,7 +7137,7 @@
         "wisdom": 11,
         "charisma": 10,
         "perception": 5,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 15",
         "languages": "-",
         "challenge_rating": "13",
         "special_abilities": [
@@ -7223,7 +7223,7 @@
         "wisdom": 11,
         "charisma": 8,
         "perception": 3,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 13",
         "languages": "-",
         "challenge_rating": "5",
         "special_abilities": [
@@ -8070,7 +8070,7 @@
         "persuasion": 10,
         "stealth": 7,
         "damage_immunities": "fire",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 60ft, darkvision 120ft, passive Perception 22",
         "languages": "Common, Draconic, Giant, Ignan, Infernal, Orc",
         "challenge_rating": "16",
         "special_abilities": [
@@ -8176,7 +8176,7 @@
         "persuasion": 8,
         "stealth": 6,
         "damage_immunities": "fire",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 30ft, darkvision 120ft, passive Perception 19",
         "languages": "Common, Draconic, Ignan, Giant, Infernal, Orc",
         "challenge_rating": "9",
         "special_abilities": [
@@ -8243,7 +8243,7 @@
         "persuasion": 5,
         "stealth": 4,
         "damage_immunities": "fire",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 30ft, darkvision 120ft, passive Perception 15",
         "languages": "Common, Draconic, Ignan",
         "challenge_rating": "3",
         "actions": [
@@ -8691,7 +8691,7 @@
         "perception": 12,
         "stealth": 5,
         "damage_immunities": "cold",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 60ft, darkvision 120ft, passive Perception 22",
         "languages": "Common, Draconic",
         "challenge_rating": "16",
         "special_abilities": [
@@ -8913,7 +8913,7 @@
         "stealth": 7,
         "damage_immunities": "cold",
         "condition_immunities": "charmed, frightened",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 60ft, darkvision 120ft, passive Perception 26",
         "languages": "Celestial, Common, Draconic, Infernal, Primordial, Void Speech",
         "challenge_rating": "24",
         "special_abilities": [
@@ -9062,7 +9062,7 @@
         "stealth": 5,
         "damage_immunities": "cold",
         "condition_immunities": "charmed, frightened",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 60ft, darkvision 120ft, passive Perception 21",
         "languages": "Common, Draconic, Void Speech",
         "challenge_rating": "14",
         "special_abilities": [
@@ -9196,7 +9196,7 @@
         "stealth": 4,
         "damage_immunities": "cold",
         "condition_immunities": "charmed, frightened",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 30ft, darkvision 120ft, passive Perception 18",
         "languages": "Common, Draconic, Void Speech",
         "challenge_rating": "9",
         "special_abilities": [
@@ -9287,7 +9287,7 @@
         "perception": 3,
         "stealth": 2,
         "damage_immunities": "cold",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 30ft, darkvision 120ft, passive Perception 13",
         "languages": "Common, Draconic, Void Speech",
         "challenge_rating": "2",
         "special_abilities": [
@@ -11238,7 +11238,7 @@
         "deception": 7,
         "insight": 5,
         "perception": 5,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 15",
         "languages": "Aquan, Common, Elvish, Sylvan",
         "challenge_rating": "5",
         "special_abilities": [
@@ -11768,7 +11768,7 @@
         "damage_resistances": "cold, fire; piercing damage",
         "damage_immunities": "poison",
         "condition_immunities": "blinded, deafened, exhausted, paralyzed, petrified, poisoned, prone, unconscious",
-        "senses": "passive Perception $1",
+        "senses": "blindsight 60ft, passive Perception 13",
         "languages": "Common, Draconic, telepathy 250 ft.",
         "challenge_rating": "1",
         "special_abilities": [
@@ -11897,7 +11897,7 @@
         "charisma": 13,
         "arcana": 6,
         "history": 6,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 10",
         "languages": "Common, Eonic, Giant, Sylvan",
         "challenge_rating": "1",
         "actions": [
@@ -13513,7 +13513,7 @@
         "damage_resistances": "cold",
         "damage_immunities": "necrotic",
         "condition_immunities": "frightened",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 15",
         "languages": "Common, Void Speech",
         "challenge_rating": "2",
         "special_abilities": [
@@ -13631,7 +13631,7 @@
         "charisma": 7,
         "stealth": 4,
         "damage_immunities": "cold",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 10",
         "languages": "Sylvan",
         "challenge_rating": "1/2",
         "special_abilities": [
@@ -13801,7 +13801,7 @@
         "charisma": 7,
         "perception": 4,
         "stealth": 8,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 14",
         "languages": "-",
         "challenge_rating": "6",
         "special_abilities": [
@@ -13856,7 +13856,7 @@
         "damage_resistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
         "damage_immunities": "poison",
         "condition_immunities": "charmed, frightened, exhaustion, poisoned",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 13",
         "languages": "Common",
         "challenge_rating": "6",
         "special_abilities": [
@@ -14513,7 +14513,7 @@
         "stealth": 4,
         "survival": 8,
         "damage_immunities": "fire",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 18",
         "languages": "Common, Giant",
         "challenge_rating": "9",
         "special_abilities": [
@@ -14572,7 +14572,7 @@
         "perception": 3,
         "damage_immunities": "poison",
         "condition_immunities": "poisoned",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 13",
         "languages": "Dwarvish, Giant",
         "challenge_rating": "4",
         "special_abilities": [
@@ -14631,7 +14631,7 @@
         "damage_resistances": "lightning, thunder",
         "damage_immunities": "cold; bludgeoning, piercing, and slashing from nonmagical attacks",
         "condition_immunities": "exhaustion",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 19",
         "languages": "Auran, Common, Giant (can't speak in roc form)",
         "challenge_rating": "19",
         "special_abilities": [
@@ -17441,7 +17441,7 @@
         "wisdom": 10,
         "charisma": 7,
         "perception": 3,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 13",
         "languages": "-",
         "challenge_rating": "5",
         "special_abilities": [
@@ -18442,7 +18442,7 @@
         "wisdom": 14,
         "charisma": 10,
         "survival": 5,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 12",
         "languages": "Loxodan",
         "challenge_rating": "6",
         "special_abilities": [
@@ -20226,7 +20226,7 @@
         "intelligence": 2,
         "wisdom": 10,
         "charisma": 5,
-        "senses": "passive Perception $1",
+        "senses": "darkvision 60ft, passive Perception 10",
         "languages": "-",
         "challenge_rating": "1/2",
         "special_abilities": [
@@ -20276,7 +20276,7 @@
         "wisdom": 11,
         "charisma": 16,
         "condition_immunities": "frightened",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 10",
         "languages": "Common, plus the language spoken by the noctini's fext master",
         "challenge_rating": "2",
         "special_abilities": [
@@ -20832,7 +20832,7 @@
         "charisma": 11,
         "arcana": 5,
         "investigation": 5,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 11",
         "languages": "Common",
         "challenge_rating": "1/4",
         "special_abilities": [
@@ -21133,7 +21133,7 @@
         "damage_vulnerabilities": "cold, fire",
         "damage_resistances": "bludgeoning, piercing",
         "condition_immunities": "blinded, deafened",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 13",
         "languages": "Common, Druidic, Elvish, Sylvan",
         "challenge_rating": "5",
         "special_abilities": [
@@ -24221,7 +24221,7 @@
         "dexterity_save": 7,
         "damage_resistances": "piercing from nonmagical attacks",
         "damage_immunities": "lightning, thunder",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 10",
         "languages": "Common, Sylvan",
         "challenge_rating": "3",
         "special_abilities": [
@@ -27358,7 +27358,7 @@
         "charisma": 10,
         "damage_resistances": "bludgeoning",
         "condition_immunities": "exhaustion",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 11",
         "languages": "-",
         "challenge_rating": "11",
         "special_abilities": [
@@ -27749,7 +27749,7 @@
         "athletics": 5,
         "deception": 4,
         "intimidation": 4,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 10",
         "languages": "any two languages",
         "challenge_rating": "4",
         "special_abilities": [
@@ -27822,7 +27822,7 @@
         "animal Handling": 4,
         "athletics": 7,
         " Intimidation": 5,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 11",
         "languages": "any two languages",
         "challenge_rating": "5",
         "special_abilities": [
@@ -27888,7 +27888,7 @@
         "wisdom": 11,
         "charisma": 13,
         "perception": 2,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 12",
         "languages": "one language (usually Common)",
         "challenge_rating": "4",
         "special_abilities": [
@@ -28096,7 +28096,7 @@
         "perception": 5,
         "stealth": 5,
         "survival": 3,
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 15",
         "languages": "Common, Elvish",
         "challenge_rating": "3",
         "special_abilities": [
@@ -28323,7 +28323,7 @@
         "perception": 3,
         "stealth": 4,
         "damage_resistances": "poison",
-        "senses": "passive Perception $1",
+        "senses": "passive Perception 13",
         "languages": "Common",
         "challenge_rating": "1/2",
         "special_abilities": [

--- a/data/tome_of_beasts/monsters.json
+++ b/data/tome_of_beasts/monsters.json
@@ -1428,7 +1428,7 @@
         "damage_resistances": "bludgeoning, piercing, and slashing from nonmagical attacks",
         "damage_immunities": "cold, lightning, poison",
         "condition_immunities": "exhaustion, paralyzed, poisoned",
-        "senses": "Devil's Sight 120ft, passive Perception 18",
+        "senses": "Devil sight 120ft, passive Perception 18",
         "languages": "Celestial, Common, Infernal; telepathy 100 ft.",
         "challenge_rating": "11",
         "special_abilities": [


### PR DESCRIPTION
Fixes Issue open5e/open5e-api#85

Updated the Senses on Tome of Beast monsters where they had the value of $1 to correct both the passive perception as well as adding in the missing senses they should have called out