### PR TITLE
cant -> can't

### DIFF
--- a/data/menagerie/monsters.json
+++ b/data/menagerie/monsters.json
@@ -252,7 +252,7 @@
       },
       {
         "name": "Forbiddance",
-        "desc": "The nagas lair is under the forbiddance spell. Until it is dispelled, creatures in the lair cant teleport or use planar travel. Fiends and undead that are not the nagas allies take 27 (5d10) radiant damage when they enter or start their turn in the lair."
+        "desc": "The nagas lair is under the forbiddance spell. Until it is dispelled, creatures in the lair can't teleport or use planar travel. Fiends and undead that are not the nagas allies take 27 (5d10) radiant damage when they enter or start their turn in the lair."
       },
       {
         "name": "Magic Resistance",
@@ -493,7 +493,7 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "When the dragon fails a saving throw, it can choose to succeed instead. When it does, its scales dull briefly, and it cant use telepathy or psionic abilities until the end of its next turn."
+        "desc": "When the dragon fails a saving throw, it can choose to succeed instead. When it does, its scales dull briefly, and it can't use telepathy or psionic abilities until the end of its next turn."
       },
       {
         "name": "Psionic Powers",
@@ -605,7 +605,7 @@
     "special_abilities": [
       {
         "name": "Ambusher",
-        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that cant see it with its bite, it can deal piercing damage and grapple the target simultaneously."
+        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that can't see it with its bite, it can deal piercing damage and grapple the target simultaneously."
       },
       {
         "name": "Amphibious",
@@ -631,7 +631,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +12 to hit  reach 10 ft.  one target. Hit: 22 (3d10 + 6) piercing damage plus 4 (1d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 20)  and a Large or smaller creature grappled in this way is restrained. While grappling a creature  the dragon cant bite or use Acid Spit against another target."
+        "desc": "Melee Weapon Attack: +12 to hit  reach 10 ft.  one target. Hit: 22 (3d10 + 6) piercing damage plus 4 (1d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 20)  and a Large or smaller creature grappled in this way is restrained. While grappling a creature  the dragon can't bite or use Acid Spit against another target."
       },
       {
         "name": "Claw",
@@ -663,7 +663,7 @@
       },
       {
         "name": "Darkness",
-        "desc": "The dragon creates a 20-foot-radius sphere of magical darkness originating from a point it can see within 120 feet. Darkvision cant penetrate this darkness. The darkness lasts for 1 minute or until the dragon uses this action again."
+        "desc": "The dragon creates a 20-foot-radius sphere of magical darkness originating from a point it can see within 120 feet. Darkvision can't penetrate this darkness. The darkness lasts for 1 minute or until the dragon uses this action again."
       },
       {
         "name": "Roar",
@@ -722,7 +722,7 @@
     "special_abilities": [
       {
         "name": "Ambusher",
-        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that cant see it with its bite, it can deal piercing damage and grapple the target simultaneously."
+        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that can't see it with its bite, it can deal piercing damage and grapple the target simultaneously."
       },
       {
         "name": "Innate Spellcasting",
@@ -736,7 +736,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +12 to hit  reach 10 ft.  one target. Hit: 22 (3d10 + 6) piercing damage plus 4 (1d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 20)  and a Large or smaller creature grappled in this way is restrained. While grappling a creature  the dragon cant bite or use Acid Spit against another target."
+        "desc": "Melee Weapon Attack: +12 to hit  reach 10 ft.  one target. Hit: 22 (3d10 + 6) piercing damage plus 4 (1d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 20)  and a Large or smaller creature grappled in this way is restrained. While grappling a creature  the dragon can't bite or use Acid Spit against another target."
       },
       {
         "name": "Claw",
@@ -768,7 +768,7 @@
       },
       {
         "name": "Darkness",
-        "desc": "The dragon creates a 20-foot-radius sphere of magical darkness originating from a point it can see within 120 feet. Darkvision cant penetrate this darkness. The darkness lasts for 1 minute or until the dragon uses this action again."
+        "desc": "The dragon creates a 20-foot-radius sphere of magical darkness originating from a point it can see within 120 feet. Darkvision can't penetrate this darkness. The darkness lasts for 1 minute or until the dragon uses this action again."
       },
       {
         "name": "Roar",
@@ -865,7 +865,7 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dragon exhales a 90-foot-long  5-foot wide-line of lightning. Each creature in that area makes a DC 20 Dexterity saving throw  taking 77 (14d10) lightning damage on a failed save or half damage on a success. A creature that fails the save cant take reactions until the end of its next turn."
+        "desc": "The dragon exhales a 90-foot-long  5-foot wide-line of lightning. Each creature in that area makes a DC 20 Dexterity saving throw  taking 77 (14d10) lightning damage on a failed save or half damage on a success. A creature that fails the save can't take reactions until the end of its next turn."
       },
       {
         "name": "Quake",
@@ -1002,7 +1002,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its staff."
+        "desc": "The dragon magically takes the shape of a humanoid or beast or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its staff."
       }
     ],
     "reactions": [
@@ -1122,7 +1122,7 @@
       },
       {
         "name": "Lightning Breath",
-        "desc": "The dragon exhales lightning in a 90-foot-long  5-foot-wide line. Each creature in the area makes a DC 20 Dexterity saving throw  taking 69 (13d10) lightning damage on a failed save or half damage on a success. A creature that fails the saving throw cant take reactions until the end of its next turn."
+        "desc": "The dragon exhales lightning in a 90-foot-long  5-foot-wide line. Each creature in the area makes a DC 20 Dexterity saving throw  taking 69 (13d10) lightning damage on a failed save or half damage on a success. A creature that fails the saving throw can't take reactions until the end of its next turn."
       },
       {
         "name": "Ocean Surge",
@@ -1130,7 +1130,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Lightning Pulse  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its trident."
+        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Lightning Pulse  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its trident."
       }
     ],
     "reactions": [
@@ -1254,7 +1254,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Acid Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its war pick."
+        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Acid Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its war pick."
       }
     ],
     "reactions": [
@@ -1356,7 +1356,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +12 to hit  reach 10 ft.  one target. Hit: 28 (4d10 + 6) piercing damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 20)  and a Large or smaller creature grappled in this way is restrained. While grappling a creature  the dragon cant bite another target."
+        "desc": "Melee Weapon Attack: +12 to hit  reach 10 ft.  one target. Hit: 28 (4d10 + 6) piercing damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 20)  and a Large or smaller creature grappled in this way is restrained. While grappling a creature  the dragon can't bite another target."
       },
       {
         "name": "Slam",
@@ -1386,7 +1386,7 @@
       },
       {
         "name": "Entomb (While Bloodied",
-        "desc": "The dragon targets a creature on the ground within 60 feet, forcing it to make a DC 15 Dexterity saving throw. On a failure, the creature is magically entombed 5 feet under the earth. While entombed, the target is blinded, restrained, and cant breathe. A creature can use an action to make a DC 15 Strength check, freeing an entombed creature on a success."
+        "desc": "The dragon targets a creature on the ground within 60 feet, forcing it to make a DC 15 Dexterity saving throw. On a failure, the creature is magically entombed 5 feet under the earth. While entombed, the target is blinded, restrained, and can't breathe. A creature can use an action to make a DC 15 Strength check, freeing an entombed creature on a success."
       }
     ],
     "speed_json": {
@@ -1601,7 +1601,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its greatsword."
+        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its greatsword."
       }
     ],
     "reactions": [
@@ -1724,7 +1724,7 @@
       },
       {
         "name": "Honeyed Words",
-        "desc": "The dragons words sow doubt in the minds of those who hear them. One creature within 60 feet who can hear and understand the dragon makes a DC 17 Wisdom saving throw. On a failure  the creature must use its reaction  if available  to make one attack against a creature of the dragons choice with whatever weapon it has to do so  moving up to its speed as part of the reaction if necessary. It need not use any special class features (such as Sneak Attack or Divine Smite) when making this attack. If it cant get in a position to attack the creature  it moves as far as it can toward the target before regaining its senses. A creature immune to being charmed is immune to this ability."
+        "desc": "The dragons words sow doubt in the minds of those who hear them. One creature within 60 feet who can hear and understand the dragon makes a DC 17 Wisdom saving throw. On a failure  the creature must use its reaction  if available  to make one attack against a creature of the dragons choice with whatever weapon it has to do so  moving up to its speed as part of the reaction if necessary. It need not use any special class features (such as Sneak Attack or Divine Smite) when making this attack. If it can't get in a position to attack the creature  it moves as far as it can toward the target before regaining its senses. A creature immune to being charmed is immune to this ability."
       }
     ],
     "reactions": [
@@ -2048,7 +2048,7 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "When the dragon fails a saving throw, it can choose to succeed instead. When it does, its eyes dull as it briefly loses its connection to the future. Until the end of its next turn, it cant use Foretell, Prognosticate, or Prophesy Doom, and it loses its Predictive Harmonics trait."
+        "desc": "When the dragon fails a saving throw, it can choose to succeed instead. When it does, its eyes dull as it briefly loses its connection to the future. Until the end of its next turn, it can't use Foretell, Prognosticate, or Prophesy Doom, and it loses its Predictive Harmonics trait."
       },
       {
         "name": "Predictive Harmonics",
@@ -2215,11 +2215,11 @@
       },
       {
         "name": "Lurk",
-        "desc": "If the dragon is in dim light or darkness, it magically becomes invisible until it attacks, causes a creature to make a saving throw, or enters an area of bright light. It cant use this ability if it has taken radiant damage since the end of its last turn."
+        "desc": "If the dragon is in dim light or darkness, it magically becomes invisible until it attacks, causes a creature to make a saving throw, or enters an area of bright light. It can't use this ability if it has taken radiant damage since the end of its last turn."
       },
       {
         "name": "Slip Through Shadows",
-        "desc": "If the dragon is in dim light or darkness, it magically teleports up to 45 feet to an unoccupied space that is also in dim light or darkness. The dragon cant use this ability if it has taken radiant damage since the end of its last turn."
+        "desc": "If the dragon is in dim light or darkness, it magically teleports up to 45 feet to an unoccupied space that is also in dim light or darkness. The dragon can't use this ability if it has taken radiant damage since the end of its last turn."
       },
       {
         "name": "Horrid Whispers (Costs 2 Actions)",
@@ -2274,7 +2274,7 @@
     "special_abilities": [
       {
         "name": "Cloud Strider",
-        "desc": "The dragon suffers no harmful effects from high altitudes. When flying at high altitude, the dragon can, after 1 minute of concentration, discorporate into clouds. In this form, it has advantage on Stealth checks, its fly speed increases to 300 feet, it is immune to all nonmagical damage, it has resistance to magical damage, and it cant take any actions except Hide. If it takes damage or descends more than 500 feet from where it transformed, it immediately returns to its corporeal form. It can revert to its true form as an action."
+        "desc": "The dragon suffers no harmful effects from high altitudes. When flying at high altitude, the dragon can, after 1 minute of concentration, discorporate into clouds. In this form, it has advantage on Stealth checks, its fly speed increases to 300 feet, it is immune to all nonmagical damage, it has resistance to magical damage, and it can't take any actions except Hide. If it takes damage or descends more than 500 feet from where it transformed, it immediately returns to its corporeal form. It can revert to its true form as an action."
       },
       {
         "name": "Legendary Resistance (3/Day)",
@@ -2324,7 +2324,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Spit Frost  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its rapier."
+        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Spit Frost  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its rapier."
       }
     ],
     "reactions": [
@@ -2568,7 +2568,7 @@
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, cant travel to or from the Material Plane)"
+        "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, can't travel to or from the Material Plane)"
       }
     ],
     "actions": [
@@ -2606,7 +2606,7 @@
       },
       {
         "name": "Cast Spell",
-        "desc": "The empyrean casts a spell. The empyrean cant use this option if it has cast a spell since the start of its last turn."
+        "desc": "The empyrean casts a spell. The empyrean can't use this option if it has cast a spell since the start of its last turn."
       },
       {
         "name": "Fly",
@@ -2849,7 +2849,7 @@
     "bonus_actions": [
       {
         "name": "Shapeshift",
-        "desc": "The werewolf changes its form to a wolf, a wolf-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged. It cant speak in wolf form. Its equipment is not transformed. It reverts to its true form if it dies."
+        "desc": "The werewolf changes its form to a wolf, a wolf-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged. It can't speak in wolf form. Its equipment is not transformed. It reverts to its true form if it dies."
       },
       {
         "name": "Frenzied Bite (While Bloodied",
@@ -3064,7 +3064,7 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "When the dragon fails a saving throw, it can choose to succeed instead. When it does, its scales dull briefly, and it cant use telepathy or psionic abilities until the end of its next turn."
+        "desc": "When the dragon fails a saving throw, it can choose to succeed instead. When it does, its scales dull briefly, and it can't use telepathy or psionic abilities until the end of its next turn."
       },
       {
         "name": "Psionic Powers",
@@ -3176,7 +3176,7 @@
     "special_abilities": [
       {
         "name": "Ambusher",
-        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that cant see it with its bite, it can deal piercing damage and grapple the target simultaneously."
+        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that can't see it with its bite, it can deal piercing damage and grapple the target simultaneously."
       },
       {
         "name": "Amphibious",
@@ -3202,7 +3202,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +15 to hit  reach 15 ft.  one target. Hit: 30 (4d10 + 8) piercing damage plus 9 (2d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 23)  and a Huge or smaller creature grappled in this way is restrained. While grappling a creature  the dragon cant bite or use Acid Spit against another target."
+        "desc": "Melee Weapon Attack: +15 to hit  reach 15 ft.  one target. Hit: 30 (4d10 + 8) piercing damage plus 9 (2d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 23)  and a Huge or smaller creature grappled in this way is restrained. While grappling a creature  the dragon can't bite or use Acid Spit against another target."
       },
       {
         "name": "Claw",
@@ -3234,7 +3234,7 @@
       },
       {
         "name": "Darkness",
-        "desc": "The dragon creates a 40-foot-radius sphere of magical darkness originating from a point it can see within 120 feet. Darkvision cant penetrate this darkness. The darkness lasts for 1 minute or until the dragon uses this action again."
+        "desc": "The dragon creates a 40-foot-radius sphere of magical darkness originating from a point it can see within 120 feet. Darkvision can't penetrate this darkness. The darkness lasts for 1 minute or until the dragon uses this action again."
       },
       {
         "name": "Roar",
@@ -3331,7 +3331,7 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dragon exhales a 120-foot-long  10-foot-wide line of lightning. Each creature in that area makes a DC 24 Dexterity saving throw  taking 94 (17d10) lightning damage on a failed save or half damage on a success. A creature that fails the save cant take reactions until the end of its next turn."
+        "desc": "The dragon exhales a 120-foot-long  10-foot-wide line of lightning. Each creature in that area makes a DC 24 Dexterity saving throw  taking 94 (17d10) lightning damage on a failed save or half damage on a success. A creature that fails the save can't take reactions until the end of its next turn."
       },
       {
         "name": "Quake",
@@ -3468,7 +3468,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its staff."
+        "desc": "The dragon magically takes the shape of a humanoid or beast or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its staff."
       }
     ],
     "reactions": [
@@ -3588,7 +3588,7 @@
       },
       {
         "name": "Lightning Breath",
-        "desc": "The dragon exhales lightning in a 120-foot-long  10-foot-wide line. Each creature in the area makes a DC 23 Dexterity saving throw  taking 93 (16d10) lightning damage on a failed save or half damage on a success. A creature that fails the saving throw cant take reactions until the end of its next turn."
+        "desc": "The dragon exhales lightning in a 120-foot-long  10-foot-wide line. Each creature in the area makes a DC 23 Dexterity saving throw  taking 93 (16d10) lightning damage on a failed save or half damage on a success. A creature that fails the saving throw can't take reactions until the end of its next turn."
       },
       {
         "name": "Ocean Surge",
@@ -3598,7 +3598,7 @@
     "bonus_actions": [
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast, or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form, the dragons stats are unchanged except for its size. It cant use Lightning Pulse, Breath Weapons, Tail Attack, or Wing Attack except in dragon form. In beast form, it can attack only with its bite and claws, if appropriate to its form. If the beast form is Large or smaller, the reach of these attacks is reduced to 5 feet. In humanoid form, it can attack only with its trident."
+        "desc": "The dragon magically takes the shape of a humanoid or beast, or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form, the dragons stats are unchanged except for its size. It can't use Lightning Pulse, Breath Weapons, Tail Attack, or Wing Attack except in dragon form. In beast form, it can attack only with its bite and claws, if appropriate to its form. If the beast form is Large or smaller, the reach of these attacks is reduced to 5 feet. In humanoid form, it can attack only with its trident."
       }
     ],
     "reactions": [
@@ -3608,7 +3608,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast, or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form, the dragons stats are unchanged except for its size. It cant use Lightning Pulse, Breath Weapons, Tail Attack, or Wing Attack except in dragon form. In beast form, it can attack only with its bite and claws, if appropriate to its form. If the beast form is Large or smaller, the reach of these attacks is reduced to 5 feet. In humanoid form, it can attack only with its trident."
+        "desc": "The dragon magically takes the shape of a humanoid or beast, or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form, the dragons stats are unchanged except for its size. It can't use Lightning Pulse, Breath Weapons, Tail Attack, or Wing Attack except in dragon form. In beast form, it can attack only with its bite and claws, if appropriate to its form. If the beast form is Large or smaller, the reach of these attacks is reduced to 5 feet. In humanoid form, it can attack only with its trident."
       }
     ],
     "legendary_actions": [
@@ -3728,7 +3728,7 @@
     "bonus_actions": [
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast, or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form, the dragons stats are unchanged except for its size. It cant use Acid Spit, Breath Weapons, Tail Attack, or Wing Attack except in dragon form. In beast form, it can attack only with its bite and claws, if appropriate to its form. If the beast form is Large or smaller, the reach of these attacks is reduced to 5 feet. In humanoid form, it can attack only with its war pick."
+        "desc": "The dragon magically takes the shape of a humanoid or beast, or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form, the dragons stats are unchanged except for its size. It can't use Acid Spit, Breath Weapons, Tail Attack, or Wing Attack except in dragon form. In beast form, it can attack only with its bite and claws, if appropriate to its form. If the beast form is Large or smaller, the reach of these attacks is reduced to 5 feet. In humanoid form, it can attack only with its war pick."
       }
     ],
     "reactions": [
@@ -3738,7 +3738,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast, or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form, the dragons stats are unchanged except for its size. It cant use Acid Spit, Breath Weapons, Tail Attack, or Wing Attack except in dragon form. In beast form, it can attack only with its bite and claws, if appropriate to its form. If the beast form is Large or smaller, the reach of these attacks is reduced to 5 feet. In humanoid form, it can attack only with its war pick."
+        "desc": "The dragon magically takes the shape of a humanoid or beast, or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form, the dragons stats are unchanged except for its size. It can't use Acid Spit, Breath Weapons, Tail Attack, or Wing Attack except in dragon form. In beast form, it can attack only with its bite and claws, if appropriate to its form. If the beast form is Large or smaller, the reach of these attacks is reduced to 5 feet. In humanoid form, it can attack only with its war pick."
       }
     ],
     "legendary_actions": [
@@ -3834,7 +3834,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +15 to hit  reach 15 ft.  one target. Hit: 35 (5d10 + 8) piercing damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 23)  and a Huge or smaller creature grappled in this way is restrained. While grappling a creature  the dragon cant bite another target."
+        "desc": "Melee Weapon Attack: +15 to hit  reach 15 ft.  one target. Hit: 35 (5d10 + 8) piercing damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 23)  and a Huge or smaller creature grappled in this way is restrained. While grappling a creature  the dragon can't bite another target."
       },
       {
         "name": "Slam",
@@ -3864,7 +3864,7 @@
       },
       {
         "name": "Entomb (While Bloodied",
-        "desc": "The dragon targets a creature on the ground within 60 feet, forcing it to make a DC 17 Dexterity saving throw. On a failure, the creature is magically entombed 5 feet under the earth. While entombed, the target is blinded, restrained, and cant breathe. A creature can use an action to make a DC 17 Strength check, freeing an entombed creature on a success."
+        "desc": "The dragon targets a creature on the ground within 60 feet, forcing it to make a DC 17 Dexterity saving throw. On a failure, the creature is magically entombed 5 feet under the earth. While entombed, the target is blinded, restrained, and can't breathe. A creature can use an action to make a DC 17 Strength check, freeing an entombed creature on a success."
       }
     ],
     "speed_json": {
@@ -4079,7 +4079,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its greatsword."
+        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its greatsword."
       }
     ],
     "reactions": [
@@ -4206,7 +4206,7 @@
       },
       {
         "name": "Honeyed Words",
-        "desc": "The dragons words sow doubt in the minds of those who hear them. One creature within 60 feet who can hear and understand the dragon makes a DC 19 Wisdom saving throw. On a failure  the creature must use its reaction  if available  to make one attack against a creature of the dragons choice with whatever weapon it has to do so  moving up to its speed as part of the reaction if necessary. It need not use any special class features (such as Sneak Attack or Divine Smite) when making this attack. If it cant get in a position to attack the creature  it moves as far as it can toward the target before regaining its senses. A creature immune to being charmed is immune to this ability."
+        "desc": "The dragons words sow doubt in the minds of those who hear them. One creature within 60 feet who can hear and understand the dragon makes a DC 19 Wisdom saving throw. On a failure  the creature must use its reaction  if available  to make one attack against a creature of the dragons choice with whatever weapon it has to do so  moving up to its speed as part of the reaction if necessary. It need not use any special class features (such as Sneak Attack or Divine Smite) when making this attack. If it can't get in a position to attack the creature  it moves as far as it can toward the target before regaining its senses. A creature immune to being charmed is immune to this ability."
       }
     ],
     "reactions": [
@@ -4534,7 +4534,7 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "When the dragon fails a saving throw, it can choose to succeed instead. When it does, its eyes dull as it briefly loses its connection to the future. Until the end of its next turn, it cant use Foretell, Prognosticate, or Prophesy Doom, and it loses its Predictive Harmonics trait."
+        "desc": "When the dragon fails a saving throw, it can choose to succeed instead. When it does, its eyes dull as it briefly loses its connection to the future. Until the end of its next turn, it can't use Foretell, Prognosticate, or Prophesy Doom, and it loses its Predictive Harmonics trait."
       },
       {
         "name": "Predictive Harmonics",
@@ -4713,11 +4713,11 @@
       },
       {
         "name": "Lurk",
-        "desc": "If the dragon is in dim light or darkness, it magically becomes invisible until it attacks, causes a creature to make a saving throw, or enters an area of bright light. It cant use this ability if it has taken radiant damage since the end of its last turn."
+        "desc": "If the dragon is in dim light or darkness, it magically becomes invisible until it attacks, causes a creature to make a saving throw, or enters an area of bright light. It can't use this ability if it has taken radiant damage since the end of its last turn."
       },
       {
         "name": "Slip Through Shadows",
-        "desc": "If the dragon is in dim light or darkness, it magically teleports up to 60 feet to an unoccupied space that is also in dim light or darkness. The dragon cant use this ability if it has taken radiant damage since the end of its last turn."
+        "desc": "If the dragon is in dim light or darkness, it magically teleports up to 60 feet to an unoccupied space that is also in dim light or darkness. The dragon can't use this ability if it has taken radiant damage since the end of its last turn."
       },
       {
         "name": "Horrid Whispers (Costs 2 Actions)",
@@ -4772,7 +4772,7 @@
     "special_abilities": [
       {
         "name": "Cloud Strider",
-        "desc": "The dragon suffers no harmful effects from high altitudes. When flying at high altitude, the dragon can, after 1 minute of concentration, discorporate into clouds. In this form, it has advantage on Stealth checks, its fly speed increases to 300 feet, it is immune to all nonmagical damage, it has resistance to magical damage, and it cant take any actions except Hide. If it takes damage or descends more than 500 feet from where it transformed, it immediately returns to its corporeal form. The dragon can revert to its true form as an action."
+        "desc": "The dragon suffers no harmful effects from high altitudes. When flying at high altitude, the dragon can, after 1 minute of concentration, discorporate into clouds. In this form, it has advantage on Stealth checks, its fly speed increases to 300 feet, it is immune to all nonmagical damage, it has resistance to magical damage, and it can't take any actions except Hide. If it takes damage or descends more than 500 feet from where it transformed, it immediately returns to its corporeal form. The dragon can revert to its true form as an action."
       },
       {
         "name": "Legendary Resistance (3/Day)",
@@ -4822,7 +4822,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Spit Frost  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its rapier."
+        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Spit Frost  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its rapier."
       }
     ],
     "reactions": [
@@ -5050,7 +5050,7 @@
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one target. Hit: 12 (2d8 + 3) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 13). Until this grapple ends  the target is restrained  and the ankheg cant use its claws on anyone else."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one target. Hit: 12 (2d8 + 3) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 13). Until this grapple ends  the target is restrained  and the ankheg can't use its claws on anyone else."
       },
       {
         "name": "Bite",
@@ -5100,7 +5100,7 @@
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one target. Hit: 12 (2d8 + 3) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 13). Until this grapple ends  the target is restrained  and the ankheg cant use its claws on anyone else."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one target. Hit: 12 (2d8 + 3) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 13). Until this grapple ends  the target is restrained  and the ankheg can't use its claws on anyone else."
       },
       {
         "name": "Bite",
@@ -5411,7 +5411,7 @@
       },
       {
         "name": "Shocking Grasp (Cantrip; V, S)",
-        "desc": "Melee Spell Attack: +11 to hit  reach 5 ft.  one creature. Hit: 18 (4d8) lightning damage  and the target cant take reactions until the start of its next turn."
+        "desc": "Melee Spell Attack: +11 to hit  reach 5 ft.  one creature. Hit: 18 (4d8) lightning damage  and the target can't take reactions until the start of its next turn."
       },
       {
         "name": "Fire Bolt (Cantrip; V, S)",
@@ -5419,7 +5419,7 @@
       },
       {
         "name": "Globe of Invulnerability (6th-Level; V, S, M, Concentration)",
-        "desc": "A glimmering 10-foot-radius sphere appears around the blademaster. It remains for 1 minute and doesnt move with the blademaster. Any 5th-level or lower spell cast from outside the sphere cant affect anything inside the sphere  even if cast with a higher level spell slot. Targeting something inside the sphere or including the spheres space in an area has no effect on anything inside."
+        "desc": "A glimmering 10-foot-radius sphere appears around the blademaster. It remains for 1 minute and doesnt move with the blademaster. Any 5th-level or lower spell cast from outside the sphere can't affect anything inside the sphere  even if cast with a higher level spell slot. Targeting something inside the sphere or including the spheres space in an area has no effect on anything inside."
       },
       {
         "name": "Teleport (7th-Level; V)",
@@ -5445,7 +5445,7 @@
       },
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The blademaster teleports to an unoccupied space they can see within 30 feet. The blademaster cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The blademaster teleports to an unoccupied space they can see within 30 feet. The blademaster can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -5610,7 +5610,7 @@
     "special_abilities": [
       {
         "name": "Foresight",
-        "desc": "When the foresight spell is active, the archmage cant be surprised and has advantage on ability checks, attack rolls, and saving throws. In addition, other creatures have disadvantage on attack rolls against the archmage."
+        "desc": "When the foresight spell is active, the archmage can't be surprised and has advantage on ability checks, attack rolls, and saving throws. In addition, other creatures have disadvantage on attack rolls against the archmage."
       },
       {
         "name": "Mind Blank",
@@ -5648,7 +5648,7 @@
       },
       {
         "name": "Globe of Invulnerability (6th-Level; V, S, M, Concentration)",
-        "desc": "A glimmering  10-foot-radius sphere appears around the archmage. It remains for 1 minute and doesnt move with the archmage. Any 5th-level or lower spell cast from outside the sphere cant affect anything inside the sphere  even if cast with a higher level spell slot. Targeting something inside the sphere or including the spheres space in an area has no effect on anything inside."
+        "desc": "A glimmering  10-foot-radius sphere appears around the archmage. It remains for 1 minute and doesnt move with the archmage. Any 5th-level or lower spell cast from outside the sphere can't affect anything inside the sphere  even if cast with a higher level spell slot. Targeting something inside the sphere or including the spheres space in an area has no effect on anything inside."
       },
       {
         "name": "Teleport (7th-Level; V)",
@@ -5769,7 +5769,7 @@
       },
       {
         "name": "Additionally",
-        "desc": "Such a creature does not suffer this effect if it is already on its plane of origin. The archpriest cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "Such a creature does not suffer this effect if it is already on its plane of origin. The archpriest can't cast this spell and a 1st-level or higher spell on the same turn."
       },
       {
         "name": "Archpriests head religious orders and often serve on a monarchs council",
@@ -6463,7 +6463,7 @@
       },
       {
         "name": "Legendary Resistance (2/Day)",
-        "desc": "If the balor general fails a saving throw, it can choose to succeed instead. When it does so, it wards itself with its sword. The lightning that wreathes the sword winks out. The lightning reappears at the beginning of the balors next turn. Until then, the balors lightning sword deals no lightning damage, and the balor cant use Avenging Bolt."
+        "desc": "If the balor general fails a saving throw, it can choose to succeed instead. When it does so, it wards itself with its sword. The lightning that wreathes the sword winks out. The lightning reappears at the beginning of the balors next turn. Until then, the balors lightning sword deals no lightning damage, and the balor can't use Avenging Bolt."
       },
       {
         "name": "Fast Reflexes",
@@ -6864,7 +6864,7 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The bat cant use blindsight while deafened."
+        "desc": "The bat can't use blindsight while deafened."
       },
       {
         "name": "Keen Hearing",
@@ -6936,7 +6936,7 @@
       },
       {
         "name": "Beard",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one creature. Hit: 7 (1d8 + 3) piercing damage  and the target is poisoned until the end of the devils next turn. While poisoned in this way  the target cant regain hit points."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one creature. Hit: 7 (1d8 + 3) piercing damage  and the target is poisoned until the end of the devils next turn. While poisoned in this way  the target can't regain hit points."
       },
       {
         "name": "Glaive",
@@ -7489,7 +7489,7 @@
     },
     "senses": "passive Perception 13",
     "challenge_rating": "1",
-    "languages": "Blink Dog; understands but cant speak Sylvan",
+    "languages": "Blink Dog; understands but can't speak Sylvan",
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
@@ -8000,7 +8000,7 @@
     "actions": [
       {
         "name": "Barbed Spear",
-        "desc": "Melee or Ranged Weapon Attack: +8 to hit  reach 10 ft. or range 20/60 ft.  one target. Hit: 15 (2d10 + 4) piercing damage. If the attack is a melee attack against a creature  the target is grappled (escape DC 16). Until this grapple ends  the devil cant use its barbed spear on another target."
+        "desc": "Melee or Ranged Weapon Attack: +8 to hit  reach 10 ft. or range 20/60 ft.  one target. Hit: 15 (2d10 + 4) piercing damage. If the attack is a melee attack against a creature  the target is grappled (escape DC 16). Until this grapple ends  the devil can't use its barbed spear on another target."
       },
       {
         "name": "Claw",
@@ -8206,7 +8206,7 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 9 (2d4+4) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 14). Until this grapple ends  the bear cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 9 (2d4+4) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 14). Until this grapple ends  the bear can't attack a different target with its claws."
       }
     ],
     "speed_json": {
@@ -8253,7 +8253,7 @@
     "actions": [
       {
         "name": "Strangle",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 10 ft.  one Medium or smaller creature that is surprised  grappled by the bugbear  or that cant see the bugbear. Hit: 9 (2d6 + 2) bludgeoning damage  and the target is pulled 5 feet towards the bugbear and grappled (escape DC 12). Until this grapple ends  the bugbear automatically hits with the Strangle attack and the target cant breathe."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 10 ft.  one Medium or smaller creature that is surprised  grappled by the bugbear  or that can't see the bugbear. Hit: 9 (2d6 + 2) bludgeoning damage  and the target is pulled 5 feet towards the bugbear and grappled (escape DC 12). Until this grapple ends  the bugbear automatically hits with the Strangle attack and the target can't breathe."
       },
       {
         "name": "Maul",
@@ -8261,7 +8261,7 @@
       },
       {
         "name": "Javelin",
-        "desc": "Melee or Ranged Weapon Attack: +4 to hit  reach 5 ft. or range 30/120 ft.  one target. Hit: 5 (1d6 + 2) piercing damage  or 12 (3d6 + 2) piercing damage if the target is a creature that is surprised or that cant see the bugbear."
+        "desc": "Melee or Ranged Weapon Attack: +4 to hit  reach 5 ft. or range 30/120 ft.  one target. Hit: 5 (1d6 + 2) piercing damage  or 12 (3d6 + 2) piercing damage if the target is a creature that is surprised or that can't see the bugbear."
       },
       {
         "name": "Stealthy Sneak",
@@ -8315,11 +8315,11 @@
       },
       {
         "name": "Maul",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  or 18 (4d6 + 4) bludgeoning damage if the target is a creature that is surprised or that cant see the bugbear."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  or 18 (4d6 + 4) bludgeoning damage if the target is a creature that is surprised or that can't see the bugbear."
       },
       {
         "name": "Javelin",
-        "desc": "Melee or Ranged Weapon Attack: +6 to hit  reach 5 ft. or range 30/120 ft.  one target. Hit: 7 (1d6 + 4) piercing damage  or 14 (3d6 + 4) piercing damage if the target is a creature that is surprised or that cant see the bugbear."
+        "desc": "Melee or Ranged Weapon Attack: +6 to hit  reach 5 ft. or range 30/120 ft.  one target. Hit: 7 (1d6 + 4) piercing damage  or 14 (3d6 + 4) piercing damage if the target is a creature that is surprised or that can't see the bugbear."
       },
       {
         "name": "Move Out (1/Day)",
@@ -8456,7 +8456,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 19 (2d12+6) piercing damage  and the target is grappled (escape DC 17). Until this grapple ends  the target is restrained  and the bunyip cant bite another target."
+        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 19 (2d12+6) piercing damage  and the target is grappled (escape DC 17). Until this grapple ends  the target is restrained  and the bunyip can't bite another target."
       },
       {
         "name": "Slam",
@@ -8541,7 +8541,7 @@
       },
       {
         "name": "Shapeshift",
-        "desc": "The cambion magically changes its form to that of any humanoid creature it has seen before, or back into its true form. While shapeshifted, its statistics are unchanged except that it has no armor or equipment, cant use its black iron blade, and can fly only if it is in a form with wings. It reverts to its true form if it dies."
+        "desc": "The cambion magically changes its form to that of any humanoid creature it has seen before, or back into its true form. While shapeshifted, its statistics are unchanged except that it has no armor or equipment, can't use its black iron blade, and can fly only if it is in a form with wings. It reverts to its true form if it dies."
       }
     ],
     "speed_json": {
@@ -8693,7 +8693,7 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d4+5) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the bear cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d4+5) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the bear can't attack a different target with its claws."
       }
     ],
     "speed_json": {
@@ -8963,7 +8963,7 @@
     "bonus_actions": [
       {
         "name": "Animate Chain",
-        "desc": "One inanimate, unattended chain within 60 feet sprouts blades and magically animates under the devils control for 1 hour. It has AC 20 and 20 hit points, a Speed of 0, and immunity to psychic, piercing, poison, and thunder damage. When the devil uses Multiattack, the devil may command the chain to make one Chain attack against a target within 15 feet of it. If the chain is reduced to 0 hit points, it cant be reanimated."
+        "desc": "One inanimate, unattended chain within 60 feet sprouts blades and magically animates under the devils control for 1 hour. It has AC 20 and 20 hit points, a Speed of 0, and immunity to psychic, piercing, poison, and thunder damage. When the devil uses Multiattack, the devil may command the chain to make one Chain attack against a target within 15 feet of it. If the chain is reduced to 0 hit points, it can't be reanimated."
       }
     ],
     "reactions": [
@@ -8973,7 +8973,7 @@
       },
       {
         "name": "Animate Chain",
-        "desc": "One inanimate, unattended chain within 60 feet sprouts blades and magically animates under the devils control for 1 hour. It has AC 20 and 20 hit points, a Speed of 0, and immunity to psychic, piercing, poison, and thunder damage. When the devil uses Multiattack, the devil may command the chain to make one Chain attack against a target within 15 feet of it. If the chain is reduced to 0 hit points, it cant be reanimated."
+        "desc": "One inanimate, unattended chain within 60 feet sprouts blades and magically animates under the devils control for 1 hour. It has AC 20 and 20 hit points, a Speed of 0, and immunity to psychic, piercing, poison, and thunder damage. When the devil uses Multiattack, the devil may command the chain to make one Chain attack against a target within 15 feet of it. If the chain is reduced to 0 hit points, it can't be reanimated."
       }
     ],
     "speed_json": {
@@ -9076,7 +9076,7 @@
       },
       {
         "name": "Three Heads",
-        "desc": "The chimera has advantage on Perception checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious, and it cant be flanked."
+        "desc": "The chimera has advantage on Perception checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious, and it can't be flanked."
       },
       {
         "name": "Wakeful",
@@ -9162,7 +9162,7 @@
     "condition_immunities": "frightened, poisoned",
     "senses": "darkvision 60 ft., passive Perception 13",
     "challenge_rating": "5",
-    "languages": "understands Deep Speech but cant speak",
+    "languages": "understands Deep Speech but can't speak",
     "special_abilities": [
       {
         "name": "Amphibious",
@@ -9223,7 +9223,7 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 60 ft., passive Perception 10",
     "challenge_rating": "9",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "Constructed Nature",
@@ -9478,7 +9478,7 @@
       },
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The giant teleports to an unoccupied space it can see within 30 feet. The giant cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The giant teleports to an unoccupied space it can see within 30 feet. The giant can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -9572,7 +9572,7 @@
       },
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The giant teleports to an unoccupied space it can see within 30 feet. The giant cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The giant teleports to an unoccupied space it can see within 30 feet. The giant can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -9777,7 +9777,7 @@
       },
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 5 (1d6+2) bludgeoning damage and the target is grappled (escape DC 14). Until this grapple ends  the target is restrained and the snake cant constrict a different target."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 5 (1d6+2) bludgeoning damage and the target is grappled (escape DC 14). Until this grapple ends  the target is restrained and the snake can't constrict a different target."
       }
     ],
     "speed_json": {
@@ -9963,7 +9963,7 @@
       },
       {
         "name": "Darkness Aura (1/Day)",
-        "desc": "A 15-foot radius area of magical darkness emanates from the unicorn  spreading around corners and moving with it. Darkvision and natural light cant penetrate it. If the darkness overlaps with an area of light created by a 2nd-level spell or lower  the spell creating the light is dispelled. The darkness aura lasts for 10 minutes or until the unicorn takes damage. The aura doesnt hinder the unicorns sight."
+        "desc": "A 15-foot radius area of magical darkness emanates from the unicorn  spreading around corners and moving with it. Darkvision and natural light can't penetrate it. If the darkness overlaps with an area of light created by a 2nd-level spell or lower  the spell creating the light is dispelled. The darkness aura lasts for 10 minutes or until the unicorn takes damage. The aura doesnt hinder the unicorns sight."
       },
       {
         "name": "Grant Boon (3/Day)",
@@ -10155,7 +10155,7 @@
     "actions": [
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one Medium or smaller creature. Hit: 14 (3d6 + 4) bludgeoning damage  and the target is grappled (escape DC 14). Until this grapple ends  the target is restrained  the couatl cant constrict other targets  and the couatl has advantage on attacks against the target."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one Medium or smaller creature. Hit: 14 (3d6 + 4) bludgeoning damage  and the target is grappled (escape DC 14). Until this grapple ends  the target is restrained  the couatl can't constrict other targets  and the couatl has advantage on attacks against the target."
       },
       {
         "name": "Bite",
@@ -10167,7 +10167,7 @@
       },
       {
         "name": "Shapeshift",
-        "desc": "The couatl magically changes its form to resemble that of a humanoid or beast  or back into its true form. It reverts to its true form if it dies. If its form is humanoid  it is equipped with clothing and a weapon. While shapeshifted  its statistics are the same except that it cant use Constrict and Shielding Wing and it may gain a swim speed of 60 or lose its fly speed if appropriate to its new form. If its a beast  it can use its bite attack. If its a humanoid  it may make a weapon attack  which functions identically to its bite attack."
+        "desc": "The couatl magically changes its form to resemble that of a humanoid or beast  or back into its true form. It reverts to its true form if it dies. If its form is humanoid  it is equipped with clothing and a weapon. While shapeshifted  its statistics are the same except that it can't use Constrict and Shielding Wing and it may gain a swim speed of 60 or lose its fly speed if appropriate to its new form. If its a beast  it can use its bite attack. If its a humanoid  it may make a weapon attack  which functions identically to its bite attack."
       }
     ],
     "reactions": [
@@ -10235,7 +10235,7 @@
       },
       {
         "name": "Beast Form",
-        "desc": "The hag magically transforms into a Large or smaller beast or back into its true form. While in beast form  it retains its game statistics  cant cast spells  cant use Hex  and cant speak. The hags Speed increases by 10 feet  and when appropriate to its beast form it gains a climb  fly  or swim speed of 40 feet. Any equipment the hag is wearing or wielding merges into its new form."
+        "desc": "The hag magically transforms into a Large or smaller beast or back into its true form. While in beast form  it retains its game statistics can't cast spells can't use Hex  and can't speak. The hags Speed increases by 10 feet  and when appropriate to its beast form it gains a climb  fly  or swim speed of 40 feet. Any equipment the hag is wearing or wielding merges into its new form."
       },
       {
         "name": "Claws",
@@ -10328,7 +10328,7 @@
       },
       {
         "name": "Sleep Touch",
-        "desc": "Melee Spell Attack: +5 to hit  reach 5 ft.  one creature. Hit: The target falls asleep for 4 hours or until it takes damage or is shaken awake. Once the hag successfully hits a target  it cant make this attack again until it finishes a long rest."
+        "desc": "Melee Spell Attack: +5 to hit  reach 5 ft.  one creature. Hit: The target falls asleep for 4 hours or until it takes damage or is shaken awake. Once the hag successfully hits a target  it can't make this attack again until it finishes a long rest."
       },
       {
         "name": "Shapeshift",
@@ -10701,7 +10701,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 7 (1d10+2) piercing damage and the target is grappled (escape DC 12). Until this grapple ends  the target is restrained and the crocodile cant bite a different target."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 7 (1d10+2) piercing damage and the target is grappled (escape DC 12). Until this grapple ends  the target is restrained and the crocodile can't bite a different target."
       }
     ],
     "speed_json": {
@@ -11168,7 +11168,7 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The darkmantle cant use blindsight while deafened."
+        "desc": "The darkmantle can't use blindsight while deafened."
       },
       {
         "name": "False Appearance",
@@ -11182,11 +11182,11 @@
       },
       {
         "name": "Darkness Aura",
-        "desc": "A 15-foot radius area of magical darkness emanates from the darkmantle  spreading around corners and moving with it. Darkvision and natural light cant penetrate it. If the darkness overlaps with an area of light created by a 2nd-level spell or lower  the spell creating the light is dispelled. The darkness aura lasts for 10 minutes or until the darkmantle takes damage."
+        "desc": "A 15-foot radius area of magical darkness emanates from the darkmantle  spreading around corners and moving with it. Darkvision and natural light can't penetrate it. If the darkness overlaps with an area of light created by a 2nd-level spell or lower  the spell creating the light is dispelled. The darkness aura lasts for 10 minutes or until the darkmantle takes damage."
       },
       {
         "name": "Crush",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one creature. Hit: 6 (1d6 + 3) bludgeoning damage  and the target is grappled (escape DC 13). If the darkmantle made the attack with advantage  it attaches to the targets head  and the target is blinded and cant breathe. While grappling  the darkmantle can only attack the grappled creature but has advantage on its attack roll. The darkmantles speed becomes 0  and it moves with its target."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one creature. Hit: 6 (1d6 + 3) bludgeoning damage  and the target is grappled (escape DC 13). If the darkmantle made the attack with advantage  it attaches to the targets head  and the target is blinded and can't breathe. While grappling  the darkmantle can only attack the grappled creature but has advantage on its attack roll. The darkmantles speed becomes 0  and it moves with its target."
       }
     ],
     "speed_json": {
@@ -11302,7 +11302,7 @@
     "special_abilities": [
       {
         "name": "Two Heads",
-        "desc": "The death dog has advantage on Perception checks and on saving throws made to resist being blinded, charmed, deafened, frightened, stunned, or knocked unconscious, and it cant be flanked."
+        "desc": "The death dog has advantage on Perception checks and on saving throws made to resist being blinded, charmed, deafened, frightened, stunned, or knocked unconscious, and it can't be flanked."
       }
     ],
     "actions": [
@@ -11571,7 +11571,7 @@
     "actions": [
       {
         "name": "Devour Soul",
-        "desc": "The demilich targets one creature within 120 feet  forcing it to make a DC 17 Wisdom saving throw. On a success  or if all the large soul gems on the demilichs skull are occupied  the creature takes 40 necrotic damage  and the demilich regains the same number of hit points. If the target fails its saving throw and there is at least one unoccupied soul gem on the demilichs skull  the demilich regains 40 hit points  and the target dies instantly. Its soul is trapped in a soul gem on the demilichs skull  visible as a tiny  creature-shaped mote of light. While its soul is trapped  a creature cant be restored to life by any means. A soul that remains in a soul gem for 30 days is destroyed forever. If the demilich is defeated and a soul gem crushed  the creature is restored to life if its body is within 100 miles. A creature that succeeds on a saving throw against this effect is immune to it for 24 hours."
+        "desc": "The demilich targets one creature within 120 feet  forcing it to make a DC 17 Wisdom saving throw. On a success  or if all the large soul gems on the demilichs skull are occupied  the creature takes 40 necrotic damage  and the demilich regains the same number of hit points. If the target fails its saving throw and there is at least one unoccupied soul gem on the demilichs skull  the demilich regains 40 hit points  and the target dies instantly. Its soul is trapped in a soul gem on the demilichs skull  visible as a tiny  creature-shaped mote of light. While its soul is trapped  a creature can't be restored to life by any means. A soul that remains in a soul gem for 30 days is destroyed forever. If the demilich is defeated and a soul gem crushed  the creature is restored to life if its body is within 100 miles. A creature that succeeds on a saving throw against this effect is immune to it for 24 hours."
       },
       {
         "name": "A demilich begins combat with one or two empty soul gems",
@@ -11660,7 +11660,7 @@
     "actions": [
       {
         "name": "Devour Soul",
-        "desc": "The demilich targets one creature within 120 feet  forcing it to make a DC 17 Wisdom saving throw. On a success  or if all the large soul gems on the demilichs skull are occupied  the creature takes 40 necrotic damage  and the demilich regains the same number of hit points. If the target fails its saving throw and there is at least one unoccupied soul gem on the demilichs skull  the demilich regains 40 hit points  and the target dies instantly. Its soul is trapped in a soul gem on the demilichs skull  visible as a tiny  creature-shaped mote of light. While its soul is trapped  a creature cant be restored to life by any means. A soul that remains in a soul gem for 30 days is destroyed forever. If the demilich is defeated and a soul gem crushed  the creature is restored to life if its body is within 100 miles. A creature that succeeds on a saving throw against this effect is immune to it for 24 hours."
+        "desc": "The demilich targets one creature within 120 feet  forcing it to make a DC 17 Wisdom saving throw. On a success  or if all the large soul gems on the demilichs skull are occupied  the creature takes 40 necrotic damage  and the demilich regains the same number of hit points. If the target fails its saving throw and there is at least one unoccupied soul gem on the demilichs skull  the demilich regains 40 hit points  and the target dies instantly. Its soul is trapped in a soul gem on the demilichs skull  visible as a tiny  creature-shaped mote of light. While its soul is trapped  a creature can't be restored to life by any means. A soul that remains in a soul gem for 30 days is destroyed forever. If the demilich is defeated and a soul gem crushed  the creature is restored to life if its body is within 100 miles. A creature that succeeds on a saving throw against this effect is immune to it for 24 hours."
       },
       {
         "name": "A demilich mastermind begins combat with up to four empty soul gems",
@@ -11761,7 +11761,7 @@
       },
       {
         "name": "Celestial Hammer (Deva Form Only)",
-        "desc": "Melee Weapon Attack: +8 to hit  reach 5 ft.  one target. Hit: 8 (1d8 + 4) bludgeoning damage plus 17 (5d6) radiant damage. On a hit  the target cant make opportunity attacks against the deva until the beginning of the targets next turn."
+        "desc": "Melee Weapon Attack: +8 to hit  reach 5 ft.  one target. Hit: 8 (1d8 + 4) bludgeoning damage plus 17 (5d6) radiant damage. On a hit  the target can't make opportunity attacks against the deva until the beginning of the targets next turn."
       },
       {
         "name": "Divine Blast",
@@ -11911,7 +11911,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 25 (3d12 + 6) piercing damage. If the target is a creature  it is grappled (escape DC 17). Until this grapple ends  the tyrannosaurus cant bite a different creature and it has advantage on bite attacks against the grappled creature."
+        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 25 (3d12 + 6) piercing damage. If the target is a creature  it is grappled (escape DC 17). Until this grapple ends  the tyrannosaurus can't bite a different creature and it has advantage on bite attacks against the grappled creature."
       },
       {
         "name": "Tail",
@@ -12079,7 +12079,7 @@
       },
       {
         "name": "Crushing Hand",
-        "desc": "Melee Weapon Attack: +10 to hit  reach 5 ft.  one target. Hit: 15 (2d8 + 6) bludgeoning damage  and the target is grappled (escape DC 18). Until this grapple ends  the divi cant use Crushing Hand on another target and has advantage on Crushing Hand attacks against this target  and the target cant breathe."
+        "desc": "Melee Weapon Attack: +10 to hit  reach 5 ft.  one target. Hit: 15 (2d8 + 6) bludgeoning damage  and the target is grappled (escape DC 18). Until this grapple ends  the divi can't use Crushing Hand on another target and has advantage on Crushing Hand attacks against this target  and the target can't breathe."
       },
       {
         "name": "Stone Club",
@@ -12157,7 +12157,7 @@
       },
       {
         "name": "Crushing Hand",
-        "desc": "Melee Weapon Attack: +10 to hit  reach 5 ft.  one target. Hit: 15 (2d8 + 6) bludgeoning damage  and the target is grappled (escape DC 18). Until this grapple ends  the divi cant use Crushing Hand on another target and has advantage on Crushing Hand attacks against this target  and the target cant breathe."
+        "desc": "Melee Weapon Attack: +10 to hit  reach 5 ft.  one target. Hit: 15 (2d8 + 6) bludgeoning damage  and the target is grappled (escape DC 18). Until this grapple ends  the divi can't use Crushing Hand on another target and has advantage on Crushing Hand attacks against this target  and the target can't breathe."
       },
       {
         "name": "Stone Club",
@@ -12567,7 +12567,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +13 to hit  reach 15 ft.  one target. Hit: 52 (7d12 + 7) piercing damage. If the target is a creature  it is grappled (escape DC 21). Until this grapple ends  the dragon turtle cant bite a different creature  and it has advantage on bite attacks against the grappled creature."
+        "desc": "Melee Weapon Attack: +13 to hit  reach 15 ft.  one target. Hit: 52 (7d12 + 7) piercing damage. If the target is a creature  it is grappled (escape DC 21). Until this grapple ends  the dragon turtle can't bite a different creature  and it has advantage on bite attacks against the grappled creature."
       },
       {
         "name": "Ram",
@@ -12595,7 +12595,7 @@
     "reactions": [
       {
         "name": "Retract",
-        "desc": "When the dragon turtle takes 50 damage or more from a single attack or spell, it retracts its head and limbs into its shell. It immediately regains 20 hit points. While retracted, it is blinded; its Speed is 0; it cant take reactions; it has advantage on saving throws; attacks against it have disadvantage; and it has resistance to all damage. The dragon turtle stays retracted until the beginning of its next turn."
+        "desc": "When the dragon turtle takes 50 damage or more from a single attack or spell, it retracts its head and limbs into its shell. It immediately regains 20 hit points. While retracted, it is blinded; its Speed is 0; it can't take reactions; it has advantage on saving throws; attacks against it have disadvantage; and it has resistance to all damage. The dragon turtle stays retracted until the beginning of its next turn."
       },
       {
         "name": "Tail",
@@ -13028,7 +13028,7 @@
       },
       {
         "name": "Energy-Sucking Aura",
-        "desc": "A non-demon creature that takes an action or bonus action while within 10 feet of a dretch cant take another action, bonus action, or reaction until the start of its next turn."
+        "desc": "A non-demon creature that takes an action or bonus action while within 10 feet of a dretch can't take another action, bonus action, or reaction until the start of its next turn."
       }
     ],
     "actions": [
@@ -13099,7 +13099,7 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 15 (2d10 + 4) piercing damage  and the target is grappled (escape DC 15). While grappling a target  the drider cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 15 (2d10 + 4) piercing damage  and the target is grappled (escape DC 15). While grappling a target  the drider can't attack a different target with its claws."
       },
       {
         "name": "Bite",
@@ -13177,7 +13177,7 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d4+5) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the bear cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d4+5) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the bear can't attack a different target with its claws."
       }
     ],
     "speed_json": {
@@ -13238,7 +13238,7 @@
       },
       {
         "name": "Beast Form",
-        "desc": "The druid magically transforms into a Large or smaller beast or back into their true form. While in beast form  they retain their game statistics  cant cast spells  and cant speak. The druids Speed increases by 10 feet  and when appropriate to their beast form they gain climb  fly  or swim speeds of 40 feet. Any equipment the druid is wearing or wielding merges into their new form."
+        "desc": "The druid magically transforms into a Large or smaller beast or back into their true form. While in beast form  they retain their game statistics can't cast spells  and can't speak. The druids Speed increases by 10 feet  and when appropriate to their beast form they gain climb  fly  or swim speeds of 40 feet. Any equipment the druid is wearing or wielding merges into their new form."
       },
       {
         "name": "Produce Flame (Cantrip; V, S)",
@@ -13642,7 +13642,7 @@
       },
       {
         "name": "Earths Embrace",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one Large or smaller creature. Hit: 17 (2d12 + 4) bludgeoning damage  and the target is grappled (escape DC 15). Until this grapple ends  the elemental cant burrow or use Earths Embrace and its slam attacks are made with advantage against the grappled target."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one Large or smaller creature. Hit: 17 (2d12 + 4) bludgeoning damage  and the target is grappled (escape DC 15). Until this grapple ends  the elemental can't burrow or use Earths Embrace and its slam attacks are made with advantage against the grappled target."
       },
       {
         "name": "Rock",
@@ -13860,7 +13860,7 @@
       },
       {
         "name": "Multiattack",
-        "desc": "The pudding makes two pseudopod attacks. The pudding cant use Multiattack after it splits for the first time."
+        "desc": "The pudding makes two pseudopod attacks. The pudding can't use Multiattack after it splits for the first time."
       }
     ],
     "reactions": [
@@ -13919,7 +13919,7 @@
       },
       {
         "name": "Misty Recovery",
-        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It cant revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
+        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
       },
       {
         "name": "Regeneration",
@@ -13931,7 +13931,7 @@
       },
       {
         "name": "Vampire Weaknesses",
-        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it cant use its Regeneration trait or its Mist Form or Shapechange actions."
+        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it can't use its Regeneration trait or its Mist Form or Shapechange actions."
       },
       {
         "name": "Resting Place",
@@ -13987,11 +13987,11 @@
       },
       {
         "name": "Mist Form",
-        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, cant speak, cant take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but cant pass through water. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, can't speak, can't take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but can't pass through water. Anything its carrying transforms with it."
       },
       {
         "name": "Shapechange",
-        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It cant use reactions or legendary actions, and cant speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It can't use reactions or legendary actions, and can't speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
       }
     ],
     "speed_json": {
@@ -14194,7 +14194,7 @@
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, cant travel to or from the Material Plane)"
+        "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, can't travel to or from the Material Plane)"
       }
     ],
     "actions": [
@@ -14232,7 +14232,7 @@
       },
       {
         "name": "Cast Spell",
-        "desc": "The empyrean casts a spell. The empyrean cant use this option if it has cast a spell since the start of its last turn."
+        "desc": "The empyrean casts a spell. The empyrean can't use this option if it has cast a spell since the start of its last turn."
       },
       {
         "name": "Fly",
@@ -14312,7 +14312,7 @@
       },
       {
         "name": "Lasso",
-        "desc": "Melee Weapon Attack: +8 to hit  reach 15 ft.  one target. Hit: The target is entangled by the lasso. While entangled  it cant move more than 15 feet away from the erinyes. The entanglement ends if the erinyes releases the lasso or becomes incapacitated  or if the lasso is destroyed. The lasso is an object with AC 12 and 20 HP and is immune to piercing  poison  psychic  and thunder damage. The entanglement also ends if the target or a creature within 5 feet of it uses an action to succeed on a DC 16 Athletics or Acrobatics check to remove the lasso. The erinyes cant make a lasso attack while a creature is entangled."
+        "desc": "Melee Weapon Attack: +8 to hit  reach 15 ft.  one target. Hit: The target is entangled by the lasso. While entangled  it can't move more than 15 feet away from the erinyes. The entanglement ends if the erinyes releases the lasso or becomes incapacitated  or if the lasso is destroyed. The lasso is an object with AC 12 and 20 HP and is immune to piercing  poison  psychic  and thunder damage. The entanglement also ends if the target or a creature within 5 feet of it uses an action to succeed on a DC 16 Athletics or Acrobatics check to remove the lasso. The erinyes can't make a lasso attack while a creature is entangled."
       }
     ],
     "reactions": [
@@ -14395,7 +14395,7 @@
       },
       {
         "name": "Strangle",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one Medium or smaller creature against which the ettercap has advantage on the attack roll. Hit: 7 (1d8 + 3) bludgeoning damage  and the target is grappled (escape DC 13). Until this grapple ends  the ettercap automatically hits the target with its strangle attack  and the target cant breathe."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one Medium or smaller creature against which the ettercap has advantage on the attack roll. Hit: 7 (1d8 + 3) bludgeoning damage  and the target is grappled (escape DC 13). Until this grapple ends  the ettercap automatically hits the target with its strangle attack  and the target can't breathe."
       }
     ],
     "bonus_actions": [
@@ -14449,7 +14449,7 @@
       },
       {
         "name": "Two Heads",
-        "desc": "While both heads are awake, the ettin has advantage on Perception checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious, and it cant be flanked."
+        "desc": "While both heads are awake, the ettin has advantage on Perception checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious, and it can't be flanked."
       },
       {
         "name": "Wakeful",
@@ -14539,7 +14539,7 @@
       },
       {
         "name": "Beast Form (1/Day, 50+ Years Old Only)",
-        "desc": "The dragon targets one creature within 15 feet. The target makes a DC 13 Wisdom saving throw. On a failure  it is magically transformed into a harmless Tiny beast  such as a mouse or a songbird  for 1 minute. While in this form  its statistics are unchanged  except it cant speak or take actions  reactions  or"
+        "desc": "The dragon targets one creature within 15 feet. The target makes a DC 13 Wisdom saving throw. On a failure  it is magically transformed into a harmless Tiny beast  such as a mouse or a songbird  for 1 minute. While in this form  its statistics are unchanged  except it can't speak or take actions  reactions  or"
       }
     ],
     "bonus_actions": [
@@ -14610,7 +14610,7 @@
       },
       {
         "name": "Beast Form (1/Day, 50+ Years Old Only)",
-        "desc": "The dragon targets one creature within 15 feet. The target makes a DC 13 Wisdom saving throw. On a failure  it is magically transformed into a harmless Tiny beast  such as a mouse or a songbird  for 1 minute. While in this form  its statistics are unchanged  except it cant speak or take actions  reactions  or"
+        "desc": "The dragon targets one creature within 15 feet. The target makes a DC 13 Wisdom saving throw. On a failure  it is magically transformed into a harmless Tiny beast  such as a mouse or a songbird  for 1 minute. While in this form  its statistics are unchanged  except it can't speak or take actions  reactions  or"
       }
     ],
     "bonus_actions": [
@@ -14882,7 +14882,7 @@
       },
       {
         "name": "Celestial Hammer (Deva Form Only)",
-        "desc": "Melee Weapon Attack: +8 to hit  reach 5 ft.  one target. Hit: 8 (1d8 + 4) bludgeoning damage plus 17 (5d6) radiant damage. On a hit  the target cant make opportunity attacks against the deva until the beginning of the targets next turn."
+        "desc": "Melee Weapon Attack: +8 to hit  reach 5 ft.  one target. Hit: 8 (1d8 + 4) bludgeoning damage plus 17 (5d6) radiant damage. On a hit  the target can't make opportunity attacks against the deva until the beginning of the targets next turn."
       },
       {
         "name": "Divine Blast",
@@ -15146,7 +15146,7 @@
     "damage_immunities": "fire",
     "senses": "passive Perception 11",
     "challenge_rating": "5",
-    "languages": "understands Abyssal, Common, and Infernal but cant speak",
+    "languages": "understands Abyssal, Common, and Infernal but can't speak",
     "special_abilities": [
       {
         "name": "Evil",
@@ -15510,11 +15510,11 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 60 ft., passive Perception 10",
     "challenge_rating": "5",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "Berserk",
-        "desc": "When the guardian starts its turn while bloodied, roll a d6. On a 6, the guardian goes berserk. While berserk, the guardian attacks the nearest creature it can see. If it cant reach a creature, it attacks an object. The guardian stays berserk until it is destroyed or restored to full hit points."
+        "desc": "When the guardian starts its turn while bloodied, roll a d6. On a 6, the guardian goes berserk. While berserk, the guardian attacks the nearest creature it can see. If it can't reach a creature, it attacks an object. The guardian stays berserk until it is destroyed or restored to full hit points."
       },
       {
         "name": "If a berserk guardian can see and hear its creator, the creator can use an action to try to calm it by making a DC 15 Persuasion check",
@@ -15595,7 +15595,7 @@
     "damage_vulnerabilities": "psychic",
     "senses": "darkvision 60 ft., passive Perception 12",
     "challenge_rating": "1",
-    "languages": "understands Common and Undercommon but cant speak, telepathy 60 ft.",
+    "languages": "understands Common and Undercommon but can't speak, telepathy 60 ft.",
     "special_abilities": [
       {
         "name": "Amphibious",
@@ -15607,7 +15607,7 @@
       },
       {
         "name": "Telepathic Spy",
-        "desc": "The flumph can perceive any telepathic messages sent or received within 60 feet, and cant be surprised by creatures with telepathy. The flumph is also immune to divination and to any effect that would sense its emotions or read its thoughts, except for the Telepathic Spy feature of another flumph."
+        "desc": "The flumph can perceive any telepathic messages sent or received within 60 feet, and can't be surprised by creatures with telepathy. The flumph is also immune to divination and to any effect that would sense its emotions or read its thoughts, except for the Telepathic Spy feature of another flumph."
       },
       {
         "name": "Tippable",
@@ -15680,7 +15680,7 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) slashing damage  or 11 (2d6 + 4) slashing damage if the griffon started its turn at least 20 feet above the target  and the target is grappled (escape DC 14). Until this grapple ends  the griffon cant attack a different target with its talons."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) slashing damage  or 11 (2d6 + 4) slashing damage if the griffon started its turn at least 20 feet above the target  and the target is grappled (escape DC 14). Until this grapple ends  the griffon can't attack a different target with its talons."
       }
     ],
     "speed_json": {
@@ -15942,7 +15942,7 @@
     "bonus_actions": [
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "reactions": [
@@ -15956,7 +15956,7 @@
       },
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -16019,7 +16019,7 @@
         "desc": "Ranged Weapon Attack: +5 to hit  range 150/600 ft.  one target. Hit: 7 (1d8 + 3) piercing damage."
       },
       {
-        "name": "Forest gnome scouts patrol the boundaries of their hidden villages, leading trespassers astray and attacking those they cant distract",
+        "name": "Forest gnome scouts patrol the boundaries of their hidden villages, leading trespassers astray and attacking those they can't distract",
         "desc": ""
       }
     ],
@@ -16075,7 +16075,7 @@
       },
       {
         "name": "Flawed Spellcasting",
-        "desc": "The gods innate spellcasting ability is Wisdom (save DC 17).The god can try to cast flame strike or spirit guardians at will with no material component. When the god tries to cast the spell, roll 1d6. On a 1, 2, or 3 on the die, the spell visibly fails and has no effect. The gods action for the turn is not wasted, but it cant be used to cast a spell."
+        "desc": "The gods innate spellcasting ability is Wisdom (save DC 17).The god can try to cast flame strike or spirit guardians at will with no material component. When the god tries to cast the spell, roll 1d6. On a 1, 2, or 3 on the die, the spell visibly fails and has no effect. The gods action for the turn is not wasted, but it can't be used to cast a spell."
       },
       {
         "name": "Legendary Resistance (3/Day)",
@@ -16220,7 +16220,7 @@
     "bonus_actions": [
       {
         "name": "Grab",
-        "desc": "One creature within 5 feet makes a DC 11 Dexterity saving throw. On a failure, it is grappled (escape DC 18). Until this grapple ends, the giant cant grab another target, and it makes battleaxe attacks with advantage against the grappled target."
+        "desc": "One creature within 5 feet makes a DC 11 Dexterity saving throw. On a failure, it is grappled (escape DC 18). Until this grapple ends, the giant can't grab another target, and it makes battleaxe attacks with advantage against the grappled target."
       },
       {
         "name": "Stomp (1/Day)",
@@ -16290,7 +16290,7 @@
     "bonus_actions": [
       {
         "name": "Grab",
-        "desc": "One creature within 5 feet makes a DC 11 Dexterity saving throw. On a failure, it is grappled (escape DC 18). Until this grapple ends, the giant cant grab another target, and it makes battleaxe attacks with advantage against the grappled target."
+        "desc": "One creature within 5 feet makes a DC 11 Dexterity saving throw. On a failure, it is grappled (escape DC 18). Until this grapple ends, the giant can't grab another target, and it makes battleaxe attacks with advantage against the grappled target."
       },
       {
         "name": "Stomp (1/Day)",
@@ -16501,7 +16501,7 @@
         "desc": "The cube moves up to its Speed. While doing so  it can enter Large or smaller creatures spaces. Whenever the cube enters a creatures space  the creature makes a DC 13 Dexterity saving throw. If the creature is unaware of the cubes presence  it makes its saving throw against Engulf with disadvantage. On a success  the creature may use its reaction  if available  to move up to half its Speed without provoking opportunity attacks. If the creature doesnt move  it is engulfed by the cube."
       },
       {
-        "name": "A creature engulfed by the cube takes 10 (3d6) acid damage, cant breathe, is restrained, and takes 10 (3d6) acid damage at the start of each of the cubes turns",
+        "name": "A creature engulfed by the cube takes 10 (3d6) acid damage, can't breathe, is restrained, and takes 10 (3d6) acid damage at the start of each of the cubes turns",
         "desc": "It can be seen but has total cover. It moves with the cube. The cube can hold as many creatures as fit in its space without squeezing."
       },
       {
@@ -16573,7 +16573,7 @@
         "desc": "The cube moves up to its Speed. While doing so  it can enter Large or smaller creatures spaces. Whenever the cube enters a creatures space  the creature makes a DC 13 Dexterity saving throw. If the creature is unaware of the cubes presence  it makes its saving throw against Engulf with disadvantage. On a success  the creature may use its reaction  if available  to move up to half its Speed without provoking opportunity attacks. If the creature doesnt move  it is engulfed by the cube."
       },
       {
-        "name": "A creature engulfed by the cube takes 10 (3d6) acid damage plus 9 (2d6 + 2) bludgeoning damage, cant breathe, is restrained, and takes 10 (3d6) acid damage plus 9 (2d6 + 2) bludgeoning damage at the start of each of the cubes turns",
+        "name": "A creature engulfed by the cube takes 10 (3d6) acid damage plus 9 (2d6 + 2) bludgeoning damage, can't breathe, is restrained, and takes 10 (3d6) acid damage plus 9 (2d6 + 2) bludgeoning damage at the start of each of the cubes turns",
         "desc": "It can be seen but has total cover. It moves with the cube. The cube can hold as many creatures as fit in its space without squeezing."
       },
       {
@@ -16714,7 +16714,7 @@
       },
       {
         "name": "Possession (Recharge 6)",
-        "desc": "One humanoid within 5 feet makes a DC 13 Charisma saving throw. On a failure  it is possessed by the ghost. The possessed creature is unconscious. The ghost enters the creatures body and takes control of it. The ghost can be targeted only by effects that turn undead  and it retains its Intelligence  Wisdom  and Charisma. It grants its host body immunity to being charmed and frightened. It otherwise uses the possessed creatures statistics and actions instead of its own. It doesnt gain access to the creatures memories but does gain access to proficiencies  nonmagical class features and traits  and nonmagical actions. It cant use limited-used abilities or class traits that require spending a resource. The possession ends after 24 hours  when the body drops to 0 hit points  when the ghost ends it as a bonus action  or when the ghost is turned or affected by dispel evil and good or a similar effect. Additionally  the possessed creature repeats its saving throw whenever it takes damage. When the possession ends  the ghost reappears in a space within 5 feet of the body. A creature is immune to this ghosts Possession for 24 hours after succeeding on its saving throw or after the possession ends."
+        "desc": "One humanoid within 5 feet makes a DC 13 Charisma saving throw. On a failure  it is possessed by the ghost. The possessed creature is unconscious. The ghost enters the creatures body and takes control of it. The ghost can be targeted only by effects that turn undead  and it retains its Intelligence  Wisdom  and Charisma. It grants its host body immunity to being charmed and frightened. It otherwise uses the possessed creatures statistics and actions instead of its own. It doesnt gain access to the creatures memories but does gain access to proficiencies  nonmagical class features and traits  and nonmagical actions. It can't use limited-used abilities or class traits that require spending a resource. The possession ends after 24 hours  when the body drops to 0 hit points  when the ghost ends it as a bonus action  or when the ghost is turned or affected by dispel evil and good or a similar effect. Additionally  the possessed creature repeats its saving throw whenever it takes damage. When the possession ends  the ghost reappears in a space within 5 feet of the body. A creature is immune to this ghosts Possession for 24 hours after succeeding on its saving throw or after the possession ends."
       }
     ],
     "reactions": [
@@ -16981,7 +16981,7 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The bat cant use blindsight while deafened."
+        "desc": "The bat can't use blindsight while deafened."
       },
       {
         "name": "Keen Hearing",
@@ -17126,7 +17126,7 @@
       },
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6+4) bludgeoning damage and the target is grappled (escape DC 16). Until this grapple ends  the target is restrained and the snake cant constrict a different target."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6+4) bludgeoning damage and the target is grappled (escape DC 16). Until this grapple ends  the target is restrained and the snake can't constrict a different target."
       }
     ],
     "speed_json": {
@@ -17231,7 +17231,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +8 to hit  reach 5 ft.  one target. Hit: 16 (2d10+5) piercing damage and the target is grappled (escape DC 15). Until this grapple ends  the target is restrained and the crocodile cant bite a different target."
+        "desc": "Melee Weapon Attack: +8 to hit  reach 5 ft.  one target. Hit: 16 (2d10+5) piercing damage and the target is grappled (escape DC 15). Until this grapple ends  the target is restrained and the crocodile can't bite a different target."
       },
       {
         "name": "Tail",
@@ -17276,7 +17276,7 @@
     },
     "senses": "passive Perception 14",
     "challenge_rating": "1",
-    "languages": "Giant Eagle, understands but cant speak Common and Auran",
+    "languages": "Giant Eagle, understands but can't speak Common and Auran",
     "special_abilities": [
       {
         "name": "Keen Sight",
@@ -17286,7 +17286,7 @@
     "actions": [
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 9 (2d6+2) slashing damage and the target is grappled (escape DC 13). Until this grapple ends  the giant eagle cant attack a different target with its talons."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 9 (2d6+2) slashing damage and the target is grappled (escape DC 13). Until this grapple ends  the giant eagle can't attack a different target with its talons."
       }
     ],
     "bonus_actions": [
@@ -17360,7 +17360,7 @@
       },
       {
         "name": "Earths Embrace",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one Large or smaller creature. Hit: 17 (2d12 + 4) bludgeoning damage  and the target is grappled (escape DC 15). Until this grapple ends  the elemental cant burrow or use Earths Embrace and its slam attacks are made with advantage against the grappled target."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one Large or smaller creature. Hit: 17 (2d12 + 4) bludgeoning damage  and the target is grappled (escape DC 15). Until this grapple ends  the elemental can't burrow or use Earths Embrace and its slam attacks are made with advantage against the grappled target."
       },
       {
         "name": "Rock",
@@ -17401,7 +17401,7 @@
     "charisma_save": null,
     "senses": "passive Perception 12",
     "challenge_rating": "2",
-    "languages": "Giant Elk, understands but cant speak Common, Elvish, and Sylvan",
+    "languages": "Giant Elk, understands but can't speak Common, Elvish, and Sylvan",
     "actions": [
       {
         "name": "Ram",
@@ -17575,7 +17575,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit  reach 5 ft.  one target. Hit: 4 (1d6+1) piercing damage and the target is grappled (escape DC 11). Until this grapple ends  the frog cant bite another target."
+        "desc": "Melee Weapon Attack: +3 to hit  reach 5 ft.  one target. Hit: 4 (1d6+1) piercing damage and the target is grappled (escape DC 11). Until this grapple ends  the frog can't bite another target."
       },
       {
         "name": "Swallow",
@@ -17802,7 +17802,7 @@
     "bonus_actions": [
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The giant lanternfish teleports to an unoccupied space it can see within 30 feet. The giant lanternfish cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The giant lanternfish teleports to an unoccupied space it can see within 30 feet. The giant lanternfish can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -17896,7 +17896,7 @@
     "actions": [
       {
         "name": "Tentacles",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 15 ft.  one target. Hit: 8 (2d4+3) bludgeoning damage. If the target is a creature  it is grappled (escape DC 13). Until this grapple ends  the target is restrained  and the octopus cant attack a different target with its tentacles."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 15 ft.  one target. Hit: 8 (2d4+3) bludgeoning damage. If the target is a creature  it is grappled (escape DC 13). Until this grapple ends  the target is restrained  and the octopus can't attack a different target with its tentacles."
       }
     ],
     "bonus_actions": [
@@ -17944,7 +17944,7 @@
     },
     "senses": "darkvision 120 ft., passive Perception 14",
     "challenge_rating": "1",
-    "languages": "Giant Owl; understands but cant speak Common, Elvish, and Sylvan",
+    "languages": "Giant Owl; understands but can't speak Common, Elvish, and Sylvan",
     "special_abilities": [
       {
         "name": "Flyby",
@@ -18092,7 +18092,7 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 9 (2d6+2) bludgeoning damage and the target is grappled (escape DC 12). Until this grapple ends  the scorpion cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 9 (2d6+2) bludgeoning damage and the target is grappled (escape DC 12). Until this grapple ends  the scorpion can't attack a different target with its claws."
       },
       {
         "name": "Sting",
@@ -18307,7 +18307,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 5 (1d6+2) piercing damage plus 4 (1d8) poison damage and the target is grappled (escape DC 12). Until this grapple ends  the toad cant bite another target."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 5 (1d6+2) piercing damage plus 4 (1d8) poison damage and the target is grappled (escape DC 12). Until this grapple ends  the toad can't bite another target."
       },
       {
         "name": "Swallow",
@@ -18728,7 +18728,7 @@
       },
       {
         "name": "Pincer",
-        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 16 (2d10 + 5) bludgeoning damage. If the target is a Medium or smaller creature  it is grappled (escape DC 17). The glabrezu has two pincers  each of which can grapple one target. While grappling a target  a pincer cant attack a different target. If the same creature is grappled by both of the glabrezus pincers  it must escape from each of them separately."
+        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 16 (2d10 + 5) bludgeoning damage. If the target is a Medium or smaller creature  it is grappled (escape DC 17). The glabrezu has two pincers  each of which can grapple one target. While grappling a target  a pincer can't attack a different target. If the same creature is grappled by both of the glabrezus pincers  it must escape from each of them separately."
       },
       {
         "name": "Wish",
@@ -18746,7 +18746,7 @@
       },
       {
         "name": "Darkness",
-        "desc": "Magical darkness spreads from a point within 30 feet, filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute, until the glabrezu dismisses it, or until the glabrezu uses this ability again. A creature with darkvision cant see through this darkness, and nonmagical light cant illuminate it."
+        "desc": "Magical darkness spreads from a point within 30 feet, filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute, until the glabrezu dismisses it, or until the glabrezu uses this ability again. A creature with darkvision can't see through this darkness, and nonmagical light can't illuminate it."
       },
       {
         "name": "Confusion (1/Day)",
@@ -19728,7 +19728,7 @@
     "special_abilities": [
       {
         "name": "Ambusher",
-        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that cant see it with its bite, it can deal piercing damage and grapple the target simultaneously."
+        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that can't see it with its bite, it can deal piercing damage and grapple the target simultaneously."
       },
       {
         "name": "Amphibious",
@@ -19758,7 +19758,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +15 to hit  reach 15 ft.  one target. Hit: 30 (4d10 + 8) piercing damage plus 9 (2d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 23)  and a Huge or smaller creature grappled in this way is restrained. While grappling a creature  the dragon cant bite or use Acid Spit against another target."
+        "desc": "Melee Weapon Attack: +15 to hit  reach 15 ft.  one target. Hit: 30 (4d10 + 8) piercing damage plus 9 (2d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 23)  and a Huge or smaller creature grappled in this way is restrained. While grappling a creature  the dragon can't bite or use Acid Spit against another target."
       },
       {
         "name": "Claw",
@@ -19790,7 +19790,7 @@
       },
       {
         "name": "Darkness",
-        "desc": "The dragon creates a 40-foot-radius sphere of magical darkness originating from a point it can see within 120 feet. Darkvision cant penetrate this darkness. The darkness lasts for 1 minute or until the dragon uses this action again."
+        "desc": "The dragon creates a 40-foot-radius sphere of magical darkness originating from a point it can see within 120 feet. Darkvision can't penetrate this darkness. The darkness lasts for 1 minute or until the dragon uses this action again."
       },
       {
         "name": "Roar",
@@ -19861,7 +19861,7 @@
       },
       {
         "name": "High Voltage (1/Day)",
-        "desc": "When the dragon is first bloodied, it immediately recharges its breath weapon, if its not already available. After doing so, the air around it becomes electrically charged. A creature that starts its turn within 15 feet of the dragon or moves within 15 feet of it for the first time on a turn makes a DC 24 Dexterity saving throw. On a failure, it takes 11 (2d10) lightning damage and cant take reactions until the start of its next turn. Creatures in metal armor or wielding metal weapons have disadvantage on this saving throw."
+        "desc": "When the dragon is first bloodied, it immediately recharges its breath weapon, if its not already available. After doing so, the air around it becomes electrically charged. A creature that starts its turn within 15 feet of the dragon or moves within 15 feet of it for the first time on a turn makes a DC 24 Dexterity saving throw. On a failure, it takes 11 (2d10) lightning damage and can't take reactions until the start of its next turn. Creatures in metal armor or wielding metal weapons have disadvantage on this saving throw."
       },
       {
         "name": "Innate Spellcasting",
@@ -19891,7 +19891,7 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dragon exhales a 120-foot-long  10-foot-wide line of lightning. Each creature in that area makes a DC 24 Dexterity saving throw  taking 94 (17d10) lightning damage on a failed save or half damage on a success. A creature that fails the save cant take reactions until the end of its next turn."
+        "desc": "The dragon exhales a 120-foot-long  10-foot-wide line of lightning. Each creature in that area makes a DC 24 Dexterity saving throw  taking 94 (17d10) lightning damage on a failed save or half damage on a success. A creature that fails the save can't take reactions until the end of its next turn."
       },
       {
         "name": "Quake",
@@ -20025,7 +20025,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its greatsword."
+        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Molten Spit  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its greatsword."
       }
     ],
     "reactions": [
@@ -20156,7 +20156,7 @@
       },
       {
         "name": "Honeyed Words",
-        "desc": "The dragons words sow doubt in the minds of those who hear them. One creature within 60 feet who can hear and understand the dragon makes a DC 19 Wisdom saving throw. On a failure  the creature must use its reaction  if available  to make one attack against a creature of the dragons choice with whatever weapon it has to do so  moving up to its speed as part of the reaction if necessary. It need not use any special class features (such as Sneak Attack or Divine Smite) when making this attack. If it cant get in a position to attack the creature  it moves as far as it can toward the target before regaining its senses. A creature immune to being charmed is immune to this ability."
+        "desc": "The dragons words sow doubt in the minds of those who hear them. One creature within 60 feet who can hear and understand the dragon makes a DC 19 Wisdom saving throw. On a failure  the creature must use its reaction  if available  to make one attack against a creature of the dragons choice with whatever weapon it has to do so  moving up to its speed as part of the reaction if necessary. It need not use any special class features (such as Sneak Attack or Divine Smite) when making this attack. If it can't get in a position to attack the creature  it moves as far as it can toward the target before regaining its senses. A creature immune to being charmed is immune to this ability."
       }
     ],
     "reactions": [
@@ -20737,7 +20737,7 @@
     "actions": [
       {
         "name": "Tentacles",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 9 (2d6 + 2) bludgeoning damage  and the target is grappled (escape DC 12). Until this grapple ends  the grick cant attack a different target with its tentacles."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 9 (2d6 + 2) bludgeoning damage  and the target is grappled (escape DC 12). Until this grapple ends  the grick can't attack a different target with its tentacles."
       }
     ],
     "bonus_actions": [
@@ -20801,7 +20801,7 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) slashing damage  or 11 (2d6 + 4) slashing damage if the griffon started its turn at least 20 feet above the target  and the target is grappled (escape DC 14). Until this grapple ends  the griffon cant attack a different target with its talons."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) slashing damage  or 11 (2d6 + 4) slashing damage if the griffon started its turn at least 20 feet above the target  and the target is grappled (escape DC 14). Until this grapple ends  the griffon can't attack a different target with its talons."
       }
     ],
     "speed_json": {
@@ -20928,7 +20928,7 @@
       },
       {
         "name": "Throttle",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 4 (1d4 + 2) bludgeoning damage  and the target is grappled (escape DC 12) and cant breathe. Until this grapple ends  the grimlock cant use any attack other than throttle and only against the grappled target  and it makes this attack with advantage."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 4 (1d4 + 2) bludgeoning damage  and the target is grappled (escape DC 12) and can't breathe. Until this grapple ends  the grimlock can't use any attack other than throttle and only against the grappled target  and it makes this attack with advantage."
       },
       {
         "name": "Sling",
@@ -20993,7 +20993,7 @@
       },
       {
         "name": "Throttle",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 4 (1d4 + 2) bludgeoning damage  and the target is grappled (escape DC 12) and cant breathe. Until this grapple ends  the grimlock cant use any attack other than throttle and only against the grappled target  and it makes this attack with advantage."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 4 (1d4 + 2) bludgeoning damage  and the target is grappled (escape DC 12) and can't breathe. Until this grapple ends  the grimlock can't use any attack other than throttle and only against the grappled target  and it makes this attack with advantage."
       },
       {
         "name": "Sling",
@@ -21160,7 +21160,7 @@
       },
       {
         "name": "Forbiddance",
-        "desc": "The nagas lair is under the forbiddance spell. Until it is dispelled, creatures in the lair cant teleport or use planar travel. Fiends and undead that are not the nagas allies take 27 (5d10) radiant damage when they enter or start their turn in the lair."
+        "desc": "The nagas lair is under the forbiddance spell. Until it is dispelled, creatures in the lair can't teleport or use planar travel. Fiends and undead that are not the nagas allies take 27 (5d10) radiant damage when they enter or start their turn in the lair."
       },
       {
         "name": "Rejuvenation",
@@ -21501,7 +21501,7 @@
     "damage_immunities": "fire",
     "senses": "darkvision 60 ft., passive Perception 15",
     "challenge_rating": "3",
-    "languages": "understands Infernal but cant speak",
+    "languages": "understands Infernal but can't speak",
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
@@ -21580,7 +21580,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 15 (2d10 + 4) piercing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the target is restrained  and the hezrou cant bite another target."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 15 (2d10 + 4) piercing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the target is restrained  and the hezrou can't bite another target."
       },
       {
         "name": "Claws",
@@ -21596,7 +21596,7 @@
       },
       {
         "name": "Darkness",
-        "desc": "Magical darkness spreads from a point within 30 feet  filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute  until the hezrou dismisses it  or until the hezrou uses this ability again. A creature with darkvision cant see through this darkness and nonmagical light cant illuminate it."
+        "desc": "Magical darkness spreads from a point within 30 feet  filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute  until the hezrou dismisses it  or until the hezrou uses this ability again. A creature with darkvision can't see through this darkness and nonmagical light can't illuminate it."
       }
     ],
     "reactions": [
@@ -21738,7 +21738,7 @@
     "bonus_actions": [
       {
         "name": "Healing Word (1st-Level; V)",
-        "desc": "The priest or a living creature within 60 feet regains 6 (1d4 + 4) hit points. The priest cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The priest or a living creature within 60 feet regains 6 (1d4 + 4) hit points. The priest can't cast this spell and a 1st-level or higher spell on the same turn."
       },
       {
         "name": "High priests lead major temples and shrines",
@@ -21800,7 +21800,7 @@
       },
       {
         "name": "Grab",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one creature. Hit: 13 (3d6 + 3) bludgeoning damage  and the target is grappled (escape DC 13). Until this grapple ends  the pugilist cant grapple a different target."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one creature. Hit: 13 (3d6 + 3) bludgeoning damage  and the target is grappled (escape DC 13). Until this grapple ends  the pugilist can't grapple a different target."
       },
       {
         "name": "Pin",
@@ -21900,7 +21900,7 @@
     "bonus_actions": [
       {
         "name": "Grab",
-        "desc": "One creature within 5 feet makes a DC 10 Dexterity saving throw. On a failure, it is grappled (escape DC 16). Until this grapple ends, the giant cant grab another target, and it makes greatclub attacks with advantage against the grappled target."
+        "desc": "One creature within 5 feet makes a DC 10 Dexterity saving throw. On a failure, it is grappled (escape DC 16). Until this grapple ends, the giant can't grab another target, and it makes greatclub attacks with advantage against the grappled target."
       }
     ],
     "speed_json": {
@@ -21964,7 +21964,7 @@
     "bonus_actions": [
       {
         "name": "Grab",
-        "desc": "One creature within 5 feet makes a DC 10 Dexterity saving throw. On a failure, it is grappled (escape DC 16). Until this grapple ends, the giant cant grab another target, and it makes greatclub attacks with advantage against the grappled target."
+        "desc": "One creature within 5 feet makes a DC 10 Dexterity saving throw. On a failure, it is grappled (escape DC 16). Until this grapple ends, the giant can't grab another target, and it makes greatclub attacks with advantage against the grappled target."
       },
       {
         "name": "Body Slam (1/Day)",
@@ -22332,7 +22332,7 @@
     "condition_immunities": "charmed, poisoned",
     "senses": "darkvision 60 ft., passive Perception 10",
     "challenge_rating": "0",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "Telepathic Bond",
@@ -22581,7 +22581,7 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 16 (4d6 + 2) necrotic damage  and the target makes a DC 12 Constitution saving throw. On a failure  the target is cursed until it finishes a short or long rest or is the subject of remove curse or a similar spell. While cursed  the target makes attack rolls  Strength checks  and Strength saving throws with disadvantage. If the target dies while cursed  a new undead shadow rises from the corpse in 1d4 hours  the corpse no longer casts a natural shadow  and the target cant be raised from the dead until the new shadow is destroyed."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 16 (4d6 + 2) necrotic damage  and the target makes a DC 12 Constitution saving throw. On a failure  the target is cursed until it finishes a short or long rest or is the subject of remove curse or a similar spell. While cursed  the target makes attack rolls  Strength checks  and Strength saving throws with disadvantage. If the target dies while cursed  a new undead shadow rises from the corpse in 1d4 hours  the corpse no longer casts a natural shadow  and the target can't be raised from the dead until the new shadow is destroyed."
       }
     ],
     "bonus_actions": [
@@ -22671,7 +22671,7 @@
     "reactions": [
       {
         "name": "Pin (1/Day)",
-        "desc": "When a creature misses the devil with a melee attack, the devil makes a fork attack against that creature. On a hit, the target is impaled by the fork and grappled (escape DC 17). Until this grapple ends, the devil cant make fork attacks or use Inferno, but the target takes 7 (2d6) piercing damage plus 3 (1d6) fire damage at the beginning of each of its turns."
+        "desc": "When a creature misses the devil with a melee attack, the devil makes a fork attack against that creature. On a hit, the target is impaled by the fork and grappled (escape DC 17). Until this grapple ends, the devil can't make fork attacks or use Inferno, but the target takes 7 (2d6) piercing damage plus 3 (1d6) fire damage at the beginning of each of its turns."
       }
     ],
     "speed_json": {
@@ -22774,7 +22774,7 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 60 ft., passive Perception 13",
     "challenge_rating": "1",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "Immutable Form",
@@ -22904,7 +22904,7 @@
       },
       {
         "name": "Multiple Heads",
-        "desc": "While the hydra has more than one head, it has advantage on Perception checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious, and it cant be flanked."
+        "desc": "While the hydra has more than one head, it has advantage on Perception checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious, and it can't be flanked."
       },
       {
         "name": "Reactive Heads",
@@ -22940,7 +22940,7 @@
       },
       {
         "name": "Rush",
-        "desc": "The hydra moves or swims up to half its Speed without provoking opportunity attacks. If this movement would pass through the space of creatures that are not incapacitated or prone, each creature makes a DC 17 Strength saving throw. On a failure, the creature is knocked prone and the hydra can enter its space without treating it as difficult terrain. On a success, the hydra cant enter the creatures space, and the hydras movement ends. If this movement ends while the hydra is sharing a space with a creature, the creature is pushed to the nearest unoccupied space."
+        "desc": "The hydra moves or swims up to half its Speed without provoking opportunity attacks. If this movement would pass through the space of creatures that are not incapacitated or prone, each creature makes a DC 17 Strength saving throw. On a failure, the creature is knocked prone and the hydra can enter its space without treating it as difficult terrain. On a success, the hydra can't enter the creatures space, and the hydras movement ends. If this movement ends while the hydra is sharing a space with a creature, the creature is pushed to the nearest unoccupied space."
       },
       {
         "name": "Wrap",
@@ -23425,7 +23425,7 @@
     },
     "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 12",
     "challenge_rating": "3",
-    "languages": "understands Deep Speech but cant speak, telepathy 120 ft.",
+    "languages": "understands Deep Speech but can't speak, telepathy 120 ft.",
     "actions": [
       {
         "name": "Claws",
@@ -23552,7 +23552,7 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 120 ft., passive Perception 11",
     "challenge_rating": "14",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "Fire Absorption",
@@ -23930,7 +23930,7 @@
     "actions": [
       {
         "name": "Strangle",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 10 ft.  one Medium or smaller creature that is surprised  grappled by the kech  or that cant see the kech. Hit: 9 (2d6 + 2) bludgeoning damage  and the target is pulled 5 feet towards the kech and grappled (escape DC 12). Until this grapple ends  the kech automatically hits with the Strangle attack and the target cant breathe."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 10 ft.  one Medium or smaller creature that is surprised  grappled by the kech  or that can't see the kech. Hit: 9 (2d6 + 2) bludgeoning damage  and the target is pulled 5 feet towards the kech and grappled (escape DC 12). Until this grapple ends  the kech automatically hits with the Strangle attack and the target can't breathe."
       },
       {
         "name": "Claw",
@@ -24017,7 +24017,7 @@
     "bonus_actions": [
       {
         "name": "Brain Jab",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one incapacitated creature with a brain and an Intelligence of 6 or higher. Hit: 5 (1d4 + 3) piercing damage, and the target becomes diseased with brain larvae. Once the khalkos has used this attack successfully, it cant use it again for 24 hours."
+        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one incapacitated creature with a brain and an Intelligence of 6 or higher. Hit: 5 (1d4 + 3) piercing damage, and the target becomes diseased with brain larvae. Once the khalkos has used this attack successfully, it can't use it again for 24 hours."
       }
     ],
     "reactions": [
@@ -24027,7 +24027,7 @@
       },
       {
         "name": "Brain Jab",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one incapacitated creature with a brain and an Intelligence of 6 or higher. Hit: 5 (1d4 + 3) piercing damage, and the target becomes diseased with brain larvae. Once the khalkos has used this attack successfully, it cant use it again for 24 hours."
+        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one incapacitated creature with a brain and an Intelligence of 6 or higher. Hit: 5 (1d4 + 3) piercing damage, and the target becomes diseased with brain larvae. Once the khalkos has used this attack successfully, it can't use it again for 24 hours."
       }
     ],
     "speed_json": {
@@ -24122,7 +24122,7 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The whale cant use blindsight while deafened."
+        "desc": "The whale can't use blindsight while deafened."
       },
       {
         "name": "Hold Breath",
@@ -24136,7 +24136,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 14 (3d6+4) piercing damage. If the target is a creature  it is grappled (escape DC 14). Until this grapple ends  the whale cant bite another target and it has advantage on bite attacks against the creature it is grappling."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 14 (3d6+4) piercing damage. If the target is a creature  it is grappled (escape DC 14). Until this grapple ends  the whale can't bite another target and it has advantage on bite attacks against the creature it is grappling."
       }
     ],
     "speed_json": {
@@ -24183,7 +24183,7 @@
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, cant travel to or from the Material Plane)"
+        "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, can't travel to or from the Material Plane)"
       }
     ],
     "actions": [
@@ -24229,7 +24229,7 @@
       },
       {
         "name": "Cast Spell",
-        "desc": "The empyrean casts a spell. The empyrean cant use this option if it has cast a spell since the start of its last turn."
+        "desc": "The empyrean casts a spell. The empyrean can't use this option if it has cast a spell since the start of its last turn."
       },
       {
         "name": "Fly",
@@ -24816,7 +24816,7 @@
     "damage_immunities": "lightning; damage from nonmagical weapons",
     "senses": "truesight 120 ft., passive Perception 14",
     "challenge_rating": "25",
-    "languages": "understands Primordial but cant speak, telepathy 120 ft.",
+    "languages": "understands Primordial but can't speak, telepathy 120 ft.",
     "special_abilities": [
       {
         "name": "Immortal Nature",
@@ -25013,7 +25013,7 @@
     "bonus_actions": [
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The lamia teleports to an unoccupied space it can see within 30 feet. The lamia cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The lamia teleports to an unoccupied space it can see within 30 feet. The lamia can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -25052,7 +25052,7 @@
     "condition_immunities": "poisoned",
     "senses": "darkvision 120 ft., passive Perception 10",
     "challenge_rating": "1",
-    "languages": "understands Infernal but cant speak",
+    "languages": "understands Infernal but can't speak",
     "special_abilities": [
       {
         "name": "Devils Sight",
@@ -25109,7 +25109,7 @@
     "condition_immunities": "poisoned",
     "senses": "darkvision 120 ft., passive Perception 10",
     "challenge_rating": "2",
-    "languages": "understands Infernal but cant speak",
+    "languages": "understands Infernal but can't speak",
     "special_abilities": [
       {
         "name": "Area Vulnerability",
@@ -25269,7 +25269,7 @@
       },
       {
         "name": "Spell Shield Aura",
-        "desc": "The aura casts blue light. Any spell cast with a 5th-level or lower spell slot from outside the aura cant affect anything inside the aura. Using a spell to target something inside the aura or include the auras space in an area has no effect on anything inside."
+        "desc": "The aura casts blue light. Any spell cast with a 5th-level or lower spell slot from outside the aura can't affect anything inside the aura. Using a spell to target something inside the aura or include the auras space in an area has no effect on anything inside."
       }
     ],
     "reactions": [
@@ -25295,7 +25295,7 @@
       },
       {
         "name": "Spell Shield Aura",
-        "desc": "The aura casts blue light. Any spell cast with a 5th-level or lower spell slot from outside the aura cant affect anything inside the aura. Using a spell to target something inside the aura or include the auras space in an area has no effect on anything inside."
+        "desc": "The aura casts blue light. Any spell cast with a 5th-level or lower spell slot from outside the aura can't affect anything inside the aura. Using a spell to target something inside the aura or include the auras space in an area has no effect on anything inside."
       }
     ],
     "legendary_actions": [
@@ -25639,7 +25639,7 @@
     "bonus_actions": [
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "reactions": [
@@ -25653,7 +25653,7 @@
       },
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -26526,7 +26526,7 @@
       },
       {
         "name": "Snake Hair",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) piercing damage plus 7 (2d6) poison damage  plus an additional 3 (1d6) piercing damage if the target is a creature that is surprised or that cant see the medusa."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) piercing damage plus 7 (2d6) poison damage  plus an additional 3 (1d6) piercing damage if the target is a creature that is surprised or that can't see the medusa."
       },
       {
         "name": "Longbow",
@@ -26590,7 +26590,7 @@
       },
       {
         "name": "Snake Hair",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) piercing damage plus 7 (2d6) poison damage  plus an additional 3 (1d6) piercing damage if the target is a creature that is surprised or that cant see the medusa."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) piercing damage plus 7 (2d6) poison damage  plus an additional 3 (1d6) piercing damage if the target is a creature that is surprised or that can't see the medusa."
       },
       {
         "name": "Longbow",
@@ -26870,7 +26870,7 @@
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) piercing damage  and the target is grappled (escape DC 14). Until this grapple ends  the merrow cant attack a different creature with its claws."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) piercing damage  and the target is grappled (escape DC 14). Until this grapple ends  the merrow can't attack a different creature with its claws."
       },
       {
         "name": "Harpoon",
@@ -26936,7 +26936,7 @@
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) piercing damage  and the target is grappled (escape DC 14). Until this grapple ends  the merrow cant attack a different creature with its claws."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) piercing damage  and the target is grappled (escape DC 14). Until this grapple ends  the merrow can't attack a different creature with its claws."
       },
       {
         "name": "Harpoon",
@@ -26954,11 +26954,11 @@
       },
       {
         "name": "Shapeshift",
-        "desc": "The mage changes its form to that of a Medium merfolk or back into its true form. While shapeshifted, it cant use its Bite attack but its statistics are otherwise unchanged except for its size. It reverts to its true form if it dies."
+        "desc": "The mage changes its form to that of a Medium merfolk or back into its true form. While shapeshifted, it can't use its Bite attack but its statistics are otherwise unchanged except for its size. It reverts to its true form if it dies."
       },
       {
         "name": "Darkness (2nd-Level; V",
-        "desc": "Magical darkness spreads from a point within 60 feet of the mage, filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute. A creature with darkvision cant see through this darkness, and nonmagical light cant illuminate it."
+        "desc": "Magical darkness spreads from a point within 60 feet of the mage, filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute. A creature with darkvision can't see through this darkness, and nonmagical light can't illuminate it."
       },
       {
         "name": "Invisibility (2nd-Level; V",
@@ -27032,7 +27032,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one creature stuck to the mimic. Hit: 9 (2d4 + 4) piercing damage  and the target is restrained until it is no longer stuck to the mimic. While a creature is restrained by the mimic  the mimic cant bite a different creature."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one creature stuck to the mimic. Hit: 9 (2d4 + 4) piercing damage  and the target is restrained until it is no longer stuck to the mimic. While a creature is restrained by the mimic  the mimic can't bite a different creature."
       },
       {
         "name": "Swallow",
@@ -27253,7 +27253,7 @@
       },
       {
         "name": "Healing Word (1st-Level; V)",
-        "desc": "The minstrel or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The minstrel cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The minstrel or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The minstrel can't cast this spell and a 1st-level or higher spell on the same turn."
       },
       {
         "name": "Minstrels are musicians who weave magic into their performances",
@@ -27330,7 +27330,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one creature stuck to the mimic. Hit: 9 (2d4 + 4) piercing damage  and the target is restrained until it is no longer stuck to the mimic. While a creature is restrained by the mimic  the mimic cant bite a different creature."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one creature stuck to the mimic. Hit: 9 (2d4 + 4) piercing damage  and the target is restrained until it is no longer stuck to the mimic. While a creature is restrained by the mimic  the mimic can't bite a different creature."
       },
       {
         "name": "Swallow",
@@ -27726,7 +27726,7 @@
       },
       {
         "name": "Curse: Mummy Rot",
-        "desc": "A mummys touch inflicts a dreadful curse called mummy rot. A cursed creature cant regain hit points, and its hit point maximum decreases by an amount equal to the creatures total number of Hit Dice for every 24 hours that elapse. If this curse reduces the targets hit point maximum to 0, the target dies and crumbles to dust. Remove curse and similar magic ends the curse."
+        "desc": "A mummys touch inflicts a dreadful curse called mummy rot. A cursed creature can't regain hit points, and its hit point maximum decreases by an amount equal to the creatures total number of Hit Dice for every 24 hours that elapse. If this curse reduces the targets hit point maximum to 0, the target dies and crumbles to dust. Remove curse and similar magic ends the curse."
       }
     ],
     "actions": [
@@ -27786,7 +27786,7 @@
     "special_abilities": [
       {
         "name": "Curse: Mummy Rot",
-        "desc": "A mummys touch inflicts a dreadful curse called mummy rot. A cursed creature cant regain hit points, and its hit point maximum decreases by an amount equal to the creatures total number of Hit Dice for every 24 hours that elapse. If this curse reduces the targets hit point maximum to 0, the target dies and crumbles to dust. Remove curse and similar magic ends the curse."
+        "desc": "A mummys touch inflicts a dreadful curse called mummy rot. A cursed creature can't regain hit points, and its hit point maximum decreases by an amount equal to the creatures total number of Hit Dice for every 24 hours that elapse. If this curse reduces the targets hit point maximum to 0, the target dies and crumbles to dust. Remove curse and similar magic ends the curse."
       },
       {
         "name": "Flammable",
@@ -27836,7 +27836,7 @@
       },
       {
         "name": "Harm (6th-Level; V, S)",
-        "desc": "The mummy lord targets a creature within 60 feet. The target makes a DC 17 Constitution saving throw. On a failure  the creature is diseased  taking 49 (14d6) necrotic damage. Its hit point maximum is reduced by the same amount for 1 hour or until the effect is removed with a spell that removes diseases. On a successful save  the creature takes half the damage. The spells damage cant reduce a target to less than 1 hit point."
+        "desc": "The mummy lord targets a creature within 60 feet. The target makes a DC 17 Constitution saving throw. On a failure  the creature is diseased  taking 49 (14d6) necrotic damage. Its hit point maximum is reduced by the same amount for 1 hour or until the effect is removed with a spell that removes diseases. On a successful save  the creature takes half the damage. The spells damage can't reduce a target to less than 1 hit point."
       }
     ],
     "reactions": [
@@ -27852,7 +27852,7 @@
       },
       {
         "name": "Channel Negative Energy",
-        "desc": "A 60-foot-radius aura of magical negative energy surrounds the mummy lord until the end of its next turn, spreading around corners. Creatures in the aura cant regain hit points."
+        "desc": "A 60-foot-radius aura of magical negative energy surrounds the mummy lord until the end of its next turn, spreading around corners. Creatures in the aura can't regain hit points."
       },
       {
         "name": "Whirlwind of Sand",
@@ -28005,7 +28005,7 @@
     "actions": [
       {
         "name": "Watery Grasp",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 4 (1d4 + 2) bludgeoning damage  and the target is grappled (escape DC 12). While grappling a creature this way  the naiad cant use Watery Grasp on a different target and can swim at full speed."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 4 (1d4 + 2) bludgeoning damage  and the target is grappled (escape DC 12). While grappling a creature this way  the naiad can't use Watery Grasp on a different target and can swim at full speed."
       }
     ],
     "speed_json": {
@@ -28161,7 +28161,7 @@
     "bonus_actions": [
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "reactions": [
@@ -28175,7 +28175,7 @@
       },
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -28240,7 +28240,7 @@
       },
       {
         "name": "Sleep Touch",
-        "desc": "Melee Spell Attack: +5 to hit  reach 5 ft.  one creature. Hit: The target falls asleep for 4 hours or until it takes damage or is shaken awake. Once the hag successfully hits a target  it cant make this attack again until it finishes a long rest."
+        "desc": "Melee Spell Attack: +5 to hit  reach 5 ft.  one creature. Hit: The target falls asleep for 4 hours or until it takes damage or is shaken awake. Once the hag successfully hits a target  it can't make this attack again until it finishes a long rest."
       },
       {
         "name": "Shapeshift",
@@ -28290,7 +28290,7 @@
     "damage_immunities": "fire",
     "senses": "passive Perception 11",
     "challenge_rating": "3",
-    "languages": "understands Abyssal, Common, and Infernal but cant speak",
+    "languages": "understands Abyssal, Common, and Infernal but can't speak",
     "special_abilities": [
       {
         "name": "Evil",
@@ -28556,7 +28556,7 @@
     "actions": [
       {
         "name": "Tentacles",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 15 ft.  one target. Hit: 1 bludgeoning damage. If the target is a creature  it is grappled (escape DC 10). Until this grapple ends  the target is restrained  and the octopus cant attack a different target with its tentacles."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 15 ft.  one target. Hit: 1 bludgeoning damage. If the target is a creature  it is grappled (escape DC 10). Until this grapple ends  the target is restrained  and the octopus can't attack a different target with its tentacles."
       }
     ],
     "bonus_actions": [
@@ -28649,7 +28649,7 @@
     "condition_immunities": "fatigue, poisoned",
     "senses": "darkvision 60 ft., passive Perception 8",
     "challenge_rating": "4",
-    "languages": "understands Giant but cant speak",
+    "languages": "understands Giant but can't speak",
     "special_abilities": [
       {
         "name": "Undead Fortitude (1/Day)",
@@ -28671,7 +28671,7 @@
       },
       {
         "name": "Grab",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  and the target is grappled if its Medium or smaller (escape DC 14)  and until the grapple ends  the zombie cant grab another target."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  and the target is grappled if its Medium or smaller (escape DC 14)  and until the grapple ends  the zombie can't grab another target."
       },
       {
         "name": "Bite",
@@ -28754,7 +28754,7 @@
       },
       {
         "name": "Darkness (2nd-Level; V, S, Concentration)",
-        "desc": "Magical darkness spreads from a point within 30 feet of the ogre  filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute. A creature with darkvision cant see through this darkness  and nonmagical light cant illuminate it."
+        "desc": "Magical darkness spreads from a point within 30 feet of the ogre  filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute. A creature with darkvision can't see through this darkness  and nonmagical light can't illuminate it."
       },
       {
         "name": "Hold Person (2nd-Level; V, S, Concentration)",
@@ -28766,7 +28766,7 @@
       },
       {
         "name": "Gaseous Form (3rd-Level; V, S, Concentration)",
-        "desc": "The ogre and its gear becomes a hovering cloud of gas for 1 hour. Its Speed is 0  and its fly speed is 30. It cant attack  use or drop objects  talk  or cast spells. It can enter another creatures space and pass through small holes and cracks but cant pass through liquid. It is resistant to nonmagical damage  has advantage on Strength  Dexterity and Constitution saving throws  and cant fall."
+        "desc": "The ogre and its gear becomes a hovering cloud of gas for 1 hour. Its Speed is 0  and its fly speed is 30. It can't attack  use or drop objects  talk  or cast spells. It can enter another creatures space and pass through small holes and cracks but can't pass through liquid. It is resistant to nonmagical damage  has advantage on Strength  Dexterity and Constitution saving throws  and can't fall."
       },
       {
         "name": "Cone of Cold (5th-Level; V, S)",
@@ -28815,7 +28815,7 @@
     "condition_immunities": "fatigue, poisoned",
     "senses": "darkvision 60 ft., passive Perception 8",
     "challenge_rating": "2",
-    "languages": "understands Giant but cant speak",
+    "languages": "understands Giant but can't speak",
     "special_abilities": [
       {
         "name": "Undead Fortitude (1/Day)",
@@ -28837,7 +28837,7 @@
       },
       {
         "name": "Grab",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  and the target is grappled if its Medium or smaller (escape DC 14)  and until the grapple ends  the zombie cant grab another target."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  and the target is grappled if its Medium or smaller (escape DC 14)  and until the grapple ends  the zombie can't grab another target."
       },
       {
         "name": "Bite",
@@ -28980,7 +28980,7 @@
       },
       {
         "name": "Healing Word (1st-Level; V)",
-        "desc": "The minstrel or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The minstrel cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The minstrel or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The minstrel can't cast this spell and a 1st-level or higher spell on the same turn."
       },
       {
         "name": "Many orc tribes use song to preserve a communal memory of history",
@@ -29101,7 +29101,7 @@
       },
       {
         "name": "Tentacle",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 10 ft.  one target. Hit: 7 (1d8 + 3) bludgeoning damage plus 4 (1d8) piercing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 14) and restrained until the grapple ends. The otyugh has two tentacles  each of which can grapple one target and cant attack a different target while doing so."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 10 ft.  one target. Hit: 7 (1d8 + 3) bludgeoning damage plus 4 (1d8) piercing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 14) and restrained until the grapple ends. The otyugh has two tentacles  each of which can grapple one target and can't attack a different target while doing so."
       },
       {
         "name": "Tentacle Slam",
@@ -29394,7 +29394,7 @@
     },
     "senses": "passive Perception 17",
     "challenge_rating": "2",
-    "languages": "understands Celestial, Common, Elvish, and Sylvan, but cant speak",
+    "languages": "understands Celestial, Common, Elvish, and Sylvan, but can't speak",
     "special_abilities": [
       {
         "name": "Good",
@@ -29450,7 +29450,7 @@
     "damage_resistances": "damage from nonmagical weapons",
     "senses": "passive Perception 13",
     "challenge_rating": "2",
-    "languages": "understands Common and Sylvan but cant speak",
+    "languages": "understands Common and Sylvan but can't speak",
     "special_abilities": [
       {
         "name": "Keen Sight and Smell",
@@ -29833,7 +29833,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +14 to hit  reach 5 ft.  one target. Hit: 22 (4d6 + 8) piercing damage. If the target is a creature  it makes a DC 20 Constitution saving throw. On a failure  it is poisoned for 1 minute. While poisoned in this way  the target cant regain hit points and takes 21 (6d6) ongoing poison damage at the start of each of its turns. The target can repeat this saving throw at the end of each of its turns  ending the effect on a success."
+        "desc": "Melee Weapon Attack: +14 to hit  reach 5 ft.  one target. Hit: 22 (4d6 + 8) piercing damage. If the target is a creature  it makes a DC 20 Constitution saving throw. On a failure  it is poisoned for 1 minute. While poisoned in this way  the target can't regain hit points and takes 21 (6d6) ongoing poison damage at the start of each of its turns. The target can repeat this saving throw at the end of each of its turns  ending the effect on a success."
       },
       {
         "name": "Mace",
@@ -29855,7 +29855,7 @@
     "bonus_actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one creature. Hit: 19 (2d10 + 8) slashing damage, and the target is grappled (escape DC 22). While the target is grappled, the pit fiend cant use its claw against a different creature."
+        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one creature. Hit: 19 (2d10 + 8) slashing damage, and the target is grappled (escape DC 22). While the target is grappled, the pit fiend can't use its claw against a different creature."
       },
       {
         "name": "Tail",
@@ -29923,7 +29923,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +14 to hit  reach 5 ft.  one target. Hit: 22 (4d6 + 8) piercing damage. If the target is a creature  it makes a DC 20 Constitution saving throw. On a failure  it is poisoned for 1 minute. While poisoned in this way  the target cant regain hit points and takes 21 (6d6) ongoing poison damage at the start of each of its turns. The target can repeat this saving throw at the end of each of its turns  ending the effect on a success."
+        "desc": "Melee Weapon Attack: +14 to hit  reach 5 ft.  one target. Hit: 22 (4d6 + 8) piercing damage. If the target is a creature  it makes a DC 20 Constitution saving throw. On a failure  it is poisoned for 1 minute. While poisoned in this way  the target can't regain hit points and takes 21 (6d6) ongoing poison damage at the start of each of its turns. The target can repeat this saving throw at the end of each of its turns  ending the effect on a success."
       },
       {
         "name": "Mace",
@@ -29945,7 +29945,7 @@
     "bonus_actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one creature. Hit: 19 (2d10 + 8) slashing damage, and the target is grappled (escape DC 22). While the target is grappled, the pit fiend cant use its claw against a different creature."
+        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one creature. Hit: 19 (2d10 + 8) slashing damage, and the target is grappled (escape DC 22). While the target is grappled, the pit fiend can't use its claw against a different creature."
       },
       {
         "name": "Tail",
@@ -30286,7 +30286,7 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d4+5) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the bear cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 7 (1d4+5) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the bear can't attack a different target with its claws."
       }
     ],
     "speed_json": {
@@ -30400,7 +30400,7 @@
     "bonus_actions": [
       {
         "name": "Healing Word (1st-Level; V)",
-        "desc": "The priest or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The priest cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The priest or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The priest can't cast this spell and a 1st-level or higher spell on the same turn."
       },
       {
         "name": "Priests are ordained followers of a deity whose faith grants them spellcasting abilities",
@@ -30445,7 +30445,7 @@
     },
     "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 16",
     "challenge_rating": "1",
-    "languages": "understands Common and Draconic but cant speak",
+    "languages": "understands Common and Draconic but can't speak",
     "special_abilities": [
       {
         "name": "Limited Telepathy",
@@ -30505,7 +30505,7 @@
     },
     "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 16",
     "challenge_rating": "1",
-    "languages": "understands Common and Draconic but cant speak",
+    "languages": "understands Common and Draconic but can't speak",
     "special_abilities": [
       {
         "name": "Limited Telepathy",
@@ -30774,7 +30774,7 @@
       },
       {
         "name": "Multiple Heads",
-        "desc": "While the hydra has more than one head, it has advantage on Perception checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious, and it cant be flanked."
+        "desc": "While the hydra has more than one head, it has advantage on Perception checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious, and it can't be flanked."
       },
       {
         "name": "Reactive Heads",
@@ -30814,7 +30814,7 @@
       },
       {
         "name": "Rush",
-        "desc": "The hydra moves or swims up to half its Speed without provoking opportunity attacks. If this movement would pass through the space of creatures that are not incapacitated or prone, each creature makes a DC 17 Strength saving throw. On a failure, the creature is knocked prone and the hydra can enter its space without treating it as difficult terrain. On a success, the hydra cant enter the creatures space, and the hydras movement ends. If this movement ends while the hydra is sharing a space with a creature, the creature is pushed to the nearest unoccupied space."
+        "desc": "The hydra moves or swims up to half its Speed without provoking opportunity attacks. If this movement would pass through the space of creatures that are not incapacitated or prone, each creature makes a DC 17 Strength saving throw. On a failure, the creature is knocked prone and the hydra can enter its space without treating it as difficult terrain. On a success, the hydra can't enter the creatures space, and the hydras movement ends. If this movement ends while the hydra is sharing a space with a creature, the creature is pushed to the nearest unoccupied space."
       },
       {
         "name": "Wrap",
@@ -31482,7 +31482,7 @@
       },
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  and the target is subjected to the remorhazs Heated Body trait. The target is grappled (escape DC 15) and restrained while grappled. Until this grapple ends  the remorhaz cant grapple another creature."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  and the target is subjected to the remorhazs Heated Body trait. The target is grappled (escape DC 15) and restrained while grappled. Until this grapple ends  the remorhaz can't grapple another creature."
       }
     ],
     "speed_json": {
@@ -31548,7 +31548,7 @@
       },
       {
         "name": "Strangle",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  and the target is grappled (escape DC 15) if its a Large or smaller creature. Until this grapple ends  the creature cant breathe  and the revenant cant strangle any other creature."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 11 (2d6 + 4) bludgeoning damage  and the target is grappled (escape DC 15) if its a Large or smaller creature. Until this grapple ends  the creature can't breathe  and the revenant can't strangle any other creature."
       },
       {
         "name": "Burning Hatred (Recharge 4-6)",
@@ -31617,7 +31617,7 @@
       },
       {
         "name": "Throttle",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 4 (1d4 + 2) bludgeoning damage  and the target is grappled (escape DC 12) and cant breathe. Until this grapple ends  the grimlock cant use any attack other than throttle and only against the grappled target  and it makes this attack with advantage."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 4 (1d4 + 2) bludgeoning damage  and the target is grappled (escape DC 12) and can't breathe. Until this grapple ends  the grimlock can't use any attack other than throttle and only against the grappled target  and it makes this attack with advantage."
       },
       {
         "name": "Sling",
@@ -31832,7 +31832,7 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +14 to hit  reach 5 ft.  one target. Hit: 23 (4d6+9) slashing damage  and the target is grappled (escape DC 22). Until this grapple ends  the target is restrained  and the roc cant attack a different target with its talons."
+        "desc": "Melee Weapon Attack: +14 to hit  reach 5 ft.  one target. Hit: 23 (4d6+9) slashing damage  and the target is grappled (escape DC 22). Until this grapple ends  the target is restrained  and the roc can't attack a different target with its talons."
       }
     ],
     "reactions": [
@@ -31896,7 +31896,7 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +9 to hit  reach 5 ft.  one target. Hit: 16 (3d6+6) slashing damage  and the target is grappled (escape DC 17). Until this grapple ends  the target is restrained  and the roc cant attack a different target with its talons."
+        "desc": "Melee Weapon Attack: +9 to hit  reach 5 ft.  one target. Hit: 16 (3d6+6) slashing damage  and the target is grappled (escape DC 17). Until this grapple ends  the target is restrained  and the roc can't attack a different target with its talons."
       }
     ],
     "reactions": [
@@ -31961,7 +31961,7 @@
       },
       {
         "name": "Tendril",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 50 ft.  one target. Hit: The target is grappled (escape DC 15). Until this grapple ends  the target is restrained and the roper cant use this tendril on another target."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 50 ft.  one target. Hit: The target is grappled (escape DC 15). Until this grapple ends  the target is restrained and the roper can't use this tendril on another target."
       },
       {
         "name": "Reel",
@@ -32022,7 +32022,7 @@
     "actions": [
       {
         "name": "Smother",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one Large or smaller creature. Hit: The target is grappled (escape DC 13). Until this grapple ends  the target is restrained and cant breathe. When the rug is dealt damage while it is grappling  it takes half the damage (rounded down) and the other half is dealt to the grappled target. The rug can only have one creature grappled at once."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one Large or smaller creature. Hit: The target is grappled (escape DC 13). Until this grapple ends  the target is restrained and can't breathe. When the rug is dealt damage while it is grappling  it takes half the damage (rounded down) and the other half is dealt to the grappled target. The rug can only have one creature grappled at once."
       },
       {
         "name": "Squeeze",
@@ -32346,7 +32346,7 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 10 ft.  one target. Hit: 9 (2d4 + 4) bludgeoning damage  the target is subjected to the salamanders Heated Body trait  and the target is grappled (escape DC 15). Until this grapple ends  the target is restrained  the salamander automatically hits the target with its tail attack  and the salamander cant attack a different target with its tail."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 10 ft.  one target. Hit: 9 (2d4 + 4) bludgeoning damage  the target is subjected to the salamanders Heated Body trait  and the target is grappled (escape DC 15). Until this grapple ends  the target is restrained  the salamander automatically hits the target with its tail attack  and the salamander can't attack a different target with its tail."
       },
       {
         "name": "Pike",
@@ -32402,7 +32402,7 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 10 ft.  one target. Hit: 9 (2d4 + 4) bludgeoning damage  the target is subjected to the salamanders Heated Body trait  and the target is grappled (escape DC 15). Until this grapple ends  the target is restrained  the salamander automatically hits the target with its tail attack  and the salamander cant attack a different target with its tail."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 10 ft.  one target. Hit: 9 (2d4 + 4) bludgeoning damage  the target is subjected to the salamanders Heated Body trait  and the target is grappled (escape DC 15). Until this grapple ends  the target is restrained  the salamander automatically hits the target with its tail attack  and the salamander can't attack a different target with its tail."
       },
       {
         "name": "Pike",
@@ -32447,7 +32447,7 @@
     "damage_immunities": "fire",
     "senses": "darkvision 60 ft., passive Perception 10",
     "challenge_rating": "1",
-    "languages": "understands Ignan but cant speak",
+    "languages": "understands Ignan but can't speak",
     "special_abilities": [
       {
         "name": "Heated Body",
@@ -32778,7 +32778,7 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 60 ft., passive Perception 10",
     "challenge_rating": "1",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "False Appearance",
@@ -32851,7 +32851,7 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 60 ft., passive Perception 12",
     "challenge_rating": "4",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "Flammable",
@@ -32969,7 +32969,7 @@
     "actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 5 (1d6 + 2) bludgeoning damage  and the target is grappled (escape DC 12). Until this grapple ends  the scorpionfolk cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 5 (1d6 + 2) bludgeoning damage  and the target is grappled (escape DC 12). Until this grapple ends  the scorpionfolk can't attack a different target with its claws."
       },
       {
         "name": "Javelin",
@@ -33033,7 +33033,7 @@
     "actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 5 (1d6 + 2) bludgeoning damage  and the target is grappled (escape DC 12). Until this grapple ends  the scorpionfolk cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 5 (1d6 + 2) bludgeoning damage  and the target is grappled (escape DC 12). Until this grapple ends  the scorpionfolk can't attack a different target with its claws."
       },
       {
         "name": "Javelin",
@@ -33313,7 +33313,7 @@
       },
       {
         "name": "Reactive",
-        "desc": "The serpent can take two reactions per round, one with its tail and one with its bite. It cant take two reactions on the same turn."
+        "desc": "The serpent can take two reactions per round, one with its tail and one with its bite. It can't take two reactions on the same turn."
       },
       {
         "name": "Sinuous",
@@ -33451,7 +33451,7 @@
     "actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 9 (2d6 + 2) necrotic damage  and the target makes a DC 12 Constitution saving throw. On a failure  the target is cursed until it finishes a short or long rest or is the subject of remove curse or a similar spell. While cursed  the target makes attack rolls  Strength checks  and Strength saving throws with disadvantage. If the target dies while cursed  a new undead shadow rises from the corpse in 1d4 hours  the corpse no longer casts a natural shadow  and the target cant be raised from the dead until the new shadow is destroyed."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one creature. Hit: 9 (2d6 + 2) necrotic damage  and the target makes a DC 12 Constitution saving throw. On a failure  the target is cursed until it finishes a short or long rest or is the subject of remove curse or a similar spell. While cursed  the target makes attack rolls  Strength checks  and Strength saving throws with disadvantage. If the target dies while cursed  a new undead shadow rises from the corpse in 1d4 hours  the corpse no longer casts a natural shadow  and the target can't be raised from the dead until the new shadow is destroyed."
       }
     ],
     "bonus_actions": [
@@ -33523,7 +33523,7 @@
       },
       {
         "name": "Replace Shadow",
-        "desc": "The demon targets a humanoid within 5 feet that is in dim light and cant see the demon. The target makes a DC 13 Constitution saving throw. On a success  the target is aware of the demon. On a failure  the target is unaware of the demon  the target no longer casts a natural shadow  and the demon magically takes on the shape of the targets shadow  appearing indistinguishable from a natural shadow except when it attacks. The demon shares the targets space and moves with the target. When the demon is dealt damage while sharing the targets space  it takes half the damage (rounded down) and the other half is dealt to the target. The effect ends when the target drops to 0 hit points  the demon no longer shares the targets space  the demon or target is affected by dispel evil and good or a similar effect  or the demon begins its turn in an area of sunlight."
+        "desc": "The demon targets a humanoid within 5 feet that is in dim light and can't see the demon. The target makes a DC 13 Constitution saving throw. On a success  the target is aware of the demon. On a failure  the target is unaware of the demon  the target no longer casts a natural shadow  and the demon magically takes on the shape of the targets shadow  appearing indistinguishable from a natural shadow except when it attacks. The demon shares the targets space and moves with the target. When the demon is dealt damage while sharing the targets space  it takes half the damage (rounded down) and the other half is dealt to the target. The effect ends when the target drops to 0 hit points  the demon no longer shares the targets space  the demon or target is affected by dispel evil and good or a similar effect  or the demon begins its turn in an area of sunlight."
       },
       {
         "name": "Claws",
@@ -33827,7 +33827,7 @@
     "bonus_actions": [
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "reactions": [
@@ -33841,7 +33841,7 @@
       },
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -33900,7 +33900,7 @@
       },
       {
         "name": "Fey Ancestry",
-        "desc": "The drider gains an expertise die on saving throws against being charmed, and magic cant put it to sleep."
+        "desc": "The drider gains an expertise die on saving throws against being charmed, and magic can't put it to sleep."
       },
       {
         "name": "Innate Spellcasting",
@@ -33914,7 +33914,7 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 15 (2d10 + 4) piercing damage  and the target is grappled (escape DC 15). While grappling a target  the drider cant attack a different target with its claws."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 15 (2d10 + 4) piercing damage  and the target is grappled (escape DC 15). While grappling a target  the drider can't attack a different target with its claws."
       },
       {
         "name": "Bite",
@@ -33930,7 +33930,7 @@
       },
       {
         "name": "Darkness (2nd-Level; V, S, Concentration)",
-        "desc": "Magical darkness spreads from a point within 30 feet  filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute. A creature with darkvision cant see through this darkness and nonmagical light cant illuminate it."
+        "desc": "Magical darkness spreads from a point within 30 feet  filling a 15-foot-radius sphere and spreading around corners. It remains for 1 minute. A creature with darkvision can't see through this darkness and nonmagical light can't illuminate it."
       },
       {
         "name": "Web (2nd-Level; V, S, Concentration)",
@@ -34055,7 +34055,7 @@
       },
       {
         "name": "Engulf",
-        "desc": "The shambling mound absorbs a Medium or smaller grappled creature into its body. The engulfed creature is blinded  restrained  cant breathe  and moves with the shambling mound. At the start of each of the shambling mounds turns  the target takes 11 (2d6 + 4) bludgeoning damage."
+        "desc": "The shambling mound absorbs a Medium or smaller grappled creature into its body. The engulfed creature is blinded  restrained can't breathe  and moves with the shambling mound. At the start of each of the shambling mounds turns  the target takes 11 (2d6 + 4) bludgeoning damage."
       }
     ],
     "speed_json": {
@@ -34094,7 +34094,7 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 60 ft., passive Perception 10",
     "challenge_rating": "7",
-    "languages": "understands all languages but cant speak",
+    "languages": "understands all languages but can't speak",
     "special_abilities": [
       {
         "name": "Amulet",
@@ -34430,7 +34430,7 @@
     "condition_immunities": "fatigue, poisoned",
     "senses": "darkvision 60 ft., passive Perception 9",
     "challenge_rating": "3",
-    "languages": "understands the languages it knew in life but cant speak",
+    "languages": "understands the languages it knew in life but can't speak",
     "special_abilities": [
       {
         "name": "Undead Nature",
@@ -34506,7 +34506,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 25 (3d12 + 6) piercing damage. If the target is a creature  it is grappled (escape DC 17). Until this grapple ends  the skeleton cant bite a different creature and it has advantage on bite attacks against the grappled creature."
+        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 25 (3d12 + 6) piercing damage. If the target is a creature  it is grappled (escape DC 17). Until this grapple ends  the skeleton can't bite a different creature and it has advantage on bite attacks against the grappled creature."
       },
       {
         "name": "Tail",
@@ -34597,7 +34597,7 @@
     "condition_immunities": "fatigue, poisoned",
     "senses": "darkvision 60 ft., passive Perception 9",
     "challenge_rating": "1",
-    "languages": "understands the languages it knew in life but cant speak",
+    "languages": "understands the languages it knew in life but can't speak",
     "special_abilities": [
       {
         "name": "Undead Nature",
@@ -34650,7 +34650,7 @@
     "condition_immunities": "fatigue, poisoned",
     "senses": "darkvision 60 ft., passive Perception 9",
     "challenge_rating": "4",
-    "languages": "understands the languages it knew in life but cant speak",
+    "languages": "understands the languages it knew in life but can't speak",
     "special_abilities": [
       {
         "name": "Undead Nature",
@@ -34723,7 +34723,7 @@
       },
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one target. Hit: 10 (2d6 + 3) bludgeoning damage  and the target is grappled (escape DC 13). Until this grapple ends  the lamia cant constrict a different target."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one target. Hit: 10 (2d6 + 3) bludgeoning damage  and the target is grappled (escape DC 13). Until this grapple ends  the lamia can't constrict a different target."
       },
       {
         "name": "Dagger",
@@ -34737,7 +34737,7 @@
     "bonus_actions": [
       {
         "name": "Misty Step (2nd-Level; V)",
-        "desc": "The lamia teleports to an unoccupied space it can see within 30 feet. The lamia cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The lamia teleports to an unoccupied space it can see within 30 feet. The lamia can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {
@@ -35075,7 +35075,7 @@
     "condition_immunities": "charmed, fatigue, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
     "senses": "darkvision 60 ft., passive Perception 10",
     "challenge_rating": "1",
-    "languages": "understands the languages it knew in life but cant speak",
+    "languages": "understands the languages it knew in life but can't speak",
     "special_abilities": [
       {
         "name": "Incorporeal",
@@ -35101,7 +35101,7 @@
       },
       {
         "name": "Fade",
-        "desc": "While not in sunlight  the specter turns invisible and takes the Hide action. It remains invisible for 1 minute or until it uses Life Drain or takes damage. If the specter takes radiant damage  it cant use this action until the end of its next turn."
+        "desc": "While not in sunlight  the specter turns invisible and takes the Hide action. It remains invisible for 1 minute or until it uses Life Drain or takes damage. If the specter takes radiant damage  it can't use this action until the end of its next turn."
       }
     ],
     "speed_json": {
@@ -35141,7 +35141,7 @@
     "condition_immunities": "frightened, poisoned",
     "senses": "darkvision 60 ft., passive Perception 13",
     "challenge_rating": "7",
-    "languages": "understands Deep Speech but cant speak",
+    "languages": "understands Deep Speech but can't speak",
     "special_abilities": [
       {
         "name": "Amphibious",
@@ -35637,7 +35637,7 @@
       },
       {
         "name": "Don Disguise",
-        "desc": "The spymaster uses a disguise kit, making a Deception check to create the disguise. While the spymaster is wearing a disguise, their true identity cant be determined even if the disguise fails."
+        "desc": "The spymaster uses a disguise kit, making a Deception check to create the disguise. While the spymaster is wearing a disguise, their true identity can't be determined even if the disguise fails."
       },
       {
         "name": "Study Adversary",
@@ -35790,7 +35790,7 @@
       },
       {
         "name": "Blood Drain",
-        "desc": "The stirge drains blood from the creature it is attached to. The creature loses 4 (1d8) hit points. After the stirge has drained 8 hit points  it detaches itself and cant use Blood Drain again until it finishes a rest."
+        "desc": "The stirge drains blood from the creature it is attached to. The creature loses 4 (1d8) hit points. After the stirge has drained 8 hit points  it detaches itself and can't use Blood Drain again until it finishes a rest."
       }
     ],
     "speed_json": {
@@ -35829,7 +35829,7 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 120 ft., passive Perception 11",
     "challenge_rating": "16",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "Immutable Form",
@@ -35879,7 +35879,7 @@
       },
       {
         "name": "Seize",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 16 (4d4 + 6) bludgeoning damage, and the target is grappled (escape DC 18). Until this grapple ends, the target is restrained, and the colossus cant seize a different creature."
+        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 16 (4d4 + 6) bludgeoning damage, and the target is grappled (escape DC 18). Until this grapple ends, the target is restrained, and the colossus can't seize a different creature."
       },
       {
         "name": "Fling",
@@ -35958,7 +35958,7 @@
     "bonus_actions": [
       {
         "name": "Grab",
-        "desc": "One creature within 5 feet makes a DC 13 Dexterity saving throw. On a failure, it is grappled (escape DC 17). Until this grapple ends, the giant cant grab another target, and it makes greatclub attacks with advantage against the grappled target."
+        "desc": "One creature within 5 feet makes a DC 13 Dexterity saving throw. On a failure, it is grappled (escape DC 17). Until this grapple ends, the giant can't grab another target, and it makes greatclub attacks with advantage against the grappled target."
       }
     ],
     "reactions": [
@@ -35968,7 +35968,7 @@
       },
       {
         "name": "Grab",
-        "desc": "One creature within 5 feet makes a DC 13 Dexterity saving throw. On a failure, it is grappled (escape DC 17). Until this grapple ends, the giant cant grab another target, and it makes greatclub attacks with advantage against the grappled target."
+        "desc": "One creature within 5 feet makes a DC 13 Dexterity saving throw. On a failure, it is grappled (escape DC 17). Until this grapple ends, the giant can't grab another target, and it makes greatclub attacks with advantage against the grappled target."
       }
     ],
     "speed_json": {
@@ -36047,7 +36047,7 @@
     "bonus_actions": [
       {
         "name": "Grab",
-        "desc": "One creature within 5 feet makes a DC 13 Dexterity saving throw. On a failure, it is grappled (escape DC 17). Until this grapple ends, the giant cant grab another target, and it makes greatclub attacks with advantage against the grappled target."
+        "desc": "One creature within 5 feet makes a DC 13 Dexterity saving throw. On a failure, it is grappled (escape DC 17). Until this grapple ends, the giant can't grab another target, and it makes greatclub attacks with advantage against the grappled target."
       }
     ],
     "reactions": [
@@ -36057,7 +36057,7 @@
       },
       {
         "name": "Grab",
-        "desc": "One creature within 5 feet makes a DC 13 Dexterity saving throw. On a failure, it is grappled (escape DC 17). Until this grapple ends, the giant cant grab another target, and it makes greatclub attacks with advantage against the grappled target."
+        "desc": "One creature within 5 feet makes a DC 13 Dexterity saving throw. On a failure, it is grappled (escape DC 17). Until this grapple ends, the giant can't grab another target, and it makes greatclub attacks with advantage against the grappled target."
       }
     ],
     "speed_json": {
@@ -36095,7 +36095,7 @@
     "condition_immunities": "charmed, fatigue, frightened, paralyzed, petrified, poisoned",
     "senses": "darkvision 120 ft., passive Perception 11",
     "challenge_rating": "10",
-    "languages": "understands the languages of its creator but cant speak",
+    "languages": "understands the languages of its creator but can't speak",
     "special_abilities": [
       {
         "name": "Immutable Form",
@@ -36392,7 +36392,7 @@
       },
       {
         "name": "Trackless Travel",
-        "desc": "The strider cant be tracked by nonmagical means."
+        "desc": "The strider can't be tracked by nonmagical means."
       },
       {
         "name": "Trained Accuracy",
@@ -36466,7 +36466,7 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The swarm cant use blindsight while deafened."
+        "desc": "The swarm can't use blindsight while deafened."
       },
       {
         "name": "Keen Hearing",
@@ -36474,7 +36474,7 @@
       },
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It cant gain hit points or temporary hit points."
+        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It can't gain hit points or temporary hit points."
       }
     ],
     "actions": [
@@ -36523,7 +36523,7 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It cant gain hit points or temporary hit points."
+        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It can't gain hit points or temporary hit points."
       }
     ],
     "actions": [
@@ -36624,7 +36624,7 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It cant gain hit points or temporary hit points."
+        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It can't gain hit points or temporary hit points."
       }
     ],
     "actions": [
@@ -36673,7 +36673,7 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It cant gain hit points or temporary hit points."
+        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It can't gain hit points or temporary hit points."
       },
       {
         "name": "Water Breathing",
@@ -36729,7 +36729,7 @@
       },
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It cant gain hit points or temporary hit points."
+        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It can't gain hit points or temporary hit points."
       }
     ],
     "actions": [
@@ -36780,7 +36780,7 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It cant gain hit points or temporary hit points."
+        "desc": "The swarm can occupy another creatures space and move through any opening large enough for a Tiny creature. It can't gain hit points or temporary hit points."
       }
     ],
     "actions": [
@@ -36863,7 +36863,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +19 to hit  reach 10 ft.  one target. Hit: 42 (5d12 + 10) piercing damage. If the target is a creature  it is grappled (escape DC 27). Until this grapple ends  the target is restrained and the tarrasque cant bite a different creature."
+        "desc": "Melee Weapon Attack: +19 to hit  reach 10 ft.  one target. Hit: 42 (5d12 + 10) piercing damage. If the target is a creature  it is grappled (escape DC 27). Until this grapple ends  the target is restrained and the tarrasque can't bite a different creature."
       },
       {
         "name": "Claw",
@@ -37034,7 +37034,7 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) slashing damage  or 11 (2d6 + 4) slashing damage if the griffon started its turn at least 20 feet above the target  and the target is grappled (escape DC 14). Until this grapple ends  the griffon cant attack a different target with its talons."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 5 ft.  one target. Hit: 7 (1d6 + 4) slashing damage  or 11 (2d6 + 4) slashing damage if the griffon started its turn at least 20 feet above the target  and the target is grappled (escape DC 14). Until this grapple ends  the griffon can't attack a different target with its talons."
       },
       {
         "name": "Lightning Strike (Recharge 6)",
@@ -37159,7 +37159,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +13 to hit  reach 15 ft.  one target. Hit: 52 (7d12 + 7) piercing damage. If the target is a creature  it is grappled (escape DC 21). Until this grapple ends  the dragon turtle cant bite a different creature  and it has advantage on bite attacks against the grappled creature."
+        "desc": "Melee Weapon Attack: +13 to hit  reach 15 ft.  one target. Hit: 52 (7d12 + 7) piercing damage. If the target is a creature  it is grappled (escape DC 21). Until this grapple ends  the dragon turtle can't bite a different creature  and it has advantage on bite attacks against the grappled creature."
       },
       {
         "name": "Ram",
@@ -37187,7 +37187,7 @@
     "reactions": [
       {
         "name": "Retract",
-        "desc": "When the dragon turtle takes 50 damage or more from a single attack or spell, it retracts its head and limbs into its shell. It immediately regains 20 hit points. While retracted, it is blinded; its Speed is 0; it cant take reactions; it has advantage on saving throws; attacks against it have disadvantage; and it has resistance to all damage. The dragon turtle stays retracted until the beginning of its next turn."
+        "desc": "When the dragon turtle takes 50 damage or more from a single attack or spell, it retracts its head and limbs into its shell. It immediately regains 20 hit points. While retracted, it is blinded; its Speed is 0; it can't take reactions; it has advantage on saving throws; attacks against it have disadvantage; and it has resistance to all damage. The dragon turtle stays retracted until the beginning of its next turn."
       },
       {
         "name": "Tail",
@@ -37257,7 +37257,7 @@
     "damage_immunities": "lightning; damage from nonmagical weapons",
     "senses": "truesight 120 ft., passive Perception 14",
     "challenge_rating": "25",
-    "languages": "understands Primordial but cant speak, telepathy 120 ft.",
+    "languages": "understands Primordial but can't speak, telepathy 120 ft.",
     "special_abilities": [
       {
         "name": "Immortal Nature",
@@ -37512,7 +37512,7 @@
     "bonus_actions": [
       {
         "name": "Healing Word (1st-Level; V)",
-        "desc": "The priest or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The priest cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The priest or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The priest can't cast this spell and a 1st-level or higher spell on the same turn."
       },
       {
         "name": "Priests devoted to trickster gods cast spells of deception that make them more akin to rogues than other priests",
@@ -37699,7 +37699,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 25 (3d12 + 6) piercing damage. If the target is a creature  it is grappled (escape DC 17). Until this grapple ends  the tyrannosaurus cant bite a different creature and it has advantage on bite attacks against the grappled creature."
+        "desc": "Melee Weapon Attack: +9 to hit  reach 10 ft.  one target. Hit: 25 (3d12 + 6) piercing damage. If the target is a creature  it is grappled (escape DC 17). Until this grapple ends  the tyrannosaurus can't bite a different creature and it has advantage on bite attacks against the grappled creature."
       },
       {
         "name": "Tail",
@@ -37834,7 +37834,7 @@
       },
       {
         "name": "Tentacle",
-        "desc": "Melee Weapon Attack: +6 to hit  reach 10 ft.  one target. Hit: 7 (1d8 + 3) bludgeoning damage plus 4 (1d8) piercing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 14) and restrained until the grapple ends. The otyugh has two tentacles  each of which can grapple one target and cant attack a different target while doing so."
+        "desc": "Melee Weapon Attack: +6 to hit  reach 10 ft.  one target. Hit: 7 (1d8 + 3) bludgeoning damage plus 4 (1d8) piercing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 14) and restrained until the grapple ends. The otyugh has two tentacles  each of which can grapple one target and can't attack a different target while doing so."
       },
       {
         "name": "Tentacle Slam",
@@ -37922,7 +37922,7 @@
       },
       {
         "name": "Misty Recovery",
-        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It cant revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
+        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
       },
       {
         "name": "Regeneration",
@@ -37934,7 +37934,7 @@
       },
       {
         "name": "Vampire Weaknesses",
-        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it cant use its Regeneration trait or its Mist Form or Shapechange actions."
+        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it can't use its Regeneration trait or its Mist Form or Shapechange actions."
       },
       {
         "name": "Resting Place",
@@ -37986,11 +37986,11 @@
       },
       {
         "name": "Mist Form",
-        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, cant speak, cant take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but cant pass through water. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, can't speak, can't take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but can't pass through water. Anything its carrying transforms with it."
       },
       {
         "name": "Shapechange",
-        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It cant use reactions or legendary actions, and cant speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It can't use reactions or legendary actions, and can't speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
       }
     ],
     "speed_json": {
@@ -38042,7 +38042,7 @@
       },
       {
         "name": "Misty Recovery",
-        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It cant revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
+        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
       },
       {
         "name": "Regeneration",
@@ -38054,7 +38054,7 @@
       },
       {
         "name": "Vampire Weaknesses",
-        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it cant use its Regeneration trait or its Mist Form or Shapechange actions."
+        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it can't use its Regeneration trait or its Mist Form or Shapechange actions."
       },
       {
         "name": "Resting Place",
@@ -38114,11 +38114,11 @@
       },
       {
         "name": "Mist Form",
-        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, cant speak, cant take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but cant pass through water. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, can't speak, can't take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but can't pass through water. Anything its carrying transforms with it."
       },
       {
         "name": "Shapechange",
-        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It cant use reactions or legendary actions, and cant speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It can't use reactions or legendary actions, and can't speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
       }
     ],
     "speed_json": {
@@ -38170,7 +38170,7 @@
       },
       {
         "name": "Misty Recovery",
-        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It cant revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
+        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
       },
       {
         "name": "Regeneration",
@@ -38182,7 +38182,7 @@
       },
       {
         "name": "Vampire Weaknesses",
-        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it cant use its Regeneration trait or its Mist Form or Shapechange actions."
+        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it can't use its Regeneration trait or its Mist Form or Shapechange actions."
       },
       {
         "name": "Resting Place",
@@ -38250,11 +38250,11 @@
       },
       {
         "name": "Mist Form",
-        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, cant speak, cant take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but cant pass through water. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, can't speak, can't take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but can't pass through water. Anything its carrying transforms with it."
       },
       {
         "name": "Shapechange",
-        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It cant use reactions or legendary actions, and cant speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It can't use reactions or legendary actions, and can't speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
       }
     ],
     "speed_json": {
@@ -38310,7 +38310,7 @@
       },
       {
         "name": "Vampire Weaknesses",
-        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it cant use its Regeneration trait."
+        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it can't use its Regeneration trait."
       }
     ],
     "actions": [
@@ -38382,7 +38382,7 @@
       },
       {
         "name": "Misty Recovery",
-        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It cant revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
+        "desc": "When the vampire drops to 0 hit points, instead of falling unconscious, it turns into mist as if it had used the Mist Form legendary action. It can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to vampire form and is paralyzed for 1 hour, at which time it regains 1 hit point. While paralyzed in this way, it can be destroyed by fire damage, radiant damage, damage from a magical weapon, or a wooden stake driven through the heart, but it is otherwise immune to damage."
       },
       {
         "name": "Regeneration",
@@ -38394,7 +38394,7 @@
       },
       {
         "name": "Vampire Weaknesses",
-        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it cant use its Regeneration trait or its Mist Form or Shapechange actions."
+        "desc": "Vampires most common weaknesses are sunlight and running water. When the vampire ends its turn in contact with one of its weaknesses (such as being bathed in sunlight or running water), it takes 20 radiant damage. While in contact with its weakness, it can't use its Regeneration trait or its Mist Form or Shapechange actions."
       },
       {
         "name": "Resting Place",
@@ -38450,11 +38450,11 @@
       },
       {
         "name": "Mist Form",
-        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, cant speak, cant take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but cant pass through water. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into a mist or back into its true form. As mist, the vampire has a flying speed of 30, can't speak, can't take actions or manipulate objects, is immune to nonmagical damage from weapons, and has advantage on saving throws and Stealth checks. It can pass through a space as narrow as 1 inch without squeezing but can't pass through water. Anything its carrying transforms with it."
       },
       {
         "name": "Shapechange",
-        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It cant use reactions or legendary actions, and cant speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
+        "desc": "The vampire transforms into the shape of a Medium or smaller beast or back into its true form. While transformed, it has the beasts size and movement modes. It can't use reactions or legendary actions, and can't speak. Otherwise, it uses the vampires statistics. Anything its carrying transforms with it."
       }
     ],
     "speed_json": {
@@ -38533,7 +38533,7 @@
       },
       {
         "name": "Possession (Recharge 6)",
-        "desc": "One humanoid within 5 feet makes a DC 13 Charisma saving throw. On a failure  it is possessed by the ghost. The possessed creature is unconscious. The ghost enters the creatures body and takes control of it. The ghost can be targeted only by effects that turn undead  and it retains its Intelligence  Wisdom  and Charisma. It grants its host body immunity to being charmed and frightened. It otherwise uses the possessed creatures statistics and actions instead of its own. It doesnt gain access to the creatures memories but does gain access to proficiencies  nonmagical class features and traits  and nonmagical actions. It cant use limited-used abilities or class traits that require spending a resource. The possession ends after 24 hours  when the body drops to 0 hit points  when the ghost ends it as a bonus action  or when the ghost is turned or affected by dispel evil and good or a similar effect. Additionally  the possessed creature repeats its saving throw whenever it takes damage. When the possession ends  the ghost reappears in a space within 5 feet of the body. A creature is immune to this ghosts Possession for 24 hours after succeeding on its saving throw or after the possession ends."
+        "desc": "One humanoid within 5 feet makes a DC 13 Charisma saving throw. On a failure  it is possessed by the ghost. The possessed creature is unconscious. The ghost enters the creatures body and takes control of it. The ghost can be targeted only by effects that turn undead  and it retains its Intelligence  Wisdom  and Charisma. It grants its host body immunity to being charmed and frightened. It otherwise uses the possessed creatures statistics and actions instead of its own. It doesnt gain access to the creatures memories but does gain access to proficiencies  nonmagical class features and traits  and nonmagical actions. It can't use limited-used abilities or class traits that require spending a resource. The possession ends after 24 hours  when the body drops to 0 hit points  when the ghost ends it as a bonus action  or when the ghost is turned or affected by dispel evil and good or a similar effect. Additionally  the possessed creature repeats its saving throw whenever it takes damage. When the possession ends  the ghost reappears in a space within 5 feet of the body. A creature is immune to this ghosts Possession for 24 hours after succeeding on its saving throw or after the possession ends."
       }
     ],
     "reactions": [
@@ -38899,7 +38899,7 @@
     "actions": [
       {
         "name": "Tentacles",
-        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 9 (2d6 + 2) bludgeoning damage  and the target is grappled (escape DC 12). Until this grapple ends  the grick cant attack a different target with its tentacles."
+        "desc": "Melee Weapon Attack: +4 to hit  reach 5 ft.  one target. Hit: 9 (2d6 + 2) bludgeoning damage  and the target is grappled (escape DC 12). Until this grapple ends  the grick can't attack a different target with its tentacles."
       }
     ],
     "bonus_actions": [
@@ -38988,7 +38988,7 @@
     "bonus_actions": [
       {
         "name": "Healing Word (1st-Level; V)",
-        "desc": "The priest or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The priest cant cast this spell and a 1st-level or higher spell on the same turn."
+        "desc": "The priest or a living creature within 60 feet regains 5 (1d4 + 3) hit points. The priest can't cast this spell and a 1st-level or higher spell on the same turn."
       },
       {
         "name": "The priests of orcish war hordes act as counselors and magical scouts",
@@ -39526,7 +39526,7 @@
       },
       {
         "name": "Claw (Bear or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 10 (1d12 + 4) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the werebear cant use its greataxe and cant attack a different target with its claw."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 10 (1d12 + 4) slashing damage. If the target is a Medium or smaller creature  it is grappled (escape DC 15). Until this grapple ends  the werebear can't use its greataxe and can't attack a different target with its claw."
       },
       {
         "name": "Bite (Bear or Hybrid Form Only)",
@@ -39536,7 +39536,7 @@
     "bonus_actions": [
       {
         "name": "Shapeshift",
-        "desc": "The werebear changes its form to a Large bear, a Large bear-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged except for its size. It cant speak in bear form. Its equipment is not transformed. It reverts to its true form if it dies."
+        "desc": "The werebear changes its form to a Large bear, a Large bear-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged except for its size. It can't speak in bear form. Its equipment is not transformed. It reverts to its true form if it dies."
       },
       {
         "name": "Frenzied Bite (While Bloodied",
@@ -39609,7 +39609,7 @@
     "bonus_actions": [
       {
         "name": "Shapeshift",
-        "desc": "The wereboar changes its form to a boar, a boar-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged. It cant speak in boar form. Its equipment is not transformed. It reverts to its true form if it dies."
+        "desc": "The wereboar changes its form to a boar, a boar-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged. It can't speak in boar form. Its equipment is not transformed. It reverts to its true form if it dies."
       },
       {
         "name": "Frenzied Tusks (While Bloodied",
@@ -39686,7 +39686,7 @@
     "bonus_actions": [
       {
         "name": "Shapeshift",
-        "desc": "The wererat changes its form to a giant rat, a rat-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged. It cant speak in rat form. Its equipment is not transformed. It reverts to its true form if it dies."
+        "desc": "The wererat changes its form to a giant rat, a rat-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged. It can't speak in rat form. Its equipment is not transformed. It reverts to its true form if it dies."
       },
       {
         "name": "Frenzied Bite (While Bloodied",
@@ -39767,7 +39767,7 @@
     "bonus_actions": [
       {
         "name": "Shapeshift",
-        "desc": "The weretiger changes its form to a Large tiger, a tiger-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged except for its size. It cant speak in tiger form. Its equipment is not transformed. It reverts to its true form if it dies."
+        "desc": "The weretiger changes its form to a Large tiger, a tiger-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged except for its size. It can't speak in tiger form. Its equipment is not transformed. It reverts to its true form if it dies."
       },
       {
         "name": "Opportune Bite (Tiger or Hybrid Form Only)",
@@ -39849,7 +39849,7 @@
     "bonus_actions": [
       {
         "name": "Shapeshift",
-        "desc": "The werewolf changes its form to a wolf, a wolf-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged. It cant speak in wolf form. Its equipment is not transformed. It reverts to its true form if it dies."
+        "desc": "The werewolf changes its form to a wolf, a wolf-humanoid hybrid, or into its true form, which is a humanoid. While shapeshifted, its statistics are unchanged. It can't speak in wolf form. Its equipment is not transformed. It reverts to its true form if it dies."
       },
       {
         "name": "Frenzied Bite (While Bloodied",
@@ -40035,7 +40035,7 @@
       },
       {
         "name": "Insubstantial",
-        "desc": "The will-o-wisp cant pick up or move objects or creatures. It can move through creatures and objects. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        "desc": "The will-o-wisp can't pick up or move objects or creatures. It can move through creatures and objects. It takes 5 (1d10) force damage if it ends its turn inside an object."
       },
       {
         "name": "Treasure Sense",
@@ -40049,7 +40049,7 @@
     "actions": [
       {
         "name": "Shock",
-        "desc": "Melee Spell Attack: +4 to hit  reach 5 ft.  one target. Hit: 10 (3d6) lightning damage. The will-o-wisp cant make this attack while its glow is extinguished."
+        "desc": "Melee Spell Attack: +4 to hit  reach 5 ft.  one target. Hit: 10 (3d6) lightning damage. The will-o-wisp can't make this attack while its glow is extinguished."
       }
     ],
     "bonus_actions": [
@@ -40368,7 +40368,7 @@
       },
       {
         "name": "Trackless Travel",
-        "desc": "The strider cant be tracked by nonmagical means."
+        "desc": "The strider can't be tracked by nonmagical means."
       },
       {
         "name": "Trained Accuracy",
@@ -40595,7 +40595,7 @@
       },
       {
         "name": "Greatsword (Corporeal Form Only)",
-        "desc": "Melee Weapon Attack: +10 to hit  reach 5 ft.  one target. Hit: 12 (2d6 + 5) slashing damage plus 17 (5d6) poison damage  and the target makes a DC 18 Constitution saving throw. On a failure  the target is poisoned for 24 hours. While poisoned in this way  the target cant regain hit points. If a creature dies while poisoned in this way  its spirit rises as a wraith under the wraith lords control 1 minute after its death."
+        "desc": "Melee Weapon Attack: +10 to hit  reach 5 ft.  one target. Hit: 12 (2d6 + 5) slashing damage plus 17 (5d6) poison damage  and the target makes a DC 18 Constitution saving throw. On a failure  the target is poisoned for 24 hours. While poisoned in this way  the target can't regain hit points. If a creature dies while poisoned in this way  its spirit rises as a wraith under the wraith lords control 1 minute after its death."
       },
       {
         "name": "Paralyzing Terror",
@@ -40648,11 +40648,11 @@
     },
     "senses": "darkvision 60 ft., passive Perception 14",
     "challenge_rating": "6",
-    "languages": "understands Draconic but cant speak",
+    "languages": "understands Draconic but can't speak",
     "special_abilities": [
       {
         "name": "Imperfect Flight",
-        "desc": "While bloodied, the wyverns fly speed is halved, and it cant gain altitude."
+        "desc": "While bloodied, the wyverns fly speed is halved, and it can't gain altitude."
       }
     ],
     "actions": [
@@ -40666,7 +40666,7 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 9 (2d4 + 4) slashing damage. If the wyvern is attacking from above  the target is grappled by the wyvern (escape DC 15). While grappling a target in this way  the wyverns Speed is reduced to 0  it cant use its claws to attack any other creature  and it has advantage on attacks against the target."
+        "desc": "Melee Weapon Attack: +7 to hit  reach 5 ft.  one target. Hit: 9 (2d4 + 4) slashing damage. If the wyvern is attacking from above  the target is grappled by the wyvern (escape DC 15). While grappling a target in this way  the wyverns Speed is reduced to 0  it can't use its claws to attack any other creature  and it has advantage on attacks against the target."
       },
       {
         "name": "Stinger",
@@ -40989,7 +40989,7 @@
     "special_abilities": [
       {
         "name": "Ambusher",
-        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that cant see it with its bite, it can deal piercing damage and grapple the target simultaneously."
+        "desc": "When submerged in water, the dragon has advantage on Stealth checks. If the dragon hits a creature that can't see it with its bite, it can deal piercing damage and grapple the target simultaneously."
       },
       {
         "name": "Amphibious",
@@ -41011,7 +41011,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +8 to hit  reach 10 ft.  one target. Hit: 20 (3d10 + 4) piercing damage plus 4 (1d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 16)  and a Medium or smaller creature grappled in this way is restrained. While grappling a creature  the dragon cant bite another creature."
+        "desc": "Melee Weapon Attack: +8 to hit  reach 10 ft.  one target. Hit: 20 (3d10 + 4) piercing damage plus 4 (1d8) acid damage. Instead of dealing piercing damage  the dragon can grapple the target (escape DC 16)  and a Medium or smaller creature grappled in this way is restrained. While grappling a creature  the dragon can't bite another creature."
       },
       {
         "name": "Claw",
@@ -41096,7 +41096,7 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dragon exhales a 60-foot-long  5-foot-wide line of lightning. Each creature in that area makes a DC 16 Dexterity saving throw  taking 44 (8d10) lightning damage on a failed save or half damage on a success. A creature that fails the save cant take reactions until the end of its next turn."
+        "desc": "The dragon exhales a 60-foot-long  5-foot-wide line of lightning. Each creature in that area makes a DC 16 Dexterity saving throw  taking 44 (8d10) lightning damage on a failed save or half damage on a success. A creature that fails the save can't take reactions until the end of its next turn."
       }
     ],
     "speed_json": {
@@ -41273,7 +41273,7 @@
       },
       {
         "name": "Lightning Breath",
-        "desc": "The dragon exhales lightning in a 90-foot-long  5-foot-wide line. Each creature in the area makes a DC 20 Dexterity saving throw  taking 69 (13d10) lightning damage on a failed save or half damage on a success. A creature that fails the saving throw cant take reactions until the end of its next turn."
+        "desc": "The dragon exhales lightning in a 90-foot-long  5-foot-wide line. Each creature in the area makes a DC 20 Dexterity saving throw  taking 69 (13d10) lightning damage on a failed save or half damage on a success. A creature that fails the saving throw can't take reactions until the end of its next turn."
       },
       {
         "name": "Ocean Surge",
@@ -41281,7 +41281,7 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It cant use Lightning Pulse  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its trident."
+        "desc": "The dragon magically takes the shape of a humanoid or beast  or changes back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (dragons choice). In the new form  the dragons stats are unchanged except for its size. It can't use Lightning Pulse  Breath Weapons  Tail Attack  or Wing Attack except in dragon form. In beast form  it can attack only with its bite and claws  if appropriate to its form. If the beast form is Large or smaller  the reach of these attacks is reduced to 5 feet. In humanoid form  it can attack only with its trident."
       }
     ],
     "reactions": [
@@ -41818,7 +41818,7 @@
     "damage_immunities": "fire, poison",
     "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 9",
     "challenge_rating": "11",
-    "languages": "understands Common and Draconic but cant speak",
+    "languages": "understands Common and Draconic but can't speak",
     "special_abilities": [
       {
         "name": "Undead Fortitude (1/Day)",
@@ -42287,7 +42287,7 @@
     "condition_immunities": "fatigue, poisoned",
     "senses": "darkvision 60 ft., passive Perception 8",
     "challenge_rating": "1",
-    "languages": "understands the languages it knew in life but cant speak",
+    "languages": "understands the languages it knew in life but can't speak",
     "special_abilities": [
       {
         "name": "Undead Fortitude (1/Day)",
@@ -42301,7 +42301,7 @@
     "actions": [
       {
         "name": "Grab",
-        "desc": "Melee Weapon Attack: +3 to hit  reach 5 ft.  one target. Hit: 4 (1d6 + 1) bludgeoning damage. If the target is a Medium or smaller creature  it is grappled (escape DC 11). Until the grapple ends  the zombie cant grab another target."
+        "desc": "Melee Weapon Attack: +3 to hit  reach 5 ft.  one target. Hit: 4 (1d6 + 1) bludgeoning damage. If the target is a Medium or smaller creature  it is grappled (escape DC 11). Until the grapple ends  the zombie can't grab another target."
       },
       {
         "name": "Bite",
@@ -42344,7 +42344,7 @@
     "condition_immunities": "fatigue, poisoned",
     "senses": "darkvision 60 ft., passive Perception 8",
     "challenge_rating": "4",
-    "languages": "understands the languages it knew in life but cant speak",
+    "languages": "understands the languages it knew in life but can't speak",
     "special_abilities": [
       {
         "name": "Area Vulnerability",
@@ -42408,7 +42408,7 @@
     "condition_immunities": "fatigue, poisoned",
     "senses": "darkvision 60 ft., passive Perception 9",
     "challenge_rating": "3",
-    "languages": "understands one language but cant speak",
+    "languages": "understands one language but can't speak",
     "special_abilities": [
       {
         "name": "Undead Fortitude (1/Day)",
@@ -42430,7 +42430,7 @@
       },
       {
         "name": "Grab",
-        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one target. Hit: 6 (1d6 + 3) bludgeoning damage  and the creature is grappled if its Medium or smaller (escape DC 13)  and until the grapple ends  the zombie cant grab another target."
+        "desc": "Melee Weapon Attack: +5 to hit  reach 5 ft.  one target. Hit: 6 (1d6 + 3) bludgeoning damage  and the creature is grappled if its Medium or smaller (escape DC 13)  and until the grapple ends  the zombie can't grab another target."
       },
       {
         "name": "Bite",


### PR DESCRIPTION
Cannot is abbreviated as can't, not cant. This pull request fixes that spelling mistake in one document where this mistake happens quite often.

NOTE: It's more than a simple find-and-replace-all to prevent Thieves cant from being changed to Thieves can't, which would be incorrect.