### PR TITLE
Lots of dependencies updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11-alpine
 
 RUN mkdir -p /opt/services/open5e-api
 WORKDIR /opt/services/open5e-api
@@ -14,6 +14,7 @@ RUN pipenv install
 RUN pipenv run python manage.py quicksetup
 
 # Create the self-signed certs for gunicorn.
+RUN apk add openssl
 RUN pipenv run sh ./scripts/generate_self_signed_cert.sh
 
 #run gunicorn.

--- a/Pipfile
+++ b/Pipfile
@@ -4,23 +4,23 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-django = "==2.1.11"
-djangorestframework = "==3.11.2"
+django = "3"
+djangorestframework = "*"
 django-filter = "*"
 django-cors-headers = "*"
-django-haystack = "==2.8.1"
-drf-haystack = "==1.8.4"
+django-haystack = "*"
+drf-haystack = "*"
 gunicorn = "*"
 jsonfield = "*"
 markdown = "*"
 "markdown2" = "*"
 pylint = "*"
-python-decouple = "==3.1"
-setuptools = "==58.2.0"
+python-decouple = "*"
+setuptools = "*"
 whitenoise = "*"
 whoosh = "*"
 
 [dev-packages]
 
 [requires]
-python_version = "3.8"
+python_version = "3.10"

--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,4 @@ whoosh = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.10"
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "00cbc6803fba562c53f550daf3be44100dfffdc15ca406d9b71cbd01a5eecd59"
+            "sha256": "fbf1bcab2de4539180269f49811de827f66a04f227bf72637ac1ebeb2c99f336"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d8674606cc379685dcd144854a4d20bad61465af72cbc5b8c291f00c2277f36b"
+            "sha256": "00cbc6803fba562c53f550daf3be44100dfffdc15ca406d9b71cbd01a5eecd59"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.10"
         },
         "sources": [
             {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:71e68008da809b957b7ee4b43dbccff33d1b23519fb8344e33f049897077afac",
+                "sha256:9567dfe7bd8d3c8c892227827c41cce860b368104c3431da67a0c5a65a949506"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.6.0"
+        },
         "astroid": {
             "hashes": [
                 "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa",
@@ -34,50 +42,51 @@
         },
         "django": {
             "hashes": [
-                "sha256:1a41831eace203fd1939edf899e07d7abd12ce9bafc3d9a5a63a24a8d1d12bd5",
-                "sha256:305b6c4fce9e03bb746e35780c2c4d52f29ea1669f15633cfd41bc8821c74c76"
+                "sha256:08208dfe892eb64fff073ca743b3b952311104f939e7f6dae954fe72dcc533ba",
+                "sha256:4d492d9024c7b3dfababf49f94511ab6a58e2c9c3c7207786f1ba4eb77750706"
             ],
             "index": "pypi",
-            "version": "==2.1.11"
+            "version": "==3.2.18"
         },
         "django-cors-headers": {
             "hashes": [
-                "sha256:5240062ef0b16668ce8a5f43324c388d65f5439e1a30e22c38684d5ddaff0d15",
-                "sha256:f5218f2f0bb1210563ff87687afbf10786e080d8494a248e705507ebd92d7153"
+                "sha256:5fbd58a6fb4119d975754b2bc090f35ec160a8373f276612c675b00e8a138739",
+                "sha256:684180013cc7277bdd8702b80a3c5a4b3fcae4abb2bf134dceb9f5dfe300228e"
             ],
             "index": "pypi",
-            "version": "==3.4.0"
+            "version": "==3.14.0"
         },
         "django-filter": {
             "hashes": [
-                "sha256:558c727bce3ffa89c4a7a0b13bc8976745d63e5fd576b3a9a851650ef11c401b",
-                "sha256:c3deb57f0dd7ff94d7dce52a047516822013e2b441bed472b722a317658cfd14"
+                "sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb",
+                "sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5"
             ],
             "index": "pypi",
-            "version": "==2.2.0"
+            "version": "==22.1"
         },
         "django-haystack": {
             "hashes": [
-                "sha256:8b54bcc926596765d0a3383d693bcdd76109c7abb6b2323b3984a39e3576028c"
+                "sha256:6d05756b95d7d5ec1dbd4668eb999ced1504b47f588e2e54be53b1404c516a82",
+                "sha256:970ebc6362f3f84861209154ec34b57f3e87d2d7922f948df80177f0e2e3ced7"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==3.1.1"
         },
         "djangorestframework": {
             "hashes": [
-                "sha256:5cc724dc4b076463497837269107e1995b1fbc917468d1b92d188fd1af9ea789",
-                "sha256:a5967b68a04e0d97d10f4df228e30f5a2d82ba63b9d03e1759f84993b7bf1b53"
+                "sha256:6d1d59f623a5ad0509fe0d6bfe93cbdfe17b8116ebc8eda86d45f6e16e819aaf",
+                "sha256:f747949a8ddac876e879190df194b925c177cdeb725a099db1460872f7c0a7f2"
             ],
             "index": "pypi",
-            "version": "==3.11.2"
+            "version": "==3.12.4"
         },
         "drf-haystack": {
             "hashes": [
-                "sha256:3304d951d18733e416831bce25b60274497691b9ae9c55c16b3c35477b783028",
-                "sha256:52d0663238b7578a94797267d6e770ddef937cbb9876448a3fac38f81b7ab12f"
+                "sha256:7c662cf5d5948007bbcdd35cb0a39c3143956086662780aab75cd61a0e7c03b0",
+                "sha256:c8744aed00ffc176834f14dd301536a0572e0dc172e38d2d34ad98a32ce03283"
             ],
             "index": "pypi",
-            "version": "==1.8.4"
+            "version": "==1.8.11"
         },
         "gunicorn": {
             "hashes": [
@@ -86,14 +95,6 @@
             ],
             "index": "pypi",
             "version": "==20.1.0"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
-                "sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d"
-            ],
-            "markers": "python_version < '3.10'",
-            "version": "==6.0.0"
         },
         "isort": {
             "hashes": [
@@ -105,11 +106,11 @@
         },
         "jsonfield": {
             "hashes": [
-                "sha256:1ae437686daab56dfb619291d4774ac075016ab4cad24abf445ad05da03a85a8",
-                "sha256:ed7c5e1829e9453e24a8bebef1e702ffe402e6def6b326f0e0b88764c59a6dc7"
+                "sha256:7e4e84597de21eeaeeaaa7cc5da08c61c48a9b64d0c446b2d71255d01812887a",
+                "sha256:df857811587f252b97bafba42e02805e70a398a7a47870bc6358a0308dd689ed"
             ],
             "index": "pypi",
-            "version": "==2.1.1"
+            "version": "==3.1.0"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -179,11 +180,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:13b08a53ed71021350c9e300d4ea8668438fb0046ab3937ac9a29913a1a1350a",
-                "sha256:accc3665857288317f32c7bebb5a8e482ba717b474f3fc1d18ca7f9214be0cef"
+                "sha256:024996549ee88ec1a9aa99ff7f8fc819bb59e2c3477b410d90a16d32d6e707aa",
+                "sha256:e5986afb596e4bb5bde29a79ac9061aa955b94fca2399b7aaac4090860920dd8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "pylint": {
             "hashes": [
@@ -203,10 +204,11 @@
         },
         "python-decouple": {
             "hashes": [
-                "sha256:1317df14b43efee4337a4aa02914bf004f010cd56d6c4bd894e6474ec8c4fe2d"
+                "sha256:ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f",
+                "sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66"
             ],
             "index": "pypi",
-            "version": "==3.1"
+            "version": "==3.8"
         },
         "pytz": {
             "hashes": [
@@ -217,11 +219,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:2551203ae6955b9876741a26ab3e767bb3242dafe86a32a749ea0d78b6792f11",
-                "sha256:2c55bdb85d5bb460bd2e3b12052b677879cffcf46c0c688f2e5bf51d36001145"
+                "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077",
+                "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"
             ],
             "index": "pypi",
-            "version": "==58.2.0"
+            "version": "==67.6.0"
         },
         "six": {
             "hashes": [
@@ -230,6 +232,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:0323c0ec29cd52bceabc1b4d9d579e311f3e4961b98d174201d5622a23b85e34",
+                "sha256:69ca804846bb114d2ec380e4360a8a340db83f0ccf3afceeb1404df028f57268"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.4.3"
         },
         "tomli": {
             "hashes": [
@@ -252,7 +262,7 @@
                 "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
                 "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version < '3.11'",
             "version": "==4.5.0"
         },
         "whitenoise": {
@@ -352,14 +362,6 @@
             ],
             "markers": "python_version < '3.11'",
             "version": "==1.15.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
-                "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.15.0"
         }
     },
     "develop": {}

--- a/api/views.py
+++ b/api/views.py
@@ -51,7 +51,7 @@ class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Document.objects.all()
     serializer_class = serializers.DocumentSerializer
-    filter_fields = (
+    filterset_fields = (
         'slug',
         'title',
         'organization',
@@ -82,7 +82,7 @@ class SpellViewSet(viewsets.ReadOnlyModelViewSet):
     API endpoint that allows viewing of Spells.
     """
     queryset = models.Spell.objects.all()
-    filter_class=SpellFilter
+    filterset_class=SpellFilter
     serializer_class = serializers.SpellSerializer
     search_fields = ['dnd_class', 'name']
     ordering_fields = '__all__'
@@ -109,7 +109,7 @@ class MonsterViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.MonsterSerializer
     ordering_fields = '__all__'
     ordering = ['name']
-    filter_fields = (
+    filterset_fields = (
         'challenge_rating',
         'armor_class',
         'type',
@@ -128,7 +128,7 @@ class BackgroundViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.BackgroundSerializer
     ordering_fields = '__all__'
     ordering=['name']
-    filter_fields=(
+    filterset_fields=(
         'name',
         'skill_proficiencies',
         'languages',
@@ -142,7 +142,7 @@ class PlaneViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Plane.objects.all()
     serializer_class = serializers.PlaneSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',
         'document__slug',
     )
@@ -155,7 +155,7 @@ class SectionViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.SectionSerializer
     ordering_fields = '__all__'
     ordering=['name']
-    filter_fields=(
+    filterset_fields=(
         'name',
         'parent',
         'document__slug',
@@ -167,7 +167,11 @@ class FeatViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Feat.objects.all()
     serializer_class = serializers.FeatSerializer
-    filter_fields=('name','prerequisite', 'document__slug',)
+    filterset_fields=(
+        'name',
+        'prerequisite', 
+        'document__slug',
+        )
 
 class ConditionViewSet(viewsets.ReadOnlyModelViewSet):
     """
@@ -175,7 +179,7 @@ class ConditionViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Condition.objects.all()
     serializer_class = serializers.ConditionSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',
         'document__slug',
     )
@@ -186,7 +190,7 @@ class RaceViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Race.objects.all()
     serializer_class = serializers.RaceSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',
         'document__slug',
     )
@@ -197,7 +201,7 @@ class SubraceViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Subrace.objects.all()
     serializer_class = serializers.SubraceSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',
         'document__slug',
     )
@@ -208,7 +212,7 @@ class CharClassViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.CharClass.objects.all()
     serializer_class = serializers.CharClassSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',
         'document__slug',
     )
@@ -219,7 +223,7 @@ class ArchetypeViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Archetype.objects.all()
     serializer_class = serializers.ArchetypeSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',
         'document__slug',
     )
@@ -230,7 +234,7 @@ class MagicItemViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.MagicItem.objects.all()
     serializer_class = serializers.MagicItemSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',        
         'document__slug',
     )
@@ -242,7 +246,7 @@ class WeaponViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Weapon.objects.all()
     serializer_class = serializers.WeaponSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',        
         'document__slug',
     )
@@ -254,7 +258,7 @@ class ArmorViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Armor.objects.all()
     serializer_class = serializers.ArmorSerializer
-    filter_fields=(
+    filterset_fields=(
         'name',        
         'document__slug',
     )

--- a/server/settings.py
+++ b/server/settings.py
@@ -29,6 +29,10 @@ SECRET_KEY = os.environ['SECRET_KEY']
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('OPEN5E_DEBUG', '') != 'False'
 
+# Added as part of the migration from django 2 to django 3.
+# Not likely to apply in the short term. https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 ## Always allow connections from localhost, and the SERVER_NAME if it's there in the .env file.
 ALLOWED_HOSTS = ['localhost', os.environ.get('SERVER_NAME', ''), '0.0.0.0', 'api.open5e.com', 'api-beta.open5e.com']
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -154,7 +154,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'api.utils.StandardResultsSetPagination',
 
     # Filtering
-    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend', 'rest_framework.filters.OrderingFilter','rest_framework.filters.SearchFilter',),
+    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend','rest_framework.filters.OrderingFilter','rest_framework.filters.SearchFilter'],
 
     'DEFAULT_AUTHENTICATION_CLASSES': [],
     'DEFAULT_PERMISSION_CLASSES': [],

--- a/server/urls.py
+++ b/server/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from rest_framework import routers
 
@@ -45,7 +45,7 @@ router.register('search', views.SearchView, basename="global-search")
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    url(r'^', include(router.urls)),
+    re_path(r'^', include(router.urls)),
     #url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
-    url(r'^search/', include('haystack.urls')),
+    re_path(r'^search/', include('haystack.urls')),
 ]


### PR DESCRIPTION
Updated python from 3.8 to 3.10, and pinned it.
Updated django to 3.2.18 and pinned it to 3.
Updated literally everything else, and set them to *
Adjusted filters to now use filtersets (per new version of drf). More info here: https://www.django-rest-framework.org/api-guide/filtering/#djangofilterbackend
Removed a couple of urls.py methods that will be deprecated in django4.

**Tested by:**
All root endpoints load visibly correctly and without error.
localhost:8000/spells/?slug__in=magic-missile producing the same results as production.
Ordering by different values produces expected results on monsters.
Pagination appears to be the same as before.
The Options button seems to work as expected.
Filters appear on all of the endpoints' pages' modal popup, and appear to be (spot-check) working.

Update your dependencies folks!