### PR TITLE
Implement dynamic field serialization on endpoints that lack it

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -18,7 +18,7 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
         super(DynamicFieldsModelSerializer, self).__init__(*args, **kwargs)
 
         # The request doesn't exist when generating an OAS file, so we have to check that first
-        if self.context['request']:
+        if 'request' in self.context:
             fields = self.context['request'].query_params.get('fields')
             if fields:
                 fields = fields.split(',')
@@ -280,7 +280,7 @@ class ConditionSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class SubraceSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class SubraceSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Subrace
         fields = ('name',

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -40,7 +40,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         model = User
         fields = ('url', 'username', 'email', 'groups')
 
-class DocumentSerializer(serializers.HyperlinkedModelSerializer):
+class DocumentSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
             model = models.Document
             fields = (
@@ -62,7 +62,7 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
         model = Group
         fields = ('url', 'name')
 
-class MonsterSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer, serializers.ModelSerializer):
+class MonsterSerializer(DynamicFieldsHyperlinkedModelSerializer):
     
     speed = serializers.SerializerMethodField()
     environments = serializers.SerializerMethodField()
@@ -215,7 +215,7 @@ class SpellListSerializer(DynamicFieldsModelSerializer):
             'document__url'
         )
 
-class BackgroundSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class BackgroundSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Background
         fields = (
@@ -235,12 +235,12 @@ class BackgroundSerializer(DynamicFieldsModelSerializer, serializers.Hyperlinked
             'document__url'
         )
 
-class PlaneSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class PlaneSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Plane
         fields = ('slug','name','desc','document__slug', 'document__title', 'document__url')
 
-class SectionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class SectionSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Section
         fields = (
@@ -254,7 +254,7 @@ class SectionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedMod
             'parent'
         )
 
-class FeatSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class FeatSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Feat
         fields = (
@@ -268,7 +268,7 @@ class FeatSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelS
             'document__url'
         )
 
-class ConditionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class ConditionSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Condition
         fields = (
@@ -280,7 +280,7 @@ class ConditionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedM
             'document__url'
         )
 
-class SubraceSerializer(serializers.HyperlinkedModelSerializer):
+class SubraceSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Subrace
         fields = ('name',
@@ -294,7 +294,7 @@ class SubraceSerializer(serializers.HyperlinkedModelSerializer):
         'document__url'
     )
 
-class RaceSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class RaceSerializer(DynamicFieldsHyperlinkedModelSerializer):
     subraces = SubraceSerializer(many=True,read_only=True)
     class Meta:
         model = models.Race
@@ -320,7 +320,7 @@ class RaceSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelS
             'document__url'
         )
 
-class ArchetypeSerializer(serializers.HyperlinkedModelSerializer):
+class ArchetypeSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Archetype
         fields = (
@@ -333,7 +333,7 @@ class ArchetypeSerializer(serializers.HyperlinkedModelSerializer):
             'document__url'
         )
 
-class CharClassSerializer(serializers.HyperlinkedModelSerializer):
+class CharClassSerializer(DynamicFieldsHyperlinkedModelSerializer):
     archetypes = ArchetypeSerializer(many=True,read_only=True)
     class Meta:
         model = models.CharClass
@@ -360,7 +360,7 @@ class CharClassSerializer(serializers.HyperlinkedModelSerializer):
             'document__url'
         )
 
-class MagicItemSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class MagicItemSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.MagicItem
         fields = (
@@ -375,7 +375,7 @@ class MagicItemSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedM
             'document__url'
         )
 
-class WeaponSerializer(serializers.HyperlinkedModelSerializer):
+class WeaponSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Weapon
         fields = (
@@ -392,7 +392,7 @@ class WeaponSerializer(serializers.HyperlinkedModelSerializer):
             'weight',
             'properties')
 
-class ArmorSerializer(serializers.HyperlinkedModelSerializer):
+class ArmorSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Armor
         fields = (

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -40,7 +40,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         model = User
         fields = ('url', 'username', 'email', 'groups')
 
-class DocumentSerializer(serializers.HyperlinkedModelSerializer):
+class DocumentSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
             model = models.Document
             fields = (
@@ -62,7 +62,7 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
         model = Group
         fields = ('url', 'name')
 
-class MonsterSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer, serializers.ModelSerializer):
+class MonsterSerializer(DynamicFieldsHyperlinkedModelSerializer):
     
     speed = serializers.SerializerMethodField()
     environments = serializers.SerializerMethodField()
@@ -215,7 +215,7 @@ class SpellListSerializer(DynamicFieldsModelSerializer):
             'document__url'
         )
 
-class BackgroundSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class BackgroundSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Background
         fields = (
@@ -235,12 +235,12 @@ class BackgroundSerializer(DynamicFieldsModelSerializer, serializers.Hyperlinked
             'document__url'
         )
 
-class PlaneSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class PlaneSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Plane
         fields = ('slug','name','desc','document__slug', 'document__title', 'document__url')
 
-class SectionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class SectionSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Section
         fields = (
@@ -254,7 +254,7 @@ class SectionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedMod
             'parent'
         )
 
-class FeatSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class FeatSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Feat
         fields = (
@@ -268,7 +268,7 @@ class FeatSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelS
             'document__url'
         )
 
-class ConditionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class ConditionSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Condition
         fields = (
@@ -280,7 +280,7 @@ class ConditionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedM
             'document__url'
         )
 
-class SubraceSerializer(serializers.HyperlinkedModelSerializer):
+class SubraceSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Subrace
         fields = ('name',
@@ -294,7 +294,7 @@ class SubraceSerializer(serializers.HyperlinkedModelSerializer):
         'document__url'
     )
 
-class RaceSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class RaceSerializer(DynamicFieldsHyperlinkedModelSerializer):
     subraces = SubraceSerializer(many=True,read_only=True)
     class Meta:
         model = models.Race
@@ -333,7 +333,7 @@ class ArchetypeSerializer(serializers.HyperlinkedModelSerializer):
             'document__url'
         )
 
-class CharClassSerializer(serializers.HyperlinkedModelSerializer):
+class CharClassSerializer(DynamicFieldsHyperlinkedModelSerializer):
     archetypes = ArchetypeSerializer(many=True,read_only=True)
     class Meta:
         model = models.CharClass
@@ -360,7 +360,7 @@ class CharClassSerializer(serializers.HyperlinkedModelSerializer):
             'document__url'
         )
 
-class MagicItemSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
+class MagicItemSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.MagicItem
         fields = (
@@ -375,7 +375,7 @@ class MagicItemSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedM
             'document__url'
         )
 
-class WeaponSerializer(serializers.HyperlinkedModelSerializer):
+class WeaponSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Weapon
         fields = (
@@ -392,7 +392,7 @@ class WeaponSerializer(serializers.HyperlinkedModelSerializer):
             'weight',
             'properties')
 
-class ArmorSerializer(serializers.HyperlinkedModelSerializer):
+class ArmorSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Armor
         fields = (

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -40,7 +40,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         model = User
         fields = ('url', 'username', 'email', 'groups')
 
-class DocumentSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class DocumentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
             model = models.Document
             fields = (
@@ -62,7 +62,7 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
         model = Group
         fields = ('url', 'name')
 
-class MonsterSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class MonsterSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer, serializers.ModelSerializer):
     
     speed = serializers.SerializerMethodField()
     environments = serializers.SerializerMethodField()
@@ -215,7 +215,7 @@ class SpellListSerializer(DynamicFieldsModelSerializer):
             'document__url'
         )
 
-class BackgroundSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class BackgroundSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Background
         fields = (
@@ -235,12 +235,12 @@ class BackgroundSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class PlaneSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class PlaneSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Plane
         fields = ('slug','name','desc','document__slug', 'document__title', 'document__url')
 
-class SectionSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class SectionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Section
         fields = (
@@ -254,7 +254,7 @@ class SectionSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'parent'
         )
 
-class FeatSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class FeatSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Feat
         fields = (
@@ -268,7 +268,7 @@ class FeatSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class ConditionSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class ConditionSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Condition
         fields = (
@@ -280,7 +280,7 @@ class ConditionSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class SubraceSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class SubraceSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Subrace
         fields = ('name',
@@ -294,7 +294,7 @@ class SubraceSerializer(DynamicFieldsHyperlinkedModelSerializer):
         'document__url'
     )
 
-class RaceSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class RaceSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
     subraces = SubraceSerializer(many=True,read_only=True)
     class Meta:
         model = models.Race
@@ -320,7 +320,7 @@ class RaceSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class ArchetypeSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class ArchetypeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Archetype
         fields = (
@@ -333,7 +333,7 @@ class ArchetypeSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class CharClassSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class CharClassSerializer(serializers.HyperlinkedModelSerializer):
     archetypes = ArchetypeSerializer(many=True,read_only=True)
     class Meta:
         model = models.CharClass
@@ -360,7 +360,7 @@ class CharClassSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class MagicItemSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class MagicItemSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.MagicItem
         fields = (
@@ -375,7 +375,7 @@ class MagicItemSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class WeaponSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class WeaponSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Weapon
         fields = (
@@ -392,7 +392,7 @@ class WeaponSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'weight',
             'properties')
 
-class ArmorSerializer(DynamicFieldsHyperlinkedModelSerializer):
+class ArmorSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Armor
         fields = (

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from api import models
 from api import search_indexes
 
+
 class ManifestSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Manifest
@@ -26,6 +27,13 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
                 existing = set(self.fields.keys())
                 for field_name in existing - allowed:
                     self.fields.pop(field_name)
+
+class DynamicFieldsHyperlinkedModelSerializer(
+    DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer
+    ):
+    """Abstract base class to be inherited by Serializers that both use
+    dynamic fields as well as hyperlinked relationships."""
+    pass
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -280,7 +280,7 @@ class ConditionSerializer(DynamicFieldsHyperlinkedModelSerializer):
             'document__url'
         )
 
-class SubraceSerializer(serializers.HyperlinkedModelSerializer):
+class SubraceSerializer(DynamicFieldsHyperlinkedModelSerializer):
     class Meta:
         model = models.Subrace
         fields = ('name',


### PR DESCRIPTION
In order to fix #300, changed `CharClassSerializer` (as well as other serializers that do not currently support dynamic field serialization) to inherit from `DynamicFieldsModelSerializer`. Did so by creating an abstract base class called `DynamicFieldsHyperlinkedModelSerializer` (hate how long that name is, but it is technically the most correct name for it) that inherits from both `DynamicFieldsModelSerializer` and `serializers.HyperlinkedModelSerializer` and modified all serializer classes that inherited from both of those classes individually, as well as all serializers that inherited from only `serializers.HyperlinkedModelSerializer` to inherit from this new abstract class.
 
As a part of this change, also modifed `DynamicFieldsModelSerializer` to use the line 
```python
if 'request' in self.context:
```
instead of 
```python
if self.context['request']:
```
as the latter caused a bug when the `SubraceSerializer` inherited from the DFMS, as `SubraceSerializer` can be called from within `RaceSerializer`, in which case the `request` key does not exist, and an error is thrown.