### PR TITLE
Add search fields to endpoints that lack them

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -605,4 +605,4 @@ class ArmorViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Armor.objects.all()
     serializer_class = serializers.ArmorSerializer
     filterset_class = ArmorFilter
-    search_fields = ['name']
+    search_fields = ['name', 'desc']

--- a/api/views.py
+++ b/api/views.py
@@ -370,6 +370,7 @@ class ConditionViewSet(viewsets.ReadOnlyModelViewSet):
     )
     queryset = models.Condition.objects.all()
     serializer_class = serializers.ConditionSerializer
+    search_fields = ['name', 'desc']
     filterset_fields=(
         'name',
         'document__slug',

--- a/api/views.py
+++ b/api/views.py
@@ -95,6 +95,7 @@ class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
 		})
     queryset = models.Document.objects.all()
     serializer_class = serializers.DocumentSerializer
+    search_fields = ['title', 'desc']
     filterset_fields = (
         'slug',
         'title',

--- a/api/views.py
+++ b/api/views.py
@@ -143,7 +143,7 @@ class SpellViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Spell.objects.all()
     filterset_class=SpellFilter
     serializer_class = serializers.SpellSerializer
-    search_fields = ['dnd_class', 'name']
+    search_fields = ['dnd_class', 'name', 'desc']
     ordering_fields = '__all__'
     ordering=['name']
     filterset_fields = (

--- a/api/views.py
+++ b/api/views.py
@@ -256,7 +256,7 @@ class BackgroundViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = '__all__'
     ordering = ['name']
     filterset_class = BackgroundFilter
-    search_fields = ['name']
+    search_fields = ['name', 'desc']
 
 class PlaneFilter(django_filters.FilterSet):
 

--- a/api/views.py
+++ b/api/views.py
@@ -284,6 +284,7 @@ class PlaneViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Plane.objects.all()
     serializer_class = serializers.PlaneSerializer
     filterset_class=PlaneFilter
+    search_fields = ['name', 'desc']
 
 class SectionFilter(django_filters.FilterSet):
 

--- a/api/views.py
+++ b/api/views.py
@@ -410,6 +410,7 @@ class RaceViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Race.objects.all()
     serializer_class = serializers.RaceSerializer
     filterset_class = RaceFilter
+    search_fields = ['name', 'desc']
 
 class SubraceFilter(django_filters.FilterSet):
     # Unused, but could be implemented later.

--- a/api/views.py
+++ b/api/views.py
@@ -221,7 +221,7 @@ class MonsterViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = MonsterFilter
     
     serializer_class = serializers.MonsterSerializer
-    search_fields = ['name']
+    search_fields = ['name', 'desc']
 
 class BackgroundFilter(django_filters.FilterSet):
 

--- a/api/views.py
+++ b/api/views.py
@@ -508,6 +508,7 @@ class ArchetypeViewSet(viewsets.ReadOnlyModelViewSet):
     )
     queryset = models.Archetype.objects.all()
     serializer_class = serializers.ArchetypeSerializer
+    search_fields = ['name', 'desc']
     filterset_fields=(
         'name',
         'document__slug',

--- a/api/views.py
+++ b/api/views.py
@@ -187,6 +187,7 @@ class SpellListViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.SpellList.objects.all()
     serializer_class = serializers.SpellListSerializer
     filterset_class = SpellListFilter
+    search_fields = ['name', 'desc']
 
 class MonsterFilter(django_filters.FilterSet):
 

--- a/api/views.py
+++ b/api/views.py
@@ -575,7 +575,7 @@ class WeaponViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Weapon.objects.all()
     serializer_class = serializers.WeaponSerializer
     filterset_class = WeaponFilter
-    search_fields = ['name']
+    search_fields = ['name', 'desc']
 
 class ArmorFilter(django_filters.FilterSet):
 

--- a/api/views.py
+++ b/api/views.py
@@ -343,6 +343,7 @@ class FeatViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Feat.objects.all()
     serializer_class = serializers.FeatSerializer
     filterset_class = FeatFilter
+    search_fields = ['name', 'desc']
 
 class ConditionFilter(django_filters.FilterSet):
 

--- a/api/views.py
+++ b/api/views.py
@@ -438,6 +438,7 @@ class SubraceViewSet(viewsets.ReadOnlyModelViewSet):
     )
     queryset = models.Subrace.objects.all()
     serializer_class = serializers.SubraceSerializer
+    search_fields = ['name', 'desc']
     filterset_fields=(
         'name',
         'document__slug',

--- a/api/views.py
+++ b/api/views.py
@@ -543,7 +543,7 @@ class MagicItemViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.MagicItem.objects.all()
     serializer_class = serializers.MagicItemSerializer
     filterset_class = MagicItemFilter
-    search_fields = ['name']
+    search_fields = ['name', 'desc']
 
 class WeaponFilter(django_filters.FilterSet):
 

--- a/api/views.py
+++ b/api/views.py
@@ -315,6 +315,7 @@ class SectionViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = '__all__'
     ordering=['name']
     filterset_class = SectionFilter
+    search_fields = ['name', 'desc']
 
 class FeatFilter(django_filters.FilterSet):
 

--- a/api/views.py
+++ b/api/views.py
@@ -480,6 +480,7 @@ class CharClassViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.CharClass.objects.all()
     serializer_class = serializers.CharClassSerializer
     filterset_class = CharClassFilter
+    search_fields = ['name', 'desc']
 
 class ArchetypeFilter(django_filters.FilterSet):
     # Unused but could be implemented later.


### PR DESCRIPTION
Ensured that all `ViewSets` (aside from Manifest, Search, User and Group) had search fields for name and description (`DocumentViewSet` uses `title` instead of `name`). This involved adding `search_fields` for `name` and `desc` to all `ViewSet`s that lacked search fields and adding a search field for `desc` to all `ViewSet`s that only had `name`. 
This should fix the bug identified in issue #301.