### PR TITLE
Correction of Goblin Specialists CR to 1/2 from 1

### DIFF
--- a/data/menagerie/monsters.json
+++ b/data/menagerie/monsters.json
@@ -19656,7 +19656,7 @@
       "stealth": 3
     },
     "senses": "darkvision 60 ft., passive Perception 10",
-    "challenge_rating": "1",
+    "challenge_rating": "1/2",
     "languages": "Common, Goblin",
     "actions": [
       {
@@ -19777,7 +19777,7 @@
       "stealth": 3
     },
     "senses": "darkvision 60 ft., passive Perception 10",
-    "challenge_rating": "1",
+    "challenge_rating": "1/2",
     "languages": "Common, Goblin",
     "actions": [
       {
@@ -19831,7 +19831,7 @@
       "stealth": 3
     },
     "senses": "darkvision 60 ft., passive Perception 10",
-    "challenge_rating": "1",
+    "challenge_rating": "1/2",
     "languages": "Common, Goblin",
     "actions": [
       {
@@ -19889,7 +19889,7 @@
       "stealth": 3
     },
     "senses": "darkvision 60 ft., passive Perception 10",
-    "challenge_rating": "1",
+    "challenge_rating": "1/2",
     "languages": "Common, Goblin",
     "actions": [
       {
@@ -19947,7 +19947,7 @@
       "stealth": 3
     },
     "senses": "darkvision 60 ft., passive Perception 10",
-    "challenge_rating": "1",
+    "challenge_rating": "1/2",
     "languages": "Common, Goblin",
     "special_abilities": [
       {


### PR DESCRIPTION
See A5E MM Page 250 for details. The Goblin Specialists of:
- Goblin Alchemist
- Goblin Dreadnought
- Goblin Musketeer
- Goblin Shieldbearer
- Goblin Skulker
each have a documented **CR** of 1/2. Not 1.