### PR TITLE
add separate descriptions for singular and plural endpoints

### DIFF
--- a/api/schema_generator.py
+++ b/api/schema_generator.py
@@ -30,11 +30,11 @@ class Open5eSchemaGenerator(SchemaGenerator):
     def get_schema(self, *args, **kwargs):
         schema = super().get_schema(*args, **kwargs)
         schema['servers'] =[
-			{
-			"url": "https://api.open5e.com/",
-			"description": "Open 5e"
-			}
-		]
+            {
+            "url": "https://api.open5e.com/",
+            "description": "Open5e"
+            }
+        ]
         # This isn't a real endpoint, so we remove it from the schema
         schema['paths'].pop('/search/{id}/')
         return schema

--- a/api/views.py
+++ b/api/views.py
@@ -10,7 +10,15 @@ from api.schema_generator import CustomSchema
 
 class ManifestViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of of manifests.
+    list: API endpoint for returning a list of of manifests.
+
+    For each data source file, there is a corresponding manifest containing an
+    MD5 hash of the data inside that file. When we update our data files, the
+    corresponding manifest's hash changes. If you host a service that
+    automatically downloads data from Open5e, you can periodically check
+    the manifests to determine whether your data is out of date.
+
+    retrieve: API endpoint for returning a particular manifest.
 
     For each data source file, there is a corresponding manifest containing an
     MD5 hash of the data inside that file. When we update our data files, the
@@ -20,23 +28,23 @@ class ManifestViewSet(viewsets.ReadOnlyModelViewSet):
     """
     schema = CustomSchema(
         summary={
-			'/manifest/': 'List Manifests',
-			'/manifest/{id}/': 'Retrieve Manifest',
-		},
-        tags=['Manifests']
+            '/manifest/': 'List Manifests',
+            '/manifest/{id}/': 'Retrieve Manifest',
+        },
+        tags=['Manifests'],
     )
     queryset = models.Manifest.objects.all()
     serializer_class = serializers.ManifestSerializer
 
 class SearchView(HaystackViewSet):
     """
-    API endpoint for returning a list of search results from the Open5e database.
+    list: API endpoint for returning a list of search results from the Open5e database.
     """
     schema = CustomSchema(
         summary={
-			'/search/': 'Search',
-			'/search/{id}/': 'Search', # I doubt this is a real endpoint
-		},
+            '/search/': 'Search',
+            '/search/{id}/': 'Search', # I doubt this is a real endpoint
+        },
         tags=['Search']
     )
     # `index_models` is an optional list of which models you would like to include
@@ -61,13 +69,14 @@ class GroupViewSet(viewsets.ReadOnlyModelViewSet):
 
 class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of documents.
+    list: API endpoint for returning a list of documents.
+    retrieve: API endpoint for returning a particular document.
     """
     schema = CustomSchema(
         summary={
-			'/documents/': 'List Documents',
-			'/documents/{id}/': 'Retrieve Document',
-		},
+            '/documents/': 'List Documents',
+            '/documents/{id}/': 'Retrieve Document',
+        },
         tags=['Documents']
     )
     queryset = models.Document.objects.all()
@@ -99,13 +108,14 @@ class SpellFilter(django_filters.FilterSet):
 
 class SpellViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of spells.
+    list: API endpoint for returning a list of spells.
+    retrieve: API endpoint for returning a particular spell.
     """
     schema = CustomSchema(
         summary={
-			'/spells/': 'List Spells',
-			'/spells/{slug}/': 'Retrieve Spell',
-		},
+            '/spells/': 'List Spells',
+            '/spells/{slug}/': 'Retrieve Spell',
+        },
         tags=['Spells']
     )
     queryset = models.Spell.objects.all()
@@ -130,13 +140,14 @@ class SpellViewSet(viewsets.ReadOnlyModelViewSet):
 
 class MonsterViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of monsters.
+    list: API endpoint for returning a list of monsters.
+    retrieve: API endpoint for returning a particular monster.
     """
     schema = CustomSchema(
         summary={
-			'/monsters/': 'List Monsters',
-			'/monsters/{slug}/': 'Retrieve Monster',
-		},
+            '/monsters/': 'List Monsters',
+            '/monsters/{slug}/': 'Retrieve Monster',
+        },
         tags=['Monsters']
     )
     queryset = models.Monster.objects.all()
@@ -156,13 +167,14 @@ class MonsterViewSet(viewsets.ReadOnlyModelViewSet):
 
 class BackgroundViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of backgrounds.
+    list: API endpoint for returning a list of backgrounds.
+    retrieve: API endpoint for returning a particular background.
     """
     schema = CustomSchema(
         summary={
-			'/backgrounds/': 'List Backgrounds',
-			'/backgrounds/{slug}/': 'Retrieve Background',
-		},
+            '/backgrounds/': 'List Backgrounds',
+            '/backgrounds/{slug}/': 'Retrieve Background',
+        },
         tags=['Backgrounds']
     )
     queryset = models.Background.objects.all()
@@ -179,13 +191,14 @@ class BackgroundViewSet(viewsets.ReadOnlyModelViewSet):
 
 class PlaneViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of planes.
+    list: API endpoint for returning a list of planes.
+    retrieve: API endpoint for returning a particular plane.
     """
     schema = CustomSchema(
         summary={
-			'/planes/': 'List Planes',
-			'/planes/{slug}/': 'Retrieve Plane',
-		},
+            '/planes/': 'List Planes',
+            '/planes/{slug}/': 'Retrieve Plane',
+        },
         tags=['Planes']
     )
     queryset = models.Plane.objects.all()
@@ -197,13 +210,14 @@ class PlaneViewSet(viewsets.ReadOnlyModelViewSet):
 
 class SectionViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of sections.
+    list: API endpoint for returning a list of sections.
+    retrieve: API endpoint for returning a particular section.
     """
     schema = CustomSchema(
         summary={
-			'/sections/': 'List Sections',
-			'/sections/{slug}/': 'Retrieve Section',
-		},
+            '/sections/': 'List Sections',
+            '/sections/{slug}/': 'Retrieve Section',
+        },
         tags=['Sections']
     )
     queryset = models.Section.objects.all()
@@ -218,13 +232,14 @@ class SectionViewSet(viewsets.ReadOnlyModelViewSet):
 
 class FeatViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of feats.
+    list: API endpoint for returning a list of feats.
+    retrieve: API endpoint for returning a particular feat.
     """
     schema = CustomSchema(
         summary={
-			'/feats/': 'List Feats',
-			'/feats/{slug}/': 'Retrieve Feat',
-		},
+            '/feats/': 'List Feats',
+            '/feats/{slug}/': 'Retrieve Feat',
+        },
         tags=['Feats']
     )
     queryset = models.Feat.objects.all()
@@ -237,13 +252,14 @@ class FeatViewSet(viewsets.ReadOnlyModelViewSet):
 
 class ConditionViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of conditions.
+    list: API endpoint for returning a list of conditions.
+    retrieve: API endpoint for returning a particular condition.
     """
     schema = CustomSchema(
         summary={
-			'/conditions/': 'List Conditions',
-			'/conditions/{slug}/': 'Retrieve Condition',
-		},
+            '/conditions/': 'List Conditions',
+            '/conditions/{slug}/': 'Retrieve Condition',
+        },
         tags=['Conditions']
     )
     queryset = models.Condition.objects.all()
@@ -255,13 +271,14 @@ class ConditionViewSet(viewsets.ReadOnlyModelViewSet):
 
 class RaceViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of races and subraces.
+    list: API endpoint for returning a list of races.
+    retrieve: API endpoint for returning a particular race.
     """
     schema = CustomSchema(
         summary={
-			'/races/': 'List Races',
-			'/races/{slug}/': 'Retrieve Race',
-		},
+            '/races/': 'List Races',
+            '/races/{slug}/': 'Retrieve Race',
+        },
         tags=['Races']
     )
     queryset = models.Race.objects.all()
@@ -273,13 +290,14 @@ class RaceViewSet(viewsets.ReadOnlyModelViewSet):
 
 class SubraceViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint that allows viewing of Races and Subraces.
+    list: API endpoint that allows viewing of Subraces.
+    retrieve: API endpoint for returning a particular subrace.
     """
     schema = CustomSchema(
         summary={
-			'/subraces/': 'List Subraces',
-			'/subraces/{slug}/': 'Retrieve Subrace',
-		},
+            '/subraces/': 'List Subraces',
+            '/subraces/{slug}/': 'Retrieve Subrace',
+        },
         tags=['Subraces']
     )
     queryset = models.Subrace.objects.all()
@@ -291,13 +309,14 @@ class SubraceViewSet(viewsets.ReadOnlyModelViewSet):
 
 class CharClassViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of classes and archetypes.
+    list: API endpoint for returning a list of classes and archetypes.
+    retrieve: API endpoint for returning a particular class or archetype.
     """
     schema = CustomSchema(
         summary={
-			'/classes/': 'List Classes',
-			'/classes/{slug}/': 'Retrieve Class',
-		},
+            '/classes/': 'List Classes',
+            '/classes/{slug}/': 'Retrieve Class',
+        },
         tags=['Classes']
     )
     queryset = models.CharClass.objects.all()
@@ -309,13 +328,14 @@ class CharClassViewSet(viewsets.ReadOnlyModelViewSet):
 
 class ArchetypeViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint that allows viewing of Archetypes.
+    list: API endpoint that allows viewing of Archetypes.
+    retrieve: API endpoint for returning a particular archetype.
     """
     schema = CustomSchema(
         summary={
-			'/archetypes/': 'List Archetypes',
-			'/archetypes/{slug}/': 'Retrieve Archetype',
-		},
+            '/archetypes/': 'List Archetypes',
+            '/archetypes/{slug}/': 'Retrieve Archetype',
+        },
         tags=['Archetypes']
     )
     queryset = models.Archetype.objects.all()
@@ -327,14 +347,15 @@ class ArchetypeViewSet(viewsets.ReadOnlyModelViewSet):
 
 class MagicItemViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of magic items.
+    list: API endpoint for returning a list of magic items.
+    retrieve: API endpoint for returning a particular magic item.
     """
     schema = CustomSchema(
         summary={
-			'/magicitems/': 'List Magic Items',
-			'/magicitems/{slug}/': 'Retrieve Magic Item',
-		},
-		tags=['Magic Items']
+            '/magicitems/': 'List Magic Items',
+            '/magicitems/{slug}/': 'Retrieve Magic Item',
+        },
+        tags=['Magic Items']
     )
     queryset = models.MagicItem.objects.all()
     serializer_class = serializers.MagicItemSerializer
@@ -346,14 +367,15 @@ class MagicItemViewSet(viewsets.ReadOnlyModelViewSet):
 
 class WeaponViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of weapons.
+    list: API endpoint for returning a list of weapons.
+    retrieve: API endpoint for returning a particular weapon.
     """
     schema = CustomSchema(
         summary={
-			'/weapons/': 'List Weapons',
-			'/weapons/{slug}/': 'Retrieve Weapon',
-		},
-		tags=['Weapons']
+            '/weapons/': 'List Weapons',
+            '/weapons/{slug}/': 'Retrieve Weapon',
+        },
+        tags=['Weapons']
     )
     queryset = models.Weapon.objects.all()
     serializer_class = serializers.WeaponSerializer
@@ -365,14 +387,15 @@ class WeaponViewSet(viewsets.ReadOnlyModelViewSet):
 
 class ArmorViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    API endpoint for returning a list of armor.
+    list: API endpoint for returning a list of armor.
+    retrieve: API endpoint for returning a particular armor.
     """
     schema = CustomSchema(
         summary={
-			'/armor/': 'List Armor',
-			'/armor/{slug}/': 'Retrieve Armor',
-		},
-		tags=['Armor']
+            '/armor/': 'List Armor',
+            '/armor/{slug}/': 'Retrieve Armor',
+        },
+        tags=['Armor']
     )
     queryset = models.Armor.objects.all()
     serializer_class = serializers.ArmorSerializer

--- a/openapi-schema.yml
+++ b/openapi-schema.yml
@@ -90,7 +90,7 @@ paths:
   /manifest/{id}/:
     get:
       operationId: retrieveManifest
-      description: 'API endpoint for returning a list of of manifests.
+      description: 'API endpoint for returning a particular manifest.
 
 
         For each data source file, there is a corresponding manifest containing an
@@ -465,7 +465,7 @@ paths:
   /spells/{slug}/:
     get:
       operationId: retrieveSpell
-      description: API endpoint for returning a list of spells.
+      description: API endpoint for returning a particular spell.
       parameters:
       - name: slug
         in: path
@@ -991,7 +991,7 @@ paths:
   /monsters/{slug}/:
     get:
       operationId: retrieveMonster
-      description: API endpoint for returning a list of monsters.
+      description: API endpoint for returning a particular monster.
       parameters:
       - name: slug
         in: path
@@ -1321,7 +1321,7 @@ paths:
   /documents/{id}/:
     get:
       operationId: retrieveDocument
-      description: API endpoint for returning a list of documents.
+      description: API endpoint for returning a particular document.
       parameters:
       - name: id
         in: path
@@ -1536,7 +1536,7 @@ paths:
   /backgrounds/{slug}/:
     get:
       operationId: retrieveBackground
-      description: API endpoint for returning a list of backgrounds.
+      description: API endpoint for returning a particular background.
       parameters:
       - name: slug
         in: path
@@ -1713,7 +1713,7 @@ paths:
   /planes/{slug}/:
     get:
       operationId: retrievePlane
-      description: API endpoint for returning a list of planes.
+      description: API endpoint for returning a particular plane.
       parameters:
       - name: slug
         in: path
@@ -1866,7 +1866,7 @@ paths:
   /sections/{slug}/:
     get:
       operationId: retrieveSection
-      description: API endpoint for returning a list of sections.
+      description: API endpoint for returning a particular section.
       parameters:
       - name: slug
         in: path
@@ -2031,7 +2031,7 @@ paths:
   /feats/{slug}/:
     get:
       operationId: retrieveFeat
-      description: API endpoint for returning a list of feats.
+      description: API endpoint for returning a particular feat.
       parameters:
       - name: slug
         in: path
@@ -2184,7 +2184,7 @@ paths:
   /conditions/{slug}/:
     get:
       operationId: retrieveCondition
-      description: API endpoint for returning a list of conditions.
+      description: API endpoint for returning a particular condition.
       parameters:
       - name: slug
         in: path
@@ -2244,7 +2244,7 @@ paths:
   /races/:
     get:
       operationId: listRaces
-      description: API endpoint for returning a list of races and subraces.
+      description: API endpoint for returning a list of races.
       parameters:
       - name: page
         required: false
@@ -2388,7 +2388,7 @@ paths:
   /races/{slug}/:
     get:
       operationId: retrieveRace
-      description: API endpoint for returning a list of races and subraces.
+      description: API endpoint for returning a particular race.
       parameters:
       - name: slug
         in: path
@@ -2655,7 +2655,7 @@ paths:
   /classes/{slug}/:
     get:
       operationId: retrieveCharClass
-      description: API endpoint for returning a list of classes and archetypes.
+      description: API endpoint for returning a particular class or archetype.
       parameters:
       - name: slug
         in: path
@@ -2868,7 +2868,7 @@ paths:
   /magicitems/{slug}/:
     get:
       operationId: retrieveMagicItem
-      description: API endpoint for returning a list of magic items.
+      description: API endpoint for returning a particular magic item.
       parameters:
       - name: slug
         in: path
@@ -3036,7 +3036,7 @@ paths:
   /weapons/{slug}/:
     get:
       operationId: retrieveWeapon
-      description: API endpoint for returning a list of weapons.
+      description: API endpoint for returning a particular weapon.
       parameters:
       - name: slug
         in: path
@@ -3213,7 +3213,7 @@ paths:
   /armor/{slug}/:
     get:
       operationId: retrieveArmor
-      description: API endpoint for returning a list of armor.
+      description: API endpoint for returning a particular armor.
       parameters:
       - name: slug
         in: path
@@ -3502,4 +3502,4 @@ paths:
       - Search
 servers:
 - url: https://api.open5e.com/
-  description: Open 5e
+  description: Open5e


### PR DESCRIPTION
adds separate endpoint descriptions for singular endpoints i.e. `/monsters/{id}` and plural endpoints i.e. `/monsters`