### PR TITLE
task: Add basic tests and fixtures for the spells view.

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Dependencies
-        run: pipenv install
+        run: pipenv install --dev
       - name: Run migrations
         run: pipenv run python manage.py migrate
       - name: Run Tests
-        run: pipenv run python3.11 manage.py test
+        run: pipenv run pytest
   build:
     runs-on: ubuntu-latest
     steps:

--- a/api/tests/views/test_spells.py
+++ b/api/tests/views/test_spells.py
@@ -1,0 +1,52 @@
+"""Tests for the spells endpoint."""
+import pytest
+from rest_framework import status
+from django.test import Client
+
+from api.models import Spell
+
+
+@pytest.mark.django_db
+class TestSpellsView:
+    @staticmethod
+    def test_spell_view_200(client: Client, spell: Spell):
+        url = "/spells/"
+        response = client.get(url)
+
+        # Confirm that the response is a 200
+        assert response.status_code == status.HTTP_200_OK
+
+        # Confirm the length of the results returned on the response
+        assert len(response.json()["results"]) == 1
+
+
+@pytest.fixture
+def spell(document):
+    data = {
+        "slug": "ray-of-sickness",
+        "name": "Ray of Sickness",
+        "desc": "A ray of green light appears at your fingertip, arcing towards a target within range.\n\nMake a ranged spell attack against the target. On a hit, the target takes 2d8 poison damage and must make a Constitution saving throw. On a failed save, it is also poisoned until the end of your next turn.\n\n*(This Open5e spell replaces a like-named non-SRD spell from an official source.*",
+        "document": document,
+        "created_at": "2023-05-17 14:25:56.609742",
+        "page_no": None,
+        "page": "",
+        "spell_level": 1,
+        "dnd_class": "Sorcerer, Wizard",
+        "school": "Necromancy",
+        "casting_time": "1 action",
+        "range": "60 feet",
+        "target_range_sort": 60,
+        "requires_verbal_components": True,
+        "requires_somatic_components": True,
+        "requires_material_components": False,
+        "material": "",
+        "higher_level": "When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.",
+        "can_be_cast_as_ritual": False,
+        "duration": "Instantaneous",
+        "requires_concentration": False,
+        "archetype": "",
+        "circles": "",
+        "route": "spells/",
+    }
+    _spell = Spell.objects.create(**data)
+    return _spell

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest configuration module."""
+import pytest
+
+from api.models import Document
+
+
+@pytest.fixture
+def document():
+    data = {
+        "id": 1,
+        "slug": "o5e",
+        "title": "Open5e OGL",
+        "desc": "Open5e Original Content",
+        "license": "Open Gaming License",
+        "author": "Ean Moody and Open Source Contributors from github.com/open5e-api",
+        "organization": "Open5e",
+        "version": "1.0",
+        "url": "open5e.com",
+        "copyright": "Open5e.com Copyright 2019.",
+        "created_at": "2023-05-17 14:25:56.586864",
+        "license_url": "http://open5e.com/legal",
+    }
+    _document = Document.objects.create(**data)
+    return _document


### PR DESCRIPTION
This PR is implementing basic tests for the Spells view.

A few pytest features are also being introduced:

- We're making use of [fixtures](https://docs.pytest.org/en/6.2.x/fixture.html):
    - A "root" fixture is being created for the Document model;
    - A module level fixture is created for the Spell model;
    - The document fixture is used on defining the spell fixture, and then the spell fixture is used inside the test function;
    - We use the client fixture for making requests (made available by the [`pytest-django`](https://pytest-django.readthedocs.io/en/latest/helpers.html#client-django-test-client);
   
- Simple [`assert`](https://docs.pytest.org/en/6.2.x/assert.html#asserting-with-the-assert-statement) statements are used for testing the expected conditions.
- A [`mark`](https://docs.pytest.org/en/6.2.x/assert.html#asserting-with-the-assert-statement) is used to allow db access inside tests.