### PR TITLE
Separate higher level description from description on spells

### DIFF
--- a/data/WOTC_5e_SRD_v5.1/spells.json
+++ b/data/WOTC_5e_SRD_v5.1/spells.json
@@ -21,7 +21,8 @@
     },
     {
         "name": "Acid Splash",
-        "desc": "You hurl a bubble of acid. Choose one creature within range, or choose two creatures within range that are within 5 feet of each other. A target must succeed on a dexterity saving throw or take 1d6 acid damage. This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
+        "desc": "You hurl a bubble of acid. Choose one creature within range, or choose two creatures within range that are within 5 feet of each other. A target must succeed on a dexterity saving throw or take 1d6 acid damage.",
+        "higher_level": "This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
         "page": "phb 211",
         "range": "60 feet",
         "components": "V, S",
@@ -715,7 +716,8 @@
     },
     {
         "name": "Chill Touch",
-        "desc": "You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn. Until then, the hand clings to the target. If you hit an undead target, it also has disadvantage on attack rolls against you until the end of your next turn. This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn. Until then, the hand clings to the target. If you hit an undead target, it also has disadvantage on attack rolls against you until the end of your next turn.",
+        "higher_level": "This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "page": "phb 221",
         "range": "120 feet",
         "components": "V, S",
@@ -2102,7 +2104,8 @@
     },
     {
         "name": "Fire Bolt",
-        "desc": "You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn't being worn or carried. This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).",
+        "desc": "You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn't being worn or carried.",
+        "higher_level": "This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).",
         "page": "phb 242",
         "range": "120 feet",
         "components": "V, S",
@@ -4011,7 +4014,8 @@
     },
     {
         "name": "Poison Spray",
-        "desc": "You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must succeed on a Constitution saving throw or take 1d12 poison damage. This spell's damage increases by 1d12 when you reach 5th level (2d12), 11th level (3d12), and 17th level (4d12).",
+        "desc": "You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must succeed on a Constitution saving throw or take 1d12 poison damage.",
+        "higher_level": "This spell's damage increases by 1d12 when you reach 5th level (2d12), 11th level (3d12), and 17th level (4d12).",
         "page": "phb 266",
         "range": "10 feet",
         "components": "V, S",
@@ -4174,7 +4178,8 @@
     },
     {
         "name": "Produce Flame",
-        "desc": "A flickering flame appears in your hand. The flame remains there for the duration and harms neither you nor your equipment. The flame sheds bright light in a 10-foot radius and dim light for an additional 10 feet. The spell ends if you dismiss it as an action or if you cast it again. You can also attack with the flame, although doing so ends the spell. When you cast this spell, or as an action on a later turn, you can hurl the flame at a creature within 30 feet of you. Make a ranged spell attack. On a hit, the target takes 1d8 fire damage. This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "A flickering flame appears in your hand. The flame remains there for the duration and harms neither you nor your equipment. The flame sheds bright light in a 10-foot radius and dim light for an additional 10 feet. The spell ends if you dismiss it as an action or if you cast it again. You can also attack with the flame, although doing so ends the spell. When you cast this spell, or as an action on a later turn, you can hurl the flame at a creature within 30 feet of you. Make a ranged spell attack. On a hit, the target takes 1d8 fire damage.",
+        "higher_level": "This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "page": "phb 269",
         "range": "Self",
         "components": "V, S",
@@ -4331,7 +4336,8 @@
     },
     {
         "name": "Ray of Frost",
-        "desc": "A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn. The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn.",
+        "higher_level": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "page": "phb 271",
         "range": "60 feet",
         "components": "V, S",
@@ -4499,7 +4505,8 @@
     },
     {
         "name": "Sacred Flame",
-        "desc": "Flame-like radiance descends on a creature that you can see within range. The target must succeed on a dexterity saving throw or take 1d8 radiant damage. The target gains no benefit from cover for this saving throw. The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "Flame-like radiance descends on a creature that you can see within range. The target must succeed on a dexterity saving throw or take 1d8 radiant damage. The target gains no benefit from cover for this saving throw.",
+        "higher_level": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "page": "phb 272",
         "range": "60 feet",
         "components": "V, S",
@@ -4755,7 +4762,8 @@
     },
     {
         "name": "Shocking Grasp",
-        "desc": "Lightning springs from your hand to deliver a shock to a creature you try to touch. Make a melee spell attack against the target. You have advantage on the attack roll if the target is wearing armor made of metal. On a hit, the target takes 1d8 lightning damage, and it can't take reactions until the start of its next turn. The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "Lightning springs from your hand to deliver a shock to a creature you try to touch. Make a melee spell attack against the target. You have advantage on the attack roll if the target is wearing armor made of metal. On a hit, the target takes 1d8 lightning damage, and it can't take reactions until the start of its next turn.",
+        "higher_level": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "page": "phb 275",
         "range": "Touch",
         "components": "V, S",
@@ -5479,7 +5487,8 @@
     },
     {
         "name": "Vicious Mockery",
-        "desc": "You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (though it need not understand you), it must succeed on a Wisdom saving throw or take 1d4 psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn. This spell's damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
+        "desc": "You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (though it need not understand you), it must succeed on a Wisdom saving throw or take 1d4 psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.",
+        "higher_level": "This spell's damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
         "page": "phb 285",
         "range": "60 feet",
         "components": "V",

--- a/data/a5e_srd/spells.json
+++ b/data/a5e_srd/spells.json
@@ -54,7 +54,8 @@
     {
         "name": "Acid Splash",
         "slug": "acid-splash-a5e",
-        "desc": "A stinking bubble of acid is conjured out of thin air to fly at the targets, dealing 1d6 acid damage.\n\nThis spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
+        "desc": "A stinking bubble of acid is conjured out of thin air to fly at the targets, dealing 1d6 acid damage.",
+        "higher_level": "This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
         "range": "60 feet",
         "components": "V, S",
         "materials": null,
@@ -190,7 +191,8 @@
     {
         "name": "Altered Strike",
         "slug": "altered-strike-a5e",
-        "desc": "You briefly transform your weapon or fist into another material and strike with it, making a melee weapon attack against a target within your reach.\n\nYou use your spellcasting ability for your attack and damage rolls, and your melee weapon attack counts as if it were made with a different material for the purpose of overcoming resistance and immunity to nonmagical attacks and damage: either bone, bronze, cold iron, steel, stone, or wood.\n\nWhen you reach 5th level, you can choose silver or mithral as the material.\n\nWhen you reach 11th level, if you have the Extra Attack feature you make two melee weapon attacks as part of the casting of this spell instead of one. In addition, you can choose adamantine as the material.\n\nWhen you reach 17th level, your attacks with this spell deal an extra 1d6 damage.",
+        "desc": "You briefly transform your weapon or fist into another material and strike with it, making a melee weapon attack against a target within your reach.\n\nYou use your spellcasting ability for your attack and damage rolls, and your melee weapon attack counts as if it were made with a different material for the purpose of overcoming resistance and immunity to nonmagical attacks and damage: either bone, bronze, cold iron, steel, stone, or wood.",
+        "higher_level": "When you reach 5th level, you can choose silver or mithral as the material. When you reach 11th level, if you have the Extra Attack feature you make two melee weapon attacks as part of the casting of this spell instead of one. In addition, you can choose adamantine as the material.\n\nWhen you reach 17th level, your attacks with this spell deal an extra 1d6 damage.",
         "range": "self",
         "components": "V, S, M",
         "materials": "piece of the desired material",
@@ -1385,7 +1387,8 @@
     {
         "name": "Chill Touch",
         "slug": "chill-touch-a5e",
-        "desc": "You reach out with a spectral hand that carries the chill of death. Make a ranged spell attack. On a hit, the target takes 1d8 necrotic damage, and it cannot regain hit points until the start of your next turn. The hand remains visibly clutching onto the target for the duration. If the target you hit is undead, it makes attack rolls against you with disadvantage until the end of your next turn.\n\nThe spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "You reach out with a spectral hand that carries the chill of death. Make a ranged spell attack. On a hit, the target takes 1d8 necrotic damage, and it cannot regain hit points until the start of your next turn. The hand remains visibly clutching onto the target for the duration. If the target you hit is undead, it makes attack rolls against you with disadvantage until the end of your next turn.",
+        "higher_level": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "range": "120 feet",
         "components": "V, S",
         "materials": null,
@@ -1444,7 +1447,8 @@
     {
         "name": "Circular Breathing",
         "slug": "circular-breathing-a5e",
-        "desc": "You begin carefully regulating your breath so that you can continue playing longer or keep breathing longer in adverse conditions.\n\nUntil the spell ends, you can breathe underwater, and you can utilize bardic performances that would normally require breathable air. In addition, you have advantage on saving throws against gases and environments with adverse breathing conditions.\n\nThe duration of this spell increases when you reach 5th level (10 minutes), 11th level (30 minutes), and 17th level (1 hour).",
+        "desc": "You begin carefully regulating your breath so that you can continue playing longer or keep breathing longer in adverse conditions.\n\nUntil the spell ends, you can breathe underwater, and you can utilize bardic performances that would normally require breathable air. In addition, you have advantage on saving throws against gases and environments with adverse breathing conditions.",
+        "higher_level": "The duration of this spell increases when you reach 5th level (10 minutes), 11th level (30 minutes), and 17th level (1 hour).",
         "range": "self",
         "components": "S, M",
         "materials": "long breath of clean air",
@@ -3675,7 +3679,8 @@
     {
         "name": "Fire Bolt",
         "slug": "fire-bolt-a5e",
-        "desc": "You cast a streak of flame at the target. Make a ranged spell attack. On a hit, you deal 1d10 fire damage. An unattended flammable object is ignited.\n\nThis spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).",
+        "desc": "You cast a streak of flame at the target. Make a ranged spell attack. On a hit, you deal 1d10 fire damage. An unattended flammable object is ignited.",
+        "higher_level": "This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).",
         "range": "120 feet",
         "components": "V, S",
         "materials": null,
@@ -6691,7 +6696,8 @@
     {
         "name": "Pestilence",
         "slug": "pestilence-a5e",
-        "desc": "A swarm of insects fills the area. Creatures that begin their turn within the spell's area or who enter the area for the first time on their turn must make a Constitution saving throw or take 1d4 piercing damage. The pests also ravage any unattended organic material within their radius, such as plant, wood, or fabric.\n\nThis spell's damage increases by 1d4 when you reach 5th level (2d4), 10th level (3d4), and 15th level (4d4).",
+        "desc": "A swarm of insects fills the area. Creatures that begin their turn within the spell's area or who enter the area for the first time on their turn must make a Constitution saving throw or take 1d4 piercing damage. The pests also ravage any unattended organic material within their radius, such as plant, wood, or fabric.",
+        "higher_level": "This spell's damage increases by 1d4 when you reach 5th level (2d4), 10th level (3d4), and 15th level (4d4).",
         "range": "60 feet",
         "components": "V, S",
         "materials": null,
@@ -7168,7 +7174,8 @@
     {
         "name": "Produce Flame",
         "slug": "produce-flame-a5e",
-        "desc": "You create a flame in your hand which lasts until the spell ends and does no harm to you or your equipment. The flame sheds bright light in a 10-foot radius and dim light for an additional 10 feet.\n\nThe spell ends when you dismiss it, cast it again, or attack with the flame. As part of casting the spell or as an action on a following turn, you can fling the flame at a creature within 30 feet, making a ranged spell attack that deals 1d8 fire damage.\n\nThis spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "You create a flame in your hand which lasts until the spell ends and does no harm to you or your equipment. The flame sheds bright light in a 10-foot radius and dim light for an additional 10 feet.\n\nThe spell ends when you dismiss it, cast it again, or attack with the flame. As part of casting the spell or as an action on a following turn, you can fling the flame at a creature within 30 feet, making a ranged spell attack that deals 1d8 fire damage.",
+        "higher_level": "This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "range": "Self",
         "components": "V, S",
         "materials": null,
@@ -7457,7 +7464,8 @@
     {
         "name": "Ray of Frost",
         "slug": "ray-of-frost-a5e",
-        "desc": "An icy beam shoots from your outstretched fingers.\n\nMake a ranged spell attack. On a hit, you deal 1d8 cold damage and reduce the target's Speed by 10 feet until the start of your next turn.\n\nThis spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "An icy beam shoots from your outstretched fingers.\n\nMake a ranged spell attack. On a hit, you deal 1d8 cold damage and reduce the target's Speed by 10 feet until the start of your next turn.",
+        "higher_level": "This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "range": "60 feet",
         "components": "V, S",
         "materials": null,
@@ -7713,7 +7721,8 @@
     {
         "name": "Sacred Flame",
         "slug": "sacred-flame-a5e",
-        "desc": "As long as you can see the target (even if it has cover) radiant holy flame envelops it, dealing 1d8 radiant damage.\n\nThis spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "As long as you can see the target (even if it has cover) radiant holy flame envelops it, dealing 1d8 radiant damage.",
+        "higher_level": "This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "range": "60 feet",
         "components": "V, S",
         "materials": null,
@@ -8172,7 +8181,8 @@
     {
         "name": "Shocking Grasp",
         "slug": "shocking-grasp-a5e",
-        "desc": "Electricity arcs from your hand to shock the target. Make a melee spell attack (with advantage if the target is wearing armor made of metal). On a hit, you deal 1d8 lightning damage, and the target can't take reactions until the start of its next turn as the electricity courses through its body.\n\nThis spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "Electricity arcs from your hand to shock the target. Make a melee spell attack (with advantage if the target is wearing armor made of metal). On a hit, you deal 1d8 lightning damage, and the target can't take reactions until the start of its next turn as the electricity courses through its body.",
+        "higher_level": "This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "range": "touch",
         "components": "V, S",
         "materials": null,
@@ -9445,7 +9455,8 @@
     {
         "name": "Vicious Mockery",
         "slug": "vicious-mockery-a5e",
-        "desc": "You verbally insult or mock the target so viciously its mind is seared. As long as the target hears you (understanding your words is not required) it takes 1d6 psychic damage and has disadvantage on the first attack roll it makes before the end of its next turn.\n\nThe spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
+        "desc": "You verbally insult or mock the target so viciously its mind is seared. As long as the target hears you (understanding your words is not required) it takes 1d6 psychic damage and has disadvantage on the first attack roll it makes before the end of its next turn.",
+        "higher_level": "The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
         "range": "60 feet",
         "components": "V",
         "materials": null,

--- a/data/deep_magic/spells.json
+++ b/data/deep_magic/spells.json
@@ -155,7 +155,8 @@
     },
     {
         "name": "Ale-dritch Blast",
-        "desc": "A stream of ice-cold ale blasts from your outstretched hands toward a creature or object within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage and it must make a successful Constitution saving throw or be poisoned until the end of its next turn. A targeted creature has disadvantage on the saving throw if it has drunk any alcohol within the last hour.\n\nThe damage increases when you reach higher levels: 2d8 at 5th level, 3d8 at 11th level, and 4d8 at 17th level.",
+        "desc": "A stream of ice-cold ale blasts from your outstretched hands toward a creature or object within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage and it must make a successful Constitution saving throw or be poisoned until the end of its next turn. A targeted creature has disadvantage on the saving throw if it has drunk any alcohol within the last hour.",
+        "higher_level": "The damage increases when you reach higher levels: 2d8 at 5th level, 3d8 at 11th level, and 4d8 at 17th level.",
         "range": "60 feet",
         "components": "V, S",
         "ritual": "no",
@@ -364,7 +365,8 @@
     },
     {
         "name": "Animated Scroll",
-        "desc": "The paper or parchment must be folded into the shape of an animal before casting the spell. It then becomes an animated paper animal of the kind the folded paper most closely resembles. The creature uses the stat block of any beast that has a challenge rating of 0. It is made of paper, not flesh and bone, but it can do anything the real creature can do: a paper owl can fly and attack with its talons, a paper frog can swim without disintegrating in water, and so forth. It follows your commands to the best of its ability, including carrying messages to a recipient whose location you know.\n\nThe duration increases by 24 hours at 5th level (48 hours), 11th level (72 hours), and 17th level (96 hours).",
+        "desc": "The paper or parchment must be folded into the shape of an animal before casting the spell. It then becomes an animated paper animal of the kind the folded paper most closely resembles. The creature uses the stat block of any beast that has a challenge rating of 0. It is made of paper, not flesh and bone, but it can do anything the real creature can do: a paper owl can fly and attack with its talons, a paper frog can swim without disintegrating in water, and so forth. It follows your commands to the best of its ability, including carrying messages to a recipient whose location you know.",
+        "higher_level": "The duration increases by 24 hours at 5th level (48 hours), 11th level (72 hours), and 17th level (96 hours).",
         "range": "Touch",
         "components": "V, S, M",
         "material": "intricately folded paper or parchment",
@@ -690,7 +692,8 @@
     },
     {
         "name": "Biting Arrow",
-        "desc": "As part of the action used to cast this spell, you make a ranged weapon attack with a bow, a crossbow, or a thrown weapon. The effect is limited to a range of 120 feet despite the weapon’s range, and the attack is made with disadvantage if the target is in the weapon’s long range.\n\nIf the weapon attack hits, it deals damage as usual. In addition, the target becomes coated in thin frost until the start of your next turn. If the target uses its reaction before the start of your next turn, it immediately takes 1d6 cold damage and the spell ends.\n\nThe spell’s damage, for both the ranged attack and the cold damage, increases by 1d6 when you reach 5th level (+1d6 and 2d6), 11th level (+2d6 and 3d6), and 17th level (+3d6 and 4d6).",
+        "desc": "As part of the action used to cast this spell, you make a ranged weapon attack with a bow, a crossbow, or a thrown weapon. The effect is limited to a range of 120 feet despite the weapon’s range, and the attack is made with disadvantage if the target is in the weapon’s long range.\n\nIf the weapon attack hits, it deals damage as usual. In addition, the target becomes coated in thin frost until the start of your next turn. If the target uses its reaction before the start of your next turn, it immediately takes 1d6 cold damage and the spell ends.",
+        "higher_level": "The spell’s damage, for both the ranged attack and the cold damage, increases by 1d6 when you reach 5th level (+1d6 and 2d6), 11th level (+2d6 and 3d6), and 17th level (+3d6 and 4d6).",
         "range": "Self",
         "components": "V, M",
         "material": "an arrow or a thrown weapon",
@@ -1100,7 +1103,8 @@
     },
     {
         "name": "Blood Tide",
-        "desc": "When you cast this spell, a creature you designate within range must succeed on a Constitution saving throw or bleed from its nose, eyes, ears, and mouth. This bleeding deals no damage but imposes a –2 penalty on the creature’s Intelligence, Charisma, and Wisdom checks. //Blood tide// has no effect on undead or constructs.\n\nA bleeding creature might attract the attention of creatures such as stirges, sharks, or giant mosquitoes, depending on the circumstances.\n\nA //[[[srd-spell:cure wounds]]]// spell stops the bleeding before the duration of blood tide expires, as does a successful DC 10 Wisdom (Medicine) check.\n\nThe spell’s duration increases to 2 minutes when you reach 5th level, to 10 minutes when you reach 11th level, and to 1 hour when you reach 17th level.",
+        "desc": "When you cast this spell, a creature you designate within range must succeed on a Constitution saving throw or bleed from its nose, eyes, ears, and mouth. This bleeding deals no damage but imposes a –2 penalty on the creature’s Intelligence, Charisma, and Wisdom checks. //Blood tide// has no effect on undead or constructs.\n\nA bleeding creature might attract the attention of creatures such as stirges, sharks, or giant mosquitoes, depending on the circumstances.\n\nA //[[[srd-spell:cure wounds]]]// spell stops the bleeding before the duration of blood tide expires, as does a successful DC 10 Wisdom (Medicine) check.",
+        "higher_level": "The spell’s duration increases to 2 minutes when you reach 5th level, to 10 minutes when you reach 11th level, and to 1 hour when you reach 17th level.",
         "range": "25 feet",
         "components": "V",
         "ritual": "no",
@@ -1576,7 +1580,8 @@
     },
     {
         "name": "Caustic Touch",
-        "desc": "Your hand sweats profusely and becomes coated in a film of caustic slime. Make a melee spell attack against a creature you touch. On a hit, the target takes 1d8 acid damage. If the target was concentrating on a spell, it has disadvantage on its Constitution saving throw to maintain concentration.\n\nThis spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "Your hand sweats profusely and becomes coated in a film of caustic slime. Make a melee spell attack against a creature you touch. On a hit, the target takes 1d8 acid damage. If the target was concentrating on a spell, it has disadvantage on its Constitution saving throw to maintain concentration.",
+        "higher_level": "This spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "range": "Touch",
         "components": "V, S",
         "ritual": "no",
@@ -1818,7 +1823,8 @@
     },
     {
         "name": "Clockwork Bolt",
-        "desc": "You imbue an arrow or crossbow bolt with clockwork magic just as you fire it at your target; spinning blades materialize on the missile after it strikes to further mutilate your enemy.\n\nAs part of the action used to cast this spell, you make a ranged weapon attack with a bow or a crossbow against one creature within range. If the attack hits, the missile embeds in the target. Unless the target (or an ally of it within 5 feet) uses an action to remove the projectile (which deals no additional damage), the target takes an additional 1d8 slashing damage at the end of its next turn from spinning blades that briefly sprout from the missile’s shaft. Afterward, the projectile reverts to normal.\n\nThis spell deals more damage when you reach higher levels. At 5th level, the ranged attack deals an extra 1d8 slashing damage to the target, and the target takes an additional 1d8 slashing damage (2d8 total) if the embedded ammunition isn’t removed. Both damage amounts increase by 1d8 again at 11th level and at 17th level.",
+        "desc": "You imbue an arrow or crossbow bolt with clockwork magic just as you fire it at your target; spinning blades materialize on the missile after it strikes to further mutilate your enemy.\n\nAs part of the action used to cast this spell, you make a ranged weapon attack with a bow or a crossbow against one creature within range. If the attack hits, the missile embeds in the target. Unless the target (or an ally of it within 5 feet) uses an action to remove the projectile (which deals no additional damage), the target takes an additional 1d8 slashing damage at the end of its next turn from spinning blades that briefly sprout from the missile’s shaft. Afterward, the projectile reverts to normal.",
+        "higher_level": "This spell deals more damage when you reach higher levels. At 5th level, the ranged attack deals an extra 1d8 slashing damage to the target, and the target takes an additional 1d8 slashing damage (2d8 total) if the embedded ammunition isn’t removed. Both damage amounts increase by 1d8 again at 11th level and at 17th level.",
         "range": "60 feet",
         "components": "V, S, M",
         "material": "an arrow or crossbow bolt",
@@ -2146,7 +2152,8 @@
     },
     {
         "name": "Crushing Curse",
-        "desc": "You speak a word of Void Speech. Choose a creature you can see within range. If the target can hear you, it must succeed on a Wisdom saving throw or take 1d6 psychic damage and be deafened for 1 minute, except that it can still hear Void Speech. A creature deafened in this way can repeat the saving throw at the end of each of its turns, ending the effect on a success.\n\nThis spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
+        "desc": "You speak a word of Void Speech. Choose a creature you can see within range. If the target can hear you, it must succeed on a Wisdom saving throw or take 1d6 psychic damage and be deafened for 1 minute, except that it can still hear Void Speech. A creature deafened in this way can repeat the saving throw at the end of each of its turns, ending the effect on a success.",
+        "higher_level": "This spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
         "range": "60 feet",
         "components": "V, S",
         "ritual": "no",
@@ -2353,7 +2360,8 @@
     },
     {
         "name": "Dark Maw",
-        "desc": "Thick, penumbral ichor drips from your shadow-stained mouth, filling your mouth with giant shadow fangs. Make a melee spell attack against the target. On a hit, the target takes 1d8 necrotic damage as your shadowy fangs sink into it. If you have a bite attack (such as from a racial trait or a spell like //[[[srd-spell:alter self]]]//), you can add your spellcasting ability modifier to the damage roll but not to your temporary hit points.\n\nIf you hit a humanoid target, you gain 1d4 temporary hit points until the start of your next turn.\n\nThis spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "Thick, penumbral ichor drips from your shadow-stained mouth, filling your mouth with giant shadow fangs. Make a melee spell attack against the target. On a hit, the target takes 1d8 necrotic damage as your shadowy fangs sink into it. If you have a bite attack (such as from a racial trait or a spell like //[[[srd-spell:alter self]]]//), you can add your spellcasting ability modifier to the damage roll but not to your temporary hit points.\n\nIf you hit a humanoid target, you gain 1d4 temporary hit points until the start of your next turn.",
+        "higher_level": "This spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "range": "Touch",
         "components": "V, S",
         "ritual": "no",
@@ -2447,7 +2455,8 @@
     },
     {
         "name": "Decay",
-        "desc": "Make a melee spell attack against a creature you touch. On a hit, the target takes 1d10 necrotic damage. If the target is a Tiny or Small nonmagical object that isn’t being worn or carried by a creature, it automatically takes maximum damage from the spell.\n\nThis spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).",
+        "desc": "Make a melee spell attack against a creature you touch. On a hit, the target takes 1d10 necrotic damage. If the target is a Tiny or Small nonmagical object that isn’t being worn or carried by a creature, it automatically takes maximum damage from the spell.",
+        "higher_level": "This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).",
         "range": "Touch",
         "components": "V, S, M",
         "material": "a handful of ash",
@@ -2865,7 +2874,8 @@
     },
     {
         "name": "Dragon Roar",
-        "desc": "Your voice is amplified to assault the mind of one creature. The target must make a Charisma saving throw. If it fails, the target takes 1d4 psychic damage and is frightened until the start of your next turn. A target can be affected by your dragon roar only once per 24 hours.\n\nThis spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
+        "desc": "Your voice is amplified to assault the mind of one creature. The target must make a Charisma saving throw. If it fails, the target takes 1d4 psychic damage and is frightened until the start of your next turn. A target can be affected by your dragon roar only once per 24 hours.",
+        "higher_level": "This spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
         "range": "30 feet",
         "components": "V",
         "ritual": "no",
@@ -3973,7 +3983,8 @@
     },
     {
         "name": "Hamstring",
-        "desc": "You create an arrow of eldritch energy and send it at a target you can see within range. Make a ranged spell attack against the target. On a hit, the target takes 1d4 force damage, and it can’t take reactions until the end of its next turn.\n\nThe spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
+        "desc": "You create an arrow of eldritch energy and send it at a target you can see within range. Make a ranged spell attack against the target. On a hit, the target takes 1d4 force damage, and it can’t take reactions until the end of its next turn.",
+        "higher_level": "The spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
         "range": "60 feet",
         "components": "S",
         "ritual": "no",
@@ -4203,7 +4214,8 @@
     },
     {
         "name": "Hoarfrost",
-        "desc": "A melee weapon you are holding is imbued with cold. For the duration, a rime of frost covers the weapon and light vapor rises from it if the temperature is above freezing. The weapon becomes magical and deals an extra 1d4 cold damage on a successful hit. The spell ends after 1 minute, or earlier if you make a successful attack with the weapon or let go of it.\n\nThe spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
+        "desc": "A melee weapon you are holding is imbued with cold. For the duration, a rime of frost covers the weapon and light vapor rises from it if the temperature is above freezing. The weapon becomes magical and deals an extra 1d4 cold damage on a successful hit. The spell ends after 1 minute, or earlier if you make a successful attack with the weapon or let go of it.",
+        "higher_level": "The spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
         "range": "Touch",
         "components": "V, S, M",
         "material": "a melee weapon",
@@ -5576,7 +5588,8 @@
     },
     {
         "name": "Pummelstone",
-        "desc": "You cause a fist-sized chunk of stone to appear and hurl itself against the spell’s target. Make a ranged spell attack. On a hit, the target takes 1d6 bludgeoning damage and must roll a d4 when it makes an attack roll or ability check during its next turn, subtracting the result of the d4 from the attack or check roll.\n\nThe spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
+        "desc": "You cause a fist-sized chunk of stone to appear and hurl itself against the spell’s target. Make a ranged spell attack. On a hit, the target takes 1d6 bludgeoning damage and must roll a d4 when it makes an attack roll or ability check during its next turn, subtracting the result of the d4 from the attack or check roll.",
+        "higher_level": "The spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
         "range": "60 feet",
         "components": "V, S, M",
         "material": "a pebble",
@@ -6180,7 +6193,8 @@
     },
     {
         "name": "Shadow Bite",
-        "desc": "You create a momentary needle of cold, sharp pain in a creature within range. The target must make a successful Constitution saving throw or take 1d6 necrotic damage immediately and have its speed halved until the start of your next turn.\n\nThis spell’s damage increases to 2d6 when you reach 5th level, 3d6 when you reach 11th level, and 4d6 when you reach 17th level.",
+        "desc": "You create a momentary needle of cold, sharp pain in a creature within range. The target must make a successful Constitution saving throw or take 1d6 necrotic damage immediately and have its speed halved until the start of your next turn.",
+        "higher_level": "This spell’s damage increases to 2d6 when you reach 5th level, 3d6 when you reach 11th level, and 4d6 when you reach 17th level.",
         "range": "60 feet",
         "components": "V, S",
         "ritual": "no",
@@ -6345,7 +6359,8 @@
     },
     {
         "name": "Shiver",
-        "desc": "You fill a humanoid creature with such cold that its teeth begin to chatter and its body shakes uncontrollably. Roll 5d8; the total is the maximum hit points of a creature this spell can affect. The affected creature must succeed on a Constitution saving throw, or it cannot cast a spell or load a missile weapon until the end of your next turn. Once a creature has been affected by this spell, it is immune to further castings of this spell for 24 hours.\n\nThe maximum hit points you can affect increases by 4d8 when you reach 5th level (9d8), 11th level (13d8), and 17th level (17d8).",
+        "desc": "You fill a humanoid creature with such cold that its teeth begin to chatter and its body shakes uncontrollably. Roll 5d8; the total is the maximum hit points of a creature this spell can affect. The affected creature must succeed on a Constitution saving throw, or it cannot cast a spell or load a missile weapon until the end of your next turn. Once a creature has been affected by this spell, it is immune to further castings of this spell for 24 hours.",
+        "higher_level": "The maximum hit points you can affect increases by 4d8 when you reach 5th level (9d8), 11th level (13d8), and 17th level (17d8).",
         "range": "30 ft.",
         "components": "V, S, M",
         "material": "humanoid tooth",
@@ -6646,7 +6661,8 @@
     },
     {
         "name": "Starburst",
-        "desc": "You cause a mote of starlight to appear and explode in a 5-foot cube you can see within range. If a creature is in the cube, it must succeed on a Charisma saving throw or take 1d8 radiant damage.\n\nThis spell’s damage increases to 2d8 when you reach 5th level, 3d8 when you reach 11th level, and 4d8 when you reach 17th level.",
+        "desc": "You cause a mote of starlight to appear and explode in a 5-foot cube you can see within range. If a creature is in the cube, it must succeed on a Charisma saving throw or take 1d8 radiant damage.",
+        "higher_level": "This spell’s damage increases to 2d8 when you reach 5th level, 3d8 when you reach 11th level, and 4d8 when you reach 17th level.",
         "range": "60 feet",
         "components": "V, S",
         "ritual": "no",
@@ -7722,7 +7738,8 @@
     },
     {
         "name": "Wind Lash",
-        "desc": "Your swift gesture creates a solid lash of howling wind. Make a melee spell attack against the target. On a hit, the target takes 1d8 slashing damage from the shearing wind and is pushed 5 feet away from you.\n\nThe spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
+        "desc": "Your swift gesture creates a solid lash of howling wind. Make a melee spell attack against the target. On a hit, the target takes 1d8 slashing damage from the shearing wind and is pushed 5 feet away from you.",
+        "higher_level": "The spell’s damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
         "range": "20 feet",
         "components": "V, S",
         "ritual": "no",

--- a/data/tome_of_heroes/spells.json
+++ b/data/tome_of_heroes/spells.json
@@ -924,7 +924,8 @@
         "components": "S",
         "duration": "Instantaneous",
         "concentration": "no",
-        "desc": "Strange things happen in the mind and body in that moment between waking and sleeping. One of the most common is being startled awake by a sudden feeling of falling. With a snap of your fingers, you trigger that sensation in a creature you can see within range. The target must succeed on a Wisdom saving throw or take 1d6 force damage. If the target fails the saving throw by 5 or more, it drops one object it is holding. A dropped object lands in the creature's space.\n  The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
+        "desc": "Strange things happen in the mind and body in that moment between waking and sleeping. One of the most common is being startled awake by a sudden feeling of falling. With a snap of your fingers, you trigger that sensation in a creature you can see within range. The target must succeed on a Wisdom saving throw or take 1d6 force damage. If the target fails the saving throw by 5 or more, it drops one object it is holding. A dropped object lands in the creature's space.",
+        "higher_level": "The spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
         "ritual": "no",
         "source": "KP:ToH",
         "class": "Bard, Wizard"

--- a/data/warlock/spells.json
+++ b/data/warlock/spells.json
@@ -271,7 +271,8 @@
     },
     {
         "name": "Obfuscate Object",
-        "desc": "While you are in dim light, you cause an object in range to become unobtrusively obscured from the sight of other creatures. For the duration, you have advantage on Dexterity (Sleight of Hand) checks to hide the object. The object can't be larger than a shortsword, and it must be on your person, held in your hand, or otherwise unattended. You can affect two objects when you reach 5th level, three objects at 11th level, and four objects at 17th level.",
+        "desc": "While you are in dim light, you cause an object in range to become unobtrusively obscured from the sight of other creatures. For the duration, you have advantage on Dexterity (Sleight of Hand) checks to hide the object. The object can't be larger than a shortsword, and it must be on your person, held in your hand, or otherwise unattended.",
+        "higher_level": "You can affect two objects when you reach 5th level, three objects at 11th level, and four objects at 17th level.",
         "range": "10 Feet",
         "components": "S",
         "ritual": "no",


### PR DESCRIPTION
Most of the higher level descriptions are of a similar form, but not all.
The ones that differ were obvious from a quick glance at the tail end of the description, some could still have been missed.
Parsed by my brain after some exploration and discovering regex's just wouldn't cut it.
The carpal tunnel REAL! <3