### PR TITLE
Fix serializer for json-based fields

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -55,7 +55,15 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('url', 'name')
 
 class MonsterSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer, serializers.ModelSerializer):
-
+    
+    img_main = serializers.SerializerMethodField()
+    speed = serializers.SerializerMethodField()
+    environments = serializers.SerializerMethodField()
+    skills = serializers.SerializerMethodField()
+    actions = serializers.SerializerMethodField()
+    reactions = serializers.SerializerMethodField()
+    legendary_actions = serializers.SerializerMethodField()
+    special_abilities = serializers.SerializerMethodField()
     img_main = serializers.SerializerMethodField()
 
     def get_img_main(self, monster):
@@ -66,6 +74,28 @@ class MonsterSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedMod
             return ('http://{domain}/{path}'.format(domain=domain, path=img_url))
         else:
              return None
+
+    def get_speed(self, monster):
+        return monster.speed()
+
+    def get_environments(self, monster):
+        return monster.environments()
+
+    def get_skills(self, monster):
+        return monster.skills()
+
+    def get_actions(self, monster):
+        return monster.actions()
+
+    def get_reactions(self, monster):
+        return monster.reactions()
+
+    def get_legendary_actions(self, monster):
+        return monster.legendary_actions()
+
+    def get_special_abilities(self, monster):
+        return monster.special_abilities()
+
 
     class Meta:
         model = models.Monster


### PR DESCRIPTION
Fixes errors like 

```
 django.core.exceptions.FieldError: Cannot resolve keyword 'reactions' into field. Choices are: actions_json...
```