### PR TITLE
populatedb: Wrap each data dir in an atomic txn

### DIFF
--- a/api/management/commands/populatedb.py
+++ b/api/management/commands/populatedb.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import django.apps
 from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
 
 from api.management.commands.importer import Importer, ImportOptions, ImportSpec
 from api import models
@@ -105,6 +106,7 @@ class Command(BaseCommand):
         for directory in options["directories"]:
             self._populate_from_directory(Path(directory))
 
+    @transaction.atomic
     def _populate_from_directory(self, directory: Path) -> None:
         """Import models from all the .json files in a single directory."""
         self.stdout.write(self.style.SUCCESS(f"Reading in files from {directory}"))


### PR DESCRIPTION
On my laptop, this speeds up `quickload` by 98.5%, from 12.25 minutes down to 11 seconds. Pretty good, eh?

Fixes #143