### PR TITLE
Fix CR values for TOB3

### DIFF
--- a/data/tome_of_beasts_3/monsters.json
+++ b/data/tome_of_beasts_3/monsters.json
@@ -35,7 +35,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 13",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Edged Scales",
@@ -108,7 +108,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Bloodthirsty Pounce",
@@ -186,7 +186,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "understands the languages of its creator but can’t speak",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -258,7 +258,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Giant, Orc",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Infernal Runes",
@@ -332,7 +332,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Dwarvish",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Forest of Pikes",
@@ -396,7 +396,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 60', darkvision 120', passive Perception 22",
   "languages": "Common, Draconic",
-  "challenge_rating": 16,
+  "challenge_rating": "16",
   "special_abilities": [
    {
     "name": "Legendary Resistance (3/Day)",
@@ -494,7 +494,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
   "senses": "passive Perception 10",
   "languages": "—",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Blood Sense",
@@ -560,7 +560,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "any three languages",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Knowledge Charm",
@@ -639,7 +639,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "Auran, Common",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Elemental Demise",
@@ -705,7 +705,7 @@
   "condition_immunities": "",
   "senses": "darkvision 120', passive Perception 15",
   "languages": "Abyssal, Common, Infernal",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Inner Light",
@@ -782,7 +782,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, poisoned",
   "senses": "darkvision 120', passive Perception 15",
   "languages": "all, telepathy 60'",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Death’s Accomplice",
@@ -867,7 +867,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 30', passive Perception 10",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Bladed Shell",
@@ -939,7 +939,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 30', darkvision 120', passive Perception 21",
   "languages": "Common, Draconic",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Sand Camouflage",
@@ -1018,7 +1018,7 @@
   "condition_immunities": "paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Giant",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -1101,7 +1101,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, unconscious",
   "senses": "darkvision 60', tremorsense 60', passive Perception 12",
   "languages": "Sylvan, Terran",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Earth Glide",
@@ -1191,7 +1191,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 60', darkvision 60' passive Perception 13",
   "languages": "Common, Draconic, Sylvan",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Floral Camouflage",
@@ -1266,7 +1266,7 @@
   "condition_immunities": "",
   "senses": "darkvision 120', passive Perception 12",
   "languages": "Undercommon",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Elusive",
@@ -1347,7 +1347,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 11",
   "languages": "Common, Dwarvish, Infernal, Undercommon",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Insanity",
@@ -1426,7 +1426,7 @@
   "condition_immunities": "",
   "senses": "blindsight 120', passive Perception 15",
   "languages": "—",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Echolocation",
@@ -1504,7 +1504,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "Common, Auran",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Elemental Weapons",
@@ -1577,7 +1577,7 @@
   "condition_immunities": "frightened, poisoned",
   "senses": "passive Perception 13",
   "languages": "—",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Trampling Charge",
@@ -1651,7 +1651,7 @@
   "condition_immunities": "blinded, deafened, exhaustion",
   "senses": "blindsight 60' (blind beyond), passive Perception 10",
   "languages": "—",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Undead Creator",
@@ -1718,7 +1718,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 10",
   "languages": "Aquan, Sylvan",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -1792,7 +1792,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 9",
   "languages": "Common, Dwarvish",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Dwarven Fleet Foot",
@@ -1864,7 +1864,7 @@
   "condition_immunities": "exhaustion, poisoned, prone",
   "senses": "tremorsense 120', passive Perception 17",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "False",
@@ -1938,7 +1938,7 @@
   "condition_immunities": "unconscious",
   "senses": "passive Perception 12",
   "languages": "Common",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Spider Climb",
@@ -2013,7 +2013,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 9",
   "languages": "Giant",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Stone Chomper",
@@ -2098,7 +2098,7 @@
   "condition_immunities": "exhaustion, poisoned",
   "senses": "darkvision 120', passive Perception 13",
   "languages": "Ignan",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Conditional Invisibility",
@@ -2177,7 +2177,7 @@
   "condition_immunities": "charmed, frightened, paralyzed, poisoned",
   "senses": "blindsight 90', passive Perception 12",
   "languages": "—",
-  "challenge_rating": 19,
+  "challenge_rating": "19",
   "special_abilities": [
    {
     "name": "Flyby",
@@ -2275,7 +2275,7 @@
   "condition_immunities": "petrified, prone",
   "senses": "tremorsense 30', passive Perception 12",
   "languages": "understands Common and Void Speech but can’t speak",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -2362,7 +2362,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 30', darkvision 120', passive Perception 18",
   "languages": "Common, Draconic",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "actions": [
    {
     "name": "Multiattack",
@@ -2429,7 +2429,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "darkvision 120', tremorsense 60', passive Perception 16",
   "languages": "understands all but can’t speak, telepathy 120'",
-  "challenge_rating": 16,
+  "challenge_rating": "16",
   "special_abilities": [
    {
     "name": "Deathlights",
@@ -2549,7 +2549,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 10",
   "languages": "any two languages",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Divine Weapons",
@@ -2625,7 +2625,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Dwarvish",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Forest of Pikes",
@@ -2705,7 +2705,7 @@
   "condition_immunities": "exhaustion, poisoned",
   "senses": "darkvision 120', passive Perception 12",
   "languages": "Infernal, telepathy 120'",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Devil’s Sight",
@@ -2798,7 +2798,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "understands Abyssal but can’t speak",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Aquatic Invisibility",
@@ -2867,7 +2867,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Infernal",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Limited Magic Immunity",
@@ -2938,7 +2938,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
   "senses": "passive Perception 10",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -3012,7 +3012,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 11",
   "languages": "Abyssal, Common, Dwarvish, Undercommon",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Insanity",
@@ -3090,7 +3090,7 @@
   "condition_immunities": "exhaustion, poisoned",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "—",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Glowing Organs",
@@ -3168,7 +3168,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 15",
   "languages": "—",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Acidic Fog",
@@ -3253,7 +3253,7 @@
   "condition_immunities": "charmed, frightened, poisoned",
   "senses": "blindsight 30', darkvision 60', passive Perception 16",
   "languages": "Common, Draconic",
-  "challenge_rating": 15,
+  "challenge_rating": "15",
   "special_abilities": [
    {
     "name": "Legendary Resistance (3/Day)",
@@ -3361,7 +3361,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 60', passive Perception 15",
   "languages": "understands Common and Terran, but can’t speak",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Aura of Chaos",
@@ -3441,7 +3441,7 @@
   "condition_immunities": "",
   "senses": "blindsight 60', passive Perception 17",
   "languages": "Auran, + any two languages",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Air Senses",
@@ -3521,7 +3521,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60' (otter &amp; hybrid forms only), passive Perception 14",
   "languages": "Common (can’t speak in otter form)",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Hold Breath",
@@ -3599,7 +3599,7 @@
   "condition_immunities": "poisoned",
   "senses": "passive Perception 14",
   "languages": "Common",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Impaling Charge",
@@ -3678,7 +3678,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common, Elvish, Sylvan",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Painted for War",
@@ -3751,7 +3751,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Fiery Nature",
@@ -3829,7 +3829,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 9",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -3903,7 +3903,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Sylvan",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Arm Spine Regrowth",
@@ -3981,7 +3981,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 8",
   "languages": "[em/]",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Firesight",
@@ -4056,7 +4056,7 @@
   "condition_immunities": "",
   "senses": "darkvision 30', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Apposable Thumbs",
@@ -4138,7 +4138,7 @@
   "condition_immunities": "blinded, charmed, frightened, prone, stunned",
   "senses": "truesight 60', passive Perception 17",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Consumed by Rage (Anger Only)",
@@ -4231,7 +4231,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "Common (can’t speak in crocodile form)",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Hold Breath (Crocodile or Hybrid Form Only)",
@@ -4307,7 +4307,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, poisoned",
   "senses": "darkvision 60', passive Perception 16",
   "languages": "Abyssal, Common, telepathy 120'",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Corpse Stride",
@@ -4400,7 +4400,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "understands creator's languages, can’t speak",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -4504,7 +4504,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "the languages it knew in life",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Aura of the Forgotten",
@@ -4587,7 +4587,7 @@
   "condition_immunities": "blinded, deafened, poisoned",
   "senses": "blindsight 60' (blind beyond), passive Perception 11",
   "languages": "understands Abyssal and Infernal but can’t speak",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Magic Resistance",
@@ -4655,7 +4655,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 60', passive Perception 16",
   "languages": "—",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Cheek Worm Regrowth",
@@ -4741,7 +4741,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common, Dwarven, Giant",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Forged Forgery",
@@ -4819,7 +4819,7 @@
   "condition_immunities": "poisoned ",
   "senses": "blindsight 30', passive Perception 11",
   "languages": "Sylvan",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Rubbery Flesh",
@@ -4889,7 +4889,7 @@
   "condition_immunities": "",
   "senses": "blindsight 120' (blind beyond), passive Perception 17",
   "languages": "understands the languages of its host companion but can’t speak",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Symbiote",
@@ -4963,7 +4963,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common, Giant",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Armored Berserker",
@@ -5043,7 +5043,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 11",
   "languages": "—",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Keen Hearing and Smell",
@@ -5112,7 +5112,7 @@
   "condition_immunities": "charmed, frightened, paralyzed, poisoned, restrained",
   "senses": "blindsight 90' (blind beyond), passive Perception 11",
   "languages": "—",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Discordant Drone",
@@ -5189,7 +5189,7 @@
   "condition_immunities": "charmed, frightened, paralyzed, poisoned",
   "senses": "blindsight 10', passive Perception 17",
   "languages": "—",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Final Fury",
@@ -5271,7 +5271,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 16",
   "languages": "Giant",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "actions": [
    {
     "name": "Multiattack",
@@ -5331,7 +5331,7 @@
   "condition_immunities": "",
   "senses": "blindsight 60', passive Perception 10",
   "languages": "—",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Blood Sense",
@@ -5404,7 +5404,7 @@
   "condition_immunities": "exhaustion",
   "senses": "blindsight 120' (whale form only), darkvision 120' passive Perception 17",
   "languages": "Aquan, Common, Giant",
-  "challenge_rating": 15,
+  "challenge_rating": "15",
   "special_abilities": [
    {
     "name": "Echolocation (Whale Form Only)",
@@ -5497,7 +5497,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', tremorsense 60', passive Perception 17",
   "languages": "Deep Speech, Undercommon, telepathy 100' (300' w/its own kind)",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Mutagenic Venom",
@@ -5569,7 +5569,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "understands Deep Speech and Void Speech but has limited speech",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -5647,7 +5647,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, poisoned",
   "senses": "blindsight 60' (blind beyond), passive Perception 10",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Spiny Defense",
@@ -5714,7 +5714,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "passive Perception 14",
   "languages": "Common, Sylvan",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Commanding Bulk",
@@ -5802,7 +5802,7 @@
   "condition_immunities": "frightened",
   "senses": "passive Perception 15",
   "languages": "Common and one other language",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Aura of Courage and Protection",
@@ -5881,7 +5881,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Draconic",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Ethereal Sight",
@@ -5957,7 +5957,7 @@
   "condition_immunities": "blinded, deafened, prone",
   "senses": "tremorsense 60', passive Perception 15",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Bountiful Death",
@@ -6033,7 +6033,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, prone",
   "senses": "darkvision 120', passive Perception 13",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Celestial Weapons",
@@ -6124,7 +6124,7 @@
   "condition_immunities": "charmed, exhausted, frightened, poisoned",
   "senses": "truesight 120', passive Perception 23",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 20,
+  "challenge_rating": "20",
   "special_abilities": [
    {
     "name": "Angelic Weapons",
@@ -6263,7 +6263,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 19",
   "languages": "any three languages",
-  "challenge_rating": 12,
+  "challenge_rating": "12",
   "special_abilities": [
    {
     "name": "Armor of Foresight",
@@ -6345,7 +6345,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 30', passive Perception 14",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Calming Presence",
@@ -6411,7 +6411,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Common, Infernal",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Devil’s Sight",
@@ -6481,7 +6481,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Sylvan",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Deep Roots",
@@ -6543,7 +6543,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "Common, Trollkin",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Regeneration",
@@ -6623,7 +6623,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "—",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Dismembering Strike",
@@ -6703,7 +6703,7 @@
   "condition_immunities": "blinded, frightened",
   "senses": "darkvision 60', tremorsense 30', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Blood Frenzy",
@@ -6773,7 +6773,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Giant, Infernal",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Death Malison",
@@ -6856,7 +6856,7 @@
   "condition_immunities": "blinded, deafened, exhaustion, poisoned",
   "senses": "blindsight 60' (blind beyond), passive Perception 13",
   "languages": "—",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -6942,7 +6942,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Frozen to the Spot",
@@ -7022,7 +7022,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 10",
   "languages": "Common, Giant",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "actions": [
    {
     "name": "Multiattack",
@@ -7089,7 +7089,7 @@
   "condition_immunities": "charmed, exhaustion, frightened",
   "senses": "darkvision 120', passive Perception 19",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -7176,7 +7176,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Sylvan",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Beast Passivism",
@@ -7254,7 +7254,7 @@
   "condition_immunities": "blinded, charmed, deafened, frightened, poisoned, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 15 ",
   "languages": "Common, Deep Speech, telepathy 120'",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Colony Cluster",
@@ -7331,7 +7331,7 @@
   "condition_immunities": "",
   "senses": "darkvision 120', truesight 30', passive Perception 16",
   "languages": "Common, Draconic, Deep Speech, telepathy 120'",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Pierce the Veil",
@@ -7417,7 +7417,7 @@
   "condition_immunities": "blinded, prone",
   "senses": "blindsight 60' (blind beyond), tremorsense 60', passive Perception 18",
   "languages": "—",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Acidic Coating",
@@ -7505,7 +7505,7 @@
   "condition_immunities": "blinded, deafened, poisoned, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 10 ",
   "languages": "Sylvan, telepathy 60'",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Pandemonium Fruit",
@@ -7574,7 +7574,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 30', passive Perception 10",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Death Trap",
@@ -7651,7 +7651,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 8",
   "languages": "any two languages",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Malleable Physiology",
@@ -7715,7 +7715,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 13",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Pack Tactics",
@@ -7783,7 +7783,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, poisoned, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 8",
   "languages": "—",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -7862,7 +7862,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Draconic",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Diving Pounce",
@@ -7944,7 +7944,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "understands the languages of its creator but can’t speak",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -8020,7 +8020,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, petrified, poisoned, prone",
   "senses": "darkvision 60', passive Perception 10 ",
   "languages": "understands the languages of its creator but can’t speak",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -8120,7 +8120,7 @@
   "condition_immunities": "charmed, exhaustion",
   "senses": "blindsight 30', darkvision 60', passive Perception 14",
   "languages": "Common, Void Speech",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Sunlight Sensitivity",
@@ -8192,7 +8192,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "Common, Terran",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "actions": [
    {
     "name": "Battleaxe",
@@ -8256,7 +8256,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 16",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -8340,7 +8340,7 @@
   "condition_immunities": "paralyzed, poisoned, stunned",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Celestial, Common",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Blur of Motion",
@@ -8448,7 +8448,7 @@
   "condition_immunities": "",
   "senses": "truesight 60', passive Perception 16",
   "languages": "Thrippish, Void Speech",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Feybane Weapons",
@@ -8529,7 +8529,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 10', darkvision 60', passive Perception 16",
   "languages": "Draconic",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Sand Camouflage",
@@ -8600,7 +8600,7 @@
   "condition_immunities": "exhaustion, poisoned",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common, Giant, Sylvan",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Disease Sense",
@@ -8678,7 +8678,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "understands Primordial but can’t speak",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Blood Sense",
@@ -8754,7 +8754,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "truesight 120', passive Perception 19",
   "languages": "understands Abyssal, Common, Infernal, and Void Speech but can’t speak, telepathy 120'",
-  "challenge_rating": 14,
+  "challenge_rating": "14",
   "special_abilities": [
    {
     "name": "Hungry Void Traveler",
@@ -8829,7 +8829,7 @@
   "condition_immunities": "poisoned, prone",
   "senses": "darkvision 90', passive Perception 11",
   "languages": "Abyssal, telepathy 120'",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -8909,7 +8909,7 @@
   "condition_immunities": "",
   "senses": "darkvision 120', passive Perception 10",
   "languages": "Common, Dwarvish, Undercommon, Void Speech",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Insanity",
@@ -8991,7 +8991,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "understands creator's languages but can't speak",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -9077,7 +9077,7 @@
   "condition_immunities": "prone",
   "senses": "blindsight 10', tremorsense 60', passive Perception 9",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Beast of Burden",
@@ -9153,7 +9153,7 @@
   "condition_immunities": "paralyzed, petrified, poisoned, prone",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "understands Giant but can’t speak",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -9228,7 +9228,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 30', passive Perception 14",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Downdraft",
@@ -9307,7 +9307,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 9",
   "languages": "understands Common and Darakhul but can’t speak",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Siege Monster",
@@ -9382,7 +9382,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned",
   "senses": "darkvision 120', passive Perception 15",
   "languages": "Celestial, Common, telepathy 60'",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -9474,7 +9474,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -9556,7 +9556,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', tremorsense 60', passive Perception 12",
   "languages": "Giant",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -9629,7 +9629,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 11",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -9709,7 +9709,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Draconic",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Keen Smell",
@@ -9778,7 +9778,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Giant",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Distracting Rattle",
@@ -9857,7 +9857,7 @@
   "condition_immunities": "paralyzed, poisoned, unconscious",
   "senses": "blindsight 120', darkvision 60', passive Perception 17",
   "languages": "Aquan, Draconic",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -9949,7 +9949,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, prone, restrained",
   "senses": "truesight 120', passive Perception 23",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 21,
+  "challenge_rating": "21",
   "special_abilities": [
    {
     "name": "Legendary Resistance (3/Day)",
@@ -10049,7 +10049,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 9",
   "languages": "Common, Elvish, Sylvan",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Invisibility Hat",
@@ -10119,7 +10119,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 120' (blind beyond), passive Perception 17",
   "languages": "Common, Giant, Primordial",
-  "challenge_rating": 12,
+  "challenge_rating": "12",
   "special_abilities": [
    {
     "name": "Limited Amphibiousness",
@@ -10193,7 +10193,7 @@
   "condition_immunities": "exhaustion, petrified",
   "senses": "passive Perception 13",
   "languages": "any one language (usually Common)",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Burning Cold",
@@ -10268,7 +10268,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, unconscious",
   "senses": "darkvision 30', tremorsense 30', passive Perception 12",
   "languages": "Terran",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Earth Glide",
@@ -10345,7 +10345,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "Common, Ignan",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Fiery Feathers",
@@ -10411,7 +10411,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Giant",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -10496,7 +10496,7 @@
   "condition_immunities": "charmed, poisoned",
   "senses": "darkvision 120', passive Perception 17",
   "languages": "Aquan, Common, Sylvan",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -10589,7 +10589,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned",
   "senses": "darkvision 60', tremorsense 60', passive Perception 12",
   "languages": "Aquan, Terran",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Puddle Jump",
@@ -10660,7 +10660,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
   "senses": "blindsight 60', passive Perception 10",
   "languages": "–",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Blood Sense",
@@ -10734,7 +10734,7 @@
   "condition_immunities": "charmed, exhaustion, poisoned",
   "senses": "blindsight 60', darkvision 120', passive Perception 17",
   "languages": "Darakhul, Giant, Undercommon",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Passage Guardian",
@@ -10812,7 +10812,7 @@
   "condition_immunities": "",
   "senses": "darkvision 120', passive Perception 16 ",
   "languages": "Common, Draconic",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Expert Wrestler",
@@ -10914,7 +10914,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned",
   "senses": "passive Perception 12",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Swarm",
@@ -10981,7 +10981,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 30', passive Perception 12",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Well-Grounded",
@@ -11053,7 +11053,7 @@
   "condition_immunities": "petrified",
   "senses": "darkvision 60', passive Perception 16",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Back Spikes",
@@ -11136,7 +11136,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 15",
   "languages": "understands Abyssal but can’t speak",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Fiery Blood",
@@ -11217,7 +11217,7 @@
   "condition_immunities": "stunned",
   "senses": "darkvision 120', passive Perception 18",
   "languages": "understands Aquan and Deep Speech, but can’t speak",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Telescoping Eyes",
@@ -11291,7 +11291,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "darkvision 90', truesight 60', passive Perception 13",
   "languages": "understands Abyssal and Common but can’t speak",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Blood Frenzy",
@@ -11375,7 +11375,7 @@
   "condition_immunities": "charmed, frightened, poisoned, restrained",
   "senses": "blindsight 90' (blind beyond), passive Perception 12",
   "languages": "—",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Flesh-Eating Aura",
@@ -11461,7 +11461,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "knows creator's, can’t speak",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -11543,7 +11543,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "blindsight 60' (blind beyond), passive Perception 7",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Antimagic Susceptibility",
@@ -11621,7 +11621,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 8",
   "languages": "Giant",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Regeneration",
@@ -11690,7 +11690,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 11",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Keen Smell",
@@ -11767,7 +11767,7 @@
   "condition_immunities": "charmed",
   "senses": "passive Perception 13",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Herd-Hidden (Herd Animal Form Only)",
@@ -11841,7 +11841,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 8",
   "languages": "Common, Void Speech",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Erratic Movement",
@@ -11924,7 +11924,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 7",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -12009,7 +12009,7 @@
   "condition_immunities": "poisoned",
   "senses": "blindsight 120' (blind beyond), passive Perception 8",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Death Spores",
@@ -12071,7 +12071,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common, Trollkin",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Regeneration",
@@ -12146,7 +12146,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, unconscious",
   "senses": "darkvision 60', tremorsense 30', passive Perception 10",
   "languages": "Terran",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Charge",
@@ -12224,7 +12224,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 11",
   "languages": "understands Common, can’t speak",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -12295,7 +12295,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained",
   "senses": "darkvision 60', passive Perception 16",
   "languages": "any languages it knew in life",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Frozen Reign",
@@ -12398,7 +12398,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "blindsight 120' (blind beyond), passive Perception 17",
   "languages": "Deep Speech",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Changing Form",
@@ -12469,7 +12469,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 8",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -12547,7 +12547,7 @@
   "condition_immunities": "poisoned",
   "senses": "blindsight 60' (blind beyond), passive Perception 10",
   "languages": "understands the languages of its creator but can’t speak",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Gut Lassos",
@@ -12621,7 +12621,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Draconic",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Crafty",
@@ -12706,7 +12706,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Primordial",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Elemental Demise",
@@ -12787,7 +12787,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, prone, unconscious ",
   "senses": "blindsight 60', passive Perception 15",
   "languages": "understands Terran but can’t speak",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Elemental Nature",
@@ -12876,7 +12876,7 @@
   "condition_immunities": "prone",
   "senses": "tremorsense 60', passive Perception 16",
   "languages": "Common, Ignan",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Tendril Whip Regrowth",
@@ -12963,7 +12963,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, grappled, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 16",
   "languages": "—",
-  "challenge_rating": 12,
+  "challenge_rating": "12",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -13061,7 +13061,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 30', passive Perception 10",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -13143,7 +13143,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "blindsight 120', passive Perception 12",
   "languages": "Primordial",
-  "challenge_rating": 16,
+  "challenge_rating": "16",
   "special_abilities": [
    {
     "name": "Elemental Nature",
@@ -13218,7 +13218,7 @@
   "condition_immunities": "poisoned, prone",
   "senses": "blindsight 10', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Jungle Camouflage",
@@ -13293,7 +13293,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 16",
   "languages": "Draconic",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Aching Venom",
@@ -13371,7 +13371,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, incapacitated, paralyzed, petrified, poisoned, stunned, unconscious",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "understands one language known by its creator but can’t speak",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -13443,7 +13443,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "darkvision 60', passive Perception 8",
   "languages": "—",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -13510,7 +13510,7 @@
   "condition_immunities": "",
   "senses": "blindsight 30', passive Perception 11",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Extradimensional Bag",
@@ -13581,7 +13581,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 10",
   "languages": "Common, Sylvan",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Reduce",
@@ -13656,7 +13656,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "Sylvan",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Diurnal",
@@ -13734,7 +13734,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -13821,7 +13821,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, poisoned",
   "senses": "darkvision 90', passive Perception 18",
   "languages": "Common + up to three other languages",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Heretic Sense",
@@ -13916,7 +13916,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 16",
   "languages": "Common, Sylvan",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Magic Resistance",
@@ -13993,7 +13993,7 @@
   "condition_immunities": "charmed, exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained",
   "senses": "passive Perception 13",
   "languages": "any languages it knew in life",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Incorporeal Movement",
@@ -14074,7 +14074,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "Sylvan",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Overpowering Stench",
@@ -14141,7 +14141,7 @@
   "condition_immunities": "",
   "senses": "darkvision 120', passive Perception 10 ",
   "languages": "Celestial, telepathy 60'",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Celestial Weapons",
@@ -14222,7 +14222,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Common, Draconic",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Drake Mount",
@@ -14305,7 +14305,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, prone, unconscious",
   "senses": "blindsight 60', passive Perception 12",
   "languages": "understands Terran but can’t speak",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Elemental Nature",
@@ -14390,7 +14390,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -14470,7 +14470,7 @@
   "condition_immunities": "charmed, frightened, poisoned",
   "senses": "darkvision 120', passive Perception 15",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Devil’s Sight",
@@ -14563,7 +14563,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "passive Perception 6",
   "languages": "—",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Beast of Burden",
@@ -14633,7 +14633,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60', passive Perception 10",
   "languages": "—",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "False",
@@ -14714,7 +14714,7 @@
   "condition_immunities": "poisoned",
   "senses": "passive Perception 11",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Shrill Screech",
@@ -14791,7 +14791,7 @@
   "condition_immunities": "",
   "senses": "blindsight 60' (blind beyond), passive Perception 11",
   "languages": "—",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Barnacle Shivers",
@@ -14863,7 +14863,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "Common, Terran",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "actions": [
    {
     "name": "Multiattack",
@@ -14932,7 +14932,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "Common, Sylvan",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Magic Resistance",
@@ -15002,7 +15002,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 16",
   "languages": "Common, Infernal",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Limited Magic Immunity",
@@ -15086,7 +15086,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, poisoned, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 12",
   "languages": "Abyssal, Common, Infernal, telepathy 120'",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Amorphous ",
@@ -15168,7 +15168,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "the languages it knew in life",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Bloodthirsty",
@@ -15249,7 +15249,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 11",
   "languages": "Aquan, Common",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Hold Breath",
@@ -15315,7 +15315,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Common, Sylvan",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Devouring Charge (Boar Form Only)",
@@ -15398,7 +15398,7 @@
   "condition_immunities": "exhaustion, poisoned, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 12",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Cursed Plant",
@@ -15479,7 +15479,7 @@
   "condition_immunities": "charmed",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Abyssal, Common, Infernal",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Bloodthirsty",
@@ -15565,7 +15565,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 18",
   "languages": "Abyssal, Common, Infernal, telepathy 120'",
-  "challenge_rating": 14,
+  "challenge_rating": "14",
   "special_abilities": [
    {
     "name": "Devil’s Sight",
@@ -15649,7 +15649,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 10",
   "languages": "understands Aquan but can’t speak",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Fear of Fire",
@@ -15723,7 +15723,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "blindsight 120' (blind beyond), passive Perception 15",
   "languages": "Primordial",
-  "challenge_rating": 21,
+  "challenge_rating": "21",
   "special_abilities": [
    {
     "name": "Elemental Attacks",
@@ -15841,7 +15841,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 13",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Perfect Landing",
@@ -15917,7 +15917,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 15",
   "languages": "Common, Sylvan",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Keen Sight and Smell",
@@ -16006,7 +16006,7 @@
   "condition_immunities": "",
   "senses": "truesight 60', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Fluorescing Challenge",
@@ -16075,7 +16075,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 8",
   "languages": "Common, Giant",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Imposing Figure",
@@ -16154,7 +16154,7 @@
   "condition_immunities": "",
   "senses": "darkvision 120', passive Perception 16",
   "languages": "—",
-  "challenge_rating": 15,
+  "challenge_rating": "15",
   "special_abilities": [
    {
     "name": "Keen Smell",
@@ -16245,7 +16245,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Infernal",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Arcane Weapons",
@@ -16333,7 +16333,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 13",
   "languages": "—",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Flyby",
@@ -16399,7 +16399,7 @@
   "condition_immunities": "",
   "senses": "blindsight 10', darkvision 120', passive Perception 14",
   "languages": "Dwarvish, Undercommon",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Underworld Camouflage",
@@ -16465,7 +16465,7 @@
   "condition_immunities": "poisoned, prone",
   "senses": "darkvision 60', tremorsense 30', passive Perception 9",
   "languages": "understands Common and Darakhul but can’t speak",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Necrotic Prison",
@@ -16533,7 +16533,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, poisoned",
   "senses": "darkvision 90', passive Perception 20 ",
   "languages": "Common",
-  "challenge_rating": 19,
+  "challenge_rating": "19",
   "special_abilities": [
    {
     "name": "Death-Infused Weapons",
@@ -16666,7 +16666,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "Abyssal, Common",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -16739,7 +16739,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 8",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -16822,7 +16822,7 @@
   "condition_immunities": "",
   "senses": "xx, passive Perception xx",
   "languages": "as Phoenixborn",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Fiery Feathers and Rebirth (1/Day)",
@@ -16899,7 +16899,7 @@
   "condition_immunities": "charmed, exhaustion, frightened",
   "senses": "truesight 120', passive Perception 20",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Celestial Weapons",
@@ -16993,7 +16993,7 @@
   "condition_immunities": "blinded, charmed, exhaustion, frightened, poisoned, restrained, unconscious",
   "senses": "blindsight 120' (blind beyond), passive Perception 15",
   "languages": "Common, Sylvan",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Grassland Camouflage",
@@ -17073,7 +17073,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common, Trollkin",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Brutal Claws",
@@ -17157,7 +17157,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "truesight 120', passive Perception 13",
   "languages": "understands creator's languages but can’t speak",
-  "challenge_rating": 16,
+  "challenge_rating": "16",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -17243,7 +17243,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, unconscious",
   "senses": "darkvision 120', passive Perception 16",
   "languages": "Common + up to two languages of its creator",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -17341,7 +17341,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "blindsight 10', darkvision 60', passive Perception 15",
   "languages": "Common, Elvish, Umbral",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Fey Ancestry",
@@ -17431,7 +17431,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "understands Abyssal but can’t speak",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Bloodthirsty",
@@ -17494,7 +17494,7 @@
   "condition_immunities": "",
   "senses": "blindsight 30', passive Perception 8",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Compact",
@@ -17555,7 +17555,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -17645,7 +17645,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "Common, Giant",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Healing Lotuscraft",
@@ -17717,7 +17717,7 @@
   "condition_immunities": "charmed, frightened, paralyzed, petrified, prone, restrained, stunned",
   "senses": "blindsight 30', passive Perception 8",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Constant Clacking",
@@ -17781,7 +17781,7 @@
   "condition_immunities": "",
   "senses": "blindsight 120' (blind beyond), passive Perception 14",
   "languages": "Common, telepathy 120' (only w/other hirudine stalkers)",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -17854,7 +17854,7 @@
   "condition_immunities": "blinded, charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 120', passive Perception 10",
   "languages": "understands creator's languages but can't speak",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Adaptable Locomotion",
@@ -17941,7 +17941,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 60', darkvision 120', passive Perception 26",
   "languages": "Common, Draconic, Terran",
-  "challenge_rating": 18,
+  "challenge_rating": "18",
   "special_abilities": [
    {
     "name": "Legendary Resistance (3/Day)",
@@ -18046,7 +18046,7 @@
   "condition_immunities": "exhaustion, poisoned",
   "senses": "passive Perception 14",
   "languages": "—",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Firesight",
@@ -18126,7 +18126,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "Aquan, Common",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Hold Breath",
@@ -18203,7 +18203,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 10",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -18281,7 +18281,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Keen Smell",
@@ -18351,7 +18351,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 10",
   "languages": "—",
-  "challenge_rating": 0,
+  "challenge_rating": "0",
   "special_abilities": [
    {
     "name": "Keen Sight",
@@ -18409,7 +18409,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 9",
   "languages": "Common, Draconic",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Bickering Heads",
@@ -18491,7 +18491,7 @@
   "condition_immunities": "deafened",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Pack Tactics",
@@ -18564,7 +18564,7 @@
   "condition_immunities": "poisoned",
   "senses": "blindsight 30', darkvision 120', passive Perception 19",
   "languages": "understands all but can’t speak, telepathy 120'",
-  "challenge_rating": 12,
+  "challenge_rating": "12",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -18666,7 +18666,7 @@
   "condition_immunities": "blinded, deafened, frightened",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Sylvan",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -18745,7 +18745,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 13",
   "languages": "Capybear",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Hold Breath",
@@ -18828,7 +18828,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhausted, frightened, paralyzed, petrified, poisoned",
   "senses": "blindsight 120' (blind beyond), passive Perception 17",
   "languages": "Void Speech, telepathy 120'",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Call of the Void",
@@ -18908,7 +18908,7 @@
   "condition_immunities": "exhaustion, poisoned",
   "senses": "blindsight 60', darkvision 300', passive Perception 16",
   "languages": "understands Primordial but can’t speak",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Elemental Traveler",
@@ -18993,7 +18993,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 10', darkvision 60', passive Perception 15",
   "languages": "Draconic",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "actions": [
    {
     "name": "Bite",
@@ -19050,7 +19050,7 @@
   "condition_immunities": "poisoned",
   "senses": "truesight 120', passive Perception 13",
   "languages": "understand Abyssal but can’t speak",
-  "challenge_rating": 18,
+  "challenge_rating": "18",
   "special_abilities": [
    {
     "name": "Magic Resistance",
@@ -19135,7 +19135,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common, Sylvan",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Aura of Honesty",
@@ -19206,7 +19206,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, unconscious",
   "senses": "darkvision 60', tremorsense 60', passive Perception 9",
   "languages": "understands Dwarvish and Terran but can’t speak",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -19283,7 +19283,7 @@
   "condition_immunities": "exhaustion, frightened, poisoned, prone",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Aura of Hope",
@@ -19370,7 +19370,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 8",
   "languages": "—",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Flowing Flesh",
@@ -19446,7 +19446,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "any two languages",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Impenetrable Ego",
@@ -19527,7 +19527,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Aquan, Deep Speech",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Pack Tactics",
@@ -19602,7 +19602,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, grappled, poisoned, prone, restrained",
   "senses": "truesight 120', passive Perception 17",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Aqueous Form",
@@ -19701,7 +19701,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone",
   "senses": "truesight 120', passive Perception 29",
   "languages": "understands all, can’t speak",
-  "challenge_rating": 30,
+  "challenge_rating": "30",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -19826,7 +19826,7 @@
   "condition_immunities": "poisoned",
   "senses": "passive Perception 12",
   "languages": "—",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "actions": [
    {
     "name": "Bite",
@@ -19888,7 +19888,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "blindsight 30', passive Perception 15",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -19959,7 +19959,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Elvish, Sylvan",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Magic Resistance",
@@ -20034,7 +20034,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Sylvan",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Plant Camouflage",
@@ -20116,7 +20116,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Infernal, telepathy 60'",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "False Appearance (Object Form Only)",
@@ -20196,7 +20196,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Sense Magic",
@@ -20279,7 +20279,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "passive Perception 10",
   "languages": "Common, Elvish, Sylvan",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Fortissimo Fibber",
@@ -20362,7 +20362,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Aquan, Common",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Blessings of the Sea Gods",
@@ -20435,7 +20435,7 @@
   "condition_immunities": "prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 15",
   "languages": "—",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -20508,7 +20508,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, incapacitated, poisoned, stunned",
   "senses": "truesight 120', passive Perception 20",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 18,
+  "challenge_rating": "18",
   "special_abilities": [
    {
     "name": "Elephantine Passivism",
@@ -20644,7 +20644,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 60', darkvision 120', passive Perception 27",
   "languages": "Common, Draconic",
-  "challenge_rating": 21,
+  "challenge_rating": "21",
   "special_abilities": [
    {
     "name": "Legendary Resistance (3/Day)",
@@ -20745,7 +20745,7 @@
   "condition_immunities": "charmed, frightened, paralyzed",
   "senses": "darkvision 60', passive Perception 19",
   "languages": "Common, Draconic, + any two languages",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Blessed Weapons",
@@ -20855,7 +20855,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "Common, Draconic, Halfling",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "",
@@ -20940,7 +20940,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "Aquan, Common, Giant",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -21020,7 +21020,7 @@
   "condition_immunities": "charmed, exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "the languages it knew in life",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Aura of Oathbreaking",
@@ -21088,7 +21088,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, unconscious",
   "senses": "darkvision 60', tremorsense 60', passive Perception 11",
   "languages": "understands Terran but can’t speak",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Earth Glide",
@@ -21156,7 +21156,7 @@
   "condition_immunities": "charmed, frightened, poisoned, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 12",
   "languages": "Deep Speech, telepathy 60'",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Mindleech Aura",
@@ -21234,7 +21234,7 @@
   "condition_immunities": "blinded, deafened, exhaustion, prone",
   "senses": "blindsight 30', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -21291,7 +21291,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "understands creator's languages but can't speak",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -21375,7 +21375,7 @@
   "condition_immunities": "deafened, exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned",
   "senses": "truesight 120', passive Perception 20",
   "languages": "understands all languages but can’t speak",
-  "challenge_rating": 15,
+  "challenge_rating": "15",
   "special_abilities": [
    {
     "name": "Invisible",
@@ -21469,7 +21469,7 @@
   "condition_immunities": "blinded, poisoned",
   "senses": "blindsight 120', passive Perception 15",
   "languages": "understands Common and Darakhul but can’t speak",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Siege Monster",
@@ -21543,7 +21543,7 @@
   "condition_immunities": "blinded, deafened, frightened",
   "senses": "tremorsense 90', passive Perception 10",
   "languages": "—",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -21622,7 +21622,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 13",
   "languages": "understands Common and Undercommon but can’t speak, telepathy 120' (with other fungi only)",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Light Absorption",
@@ -21692,7 +21692,7 @@
   "condition_immunities": "blinded, charmed, exhaustion",
   "senses": "blindsight 60' (blind beyond), passive Perception 14",
   "languages": "understands Deep Speech and Umbral but can’t speak",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Flyby",
@@ -21759,7 +21759,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "Auran, Terran",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Elemental Nature",
@@ -21828,7 +21828,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, unconscious",
   "senses": "darkvision 60', tremorsense 60', passive Perception 12",
   "languages": "Terran",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Earth Glide",
@@ -21904,7 +21904,7 @@
   "condition_immunities": "deafened",
   "senses": "passive Perception 15",
   "languages": "—",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Siege Monster",
@@ -21976,7 +21976,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 9",
   "languages": "Aquan, Sylvan",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -22049,7 +22049,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 30', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Limited Amphibiousness",
@@ -22123,7 +22123,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "—",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Charge",
@@ -22207,7 +22207,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhausted, frightened, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 8",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -22302,7 +22302,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 9",
   "languages": "Abyssal, Common, Infernal, telepathy 120'",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Memory of Shame",
@@ -22370,7 +22370,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
   "senses": "passive Perception 10",
   "languages": "—",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Corral",
@@ -22437,7 +22437,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned, prone",
   "senses": "darkvision 60', passive Perception 9",
   "languages": "understands Void Speech but can’t speak",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Mobile Grappler",
@@ -22505,7 +22505,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 11",
   "languages": "Infernal, telepathy 120'",
-  "challenge_rating": 12,
+  "challenge_rating": "12",
   "special_abilities": [
    {
     "name": "Devil’s Sight",
@@ -22588,7 +22588,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, poisoned, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 16",
   "languages": "—",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Alien Nature",
@@ -22668,7 +22668,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "truesight 60', passive Perception 17",
   "languages": "—",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -22750,7 +22750,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "Common, Sylvan",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Magic Resistance",
@@ -22828,7 +22828,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "blindsight 30', passive Perception 12",
   "languages": "Aquan",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Elemental Nature",
@@ -22902,7 +22902,7 @@
   "condition_immunities": "exhaustion, restrained, poisoned",
   "senses": "passive Perception 13",
   "languages": "any one language (usually Common)",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Evasion",
@@ -22986,7 +22986,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 16",
   "languages": "Common, Giant",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Scent of Death",
@@ -23053,7 +23053,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', tremorsense 60', passive Perception 15",
   "languages": "understands creator's languages but can’t speak",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -23133,7 +23133,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, poisoned, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 12",
   "languages": "—",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -23212,7 +23212,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "those host knew in life",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -23294,7 +23294,7 @@
   "condition_immunities": "poisoned, prone",
   "senses": "blindsight 30', darkvision 60', passive Perception 12",
   "languages": "understands Abyssal and Infernal but can’t speak",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Deadly Infestation",
@@ -23378,7 +23378,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone",
   "senses": "darkvision 60', tremorsense 60', passive Perception 12",
   "languages": "understands creator's languages but can’t speak",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -23455,7 +23455,7 @@
   "condition_immunities": "prone",
   "senses": "darkvision 60', tremorsense 60', passive Perception 14",
   "languages": "—",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Adhesive (Object or Terrain Form)",
@@ -23544,7 +23544,7 @@
   "condition_immunities": "exhaustion, poisoned, prone, unconscious",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Celestial, Common, telepathy 30'",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Flyby",
@@ -23614,7 +23614,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, prone, unconscious ",
   "senses": "blindsight 60', passive Perception 17",
   "languages": "understands Common, Terran, and Undercommon but can’t speak, telepathy 120'",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Elemental Nature",
@@ -23699,7 +23699,7 @@
   "condition_immunities": "charmed, paralyzed, poisoned",
   "senses": "blindsight 120' (blind beyond), passive Perception 13",
   "languages": "Celestial, Elvish, Sylvan, telepathy 60'",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Magic Evasion",
@@ -23784,7 +23784,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, poisoned",
   "senses": "darkvision 120', passive Perception 17",
   "languages": "Celestial, telepathy 60'",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Divine Awareness",
@@ -23873,7 +23873,7 @@
   "condition_immunities": "",
   "senses": "darkvision 120', tremorsense 30', passive Perception 14",
   "languages": "understands Undercommon but can’t speak",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Earth Climb",
@@ -23954,7 +23954,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Relentless (Recharge: Short/Long Rest)",
@@ -24015,7 +24015,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "understands Common but can't speak",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Call of the Grave",
@@ -24090,7 +24090,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, poisoned, prone",
   "senses": "truesight 120', passive Perception 20",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Angelic Weapons",
@@ -24184,7 +24184,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone",
   "senses": "darkvision 120', passive Perception 19",
   "languages": "Common, telepathy 120'",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -24265,7 +24265,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "—",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Keen Hearing and Smell",
@@ -24340,7 +24340,7 @@
   "condition_immunities": "",
   "senses": "blindsight 60' (blind beyond), passive Perception 14",
   "languages": "understands Common, + one language known by its grower, but can’t speak",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Keen Hearing",
@@ -24420,7 +24420,7 @@
   "condition_immunities": "exhaustion",
   "senses": "darkvision 60', passive Perception 17 ",
   "languages": "Common, Elvish, Giant, Sylvan",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Chilling Presence",
@@ -24505,7 +24505,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', tremorsense 30', passive Perception 15",
   "languages": "Common, Giant, Umbral",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Deceptive Steps",
@@ -24593,7 +24593,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "Auran",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Air Form",
@@ -24669,7 +24669,7 @@
   "condition_immunities": "paralyzed, unconscious",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Common, Draconic",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Fire Weakness",
@@ -24743,7 +24743,7 @@
   "condition_immunities": "paralyzed, poisoned, restrained",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Distraction",
@@ -24819,7 +24819,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 11",
   "languages": "Common, Primordial",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Elemental Weapons",
@@ -24892,7 +24892,7 @@
   "condition_immunities": "blinded, charmed, deafened, frightened, poisoned",
   "senses": "blindsight 120' (blind beyond), passive Perception 17",
   "languages": "understands Abyssal, Common, and Infernal; can’t speak",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Broken Silence",
@@ -24956,7 +24956,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "blindsight 60' (blind beyond), passive Perception 7",
   "languages": "—",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Antimagic Susceptibility",
@@ -25030,7 +25030,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, poisoned, prone",
   "senses": "tremorsense 120', blindsight 60' (blind beyond), passive Perception 14",
   "languages": "Common, Deep Speech, telepathy 120'",
-  "challenge_rating": 17,
+  "challenge_rating": "17",
   "special_abilities": [
    {
     "name": "Legendary Resistance (3/Day)",
@@ -25121,7 +25121,7 @@
   "condition_immunities": "poisoned",
   "senses": "blindsight 10', darkvision 60', passive Perception 11",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Lava Bound",
@@ -25193,7 +25193,7 @@
   "condition_immunities": "",
   "senses": "tremorsense 60', passive Perception 10",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Detect Life",
@@ -25271,7 +25271,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 10",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Hold Breath",
@@ -25333,7 +25333,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, poisoned",
   "senses": "darkvision 120', passive Perception 19",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Aura of Draconic Virtue",
@@ -25425,7 +25425,7 @@
   "condition_immunities": "",
   "senses": "blindsight 10', darkvision 60', passive Perception 12",
   "languages": "Draconic",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "Siege Monster",
@@ -25507,7 +25507,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "knows Infernal, can’t speak",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -25590,7 +25590,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Sylvan",
-  "challenge_rating": 0.25,
+  "challenge_rating": "1/4",
   "special_abilities": [
    {
     "name": "Aura of Misfortune",
@@ -25670,7 +25670,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
   "senses": "passive Perception 12",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Swarm",
@@ -25733,7 +25733,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 9",
   "languages": "—",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -25818,7 +25818,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, poisoned",
   "senses": "blindsight 30', darkvision 120', passive Perception 21",
   "languages": "all, telepathy 120'",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Angelic Poison",
@@ -25909,7 +25909,7 @@
   "condition_immunities": "exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "understands all languages it knew in life but can’t speak",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -25993,7 +25993,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 20', passive Perception 8",
   "languages": "—",
-  "challenge_rating": 0.125,
+  "challenge_rating": "1/8",
   "special_abilities": [
    {
     "name": "Digestive Dew",
@@ -26065,7 +26065,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, poisoned, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 17",
   "languages": "understands Common and Celestial but can’t speak",
-  "challenge_rating": 12,
+  "challenge_rating": "12",
   "special_abilities": [
    {
     "name": "Assisted Leaping",
@@ -26151,7 +26151,7 @@
   "condition_immunities": "poisoned",
   "senses": "blindsight 90', passive Perception 15",
   "languages": "Common",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Limited Telepathy",
@@ -26228,7 +26228,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "zztitlespacingadjust -",
@@ -26314,7 +26314,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "Common + any two languages",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "actions": [
    {
     "name": "Multiattack",
@@ -26384,7 +26384,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, petrified, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 8",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -26455,7 +26455,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "Auran, Ignan",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Blazing Maelstrom Form",
@@ -26529,7 +26529,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "darkvision 60 ft, passive Perception 14",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Good Dog",
@@ -26608,7 +26608,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned",
   "senses": "darkvision 60', passive Perception 13 ",
   "languages": "understands the languages of its creator but can’t speak",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Construct Nature",
@@ -26692,7 +26692,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Draconic",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Swamp Camouflage",
@@ -26769,7 +26769,7 @@
   "condition_immunities": "",
   "senses": "darkvision 30', passive Perception 13",
   "languages": "Sylvan, Umbral",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Beguiling Aura",
@@ -26838,7 +26838,7 @@
   "condition_immunities": "blinded, deafened, frightened, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 13",
   "languages": "—",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Central Stalk Weakness",
@@ -26930,7 +26930,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned",
   "senses": "blindsight 30', darkvision 60', passive Perception 17",
   "languages": "Aquan, Common, Giant",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Blizzard Heart",
@@ -27004,7 +27004,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 10",
   "languages": "Common, Draconic",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Eidetic Memory",
@@ -27082,7 +27082,7 @@
   "condition_immunities": "charmed, poisoned",
   "senses": "passive Perception 15",
   "languages": "understands Sylvan but can’t speak",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Deep Roots",
@@ -27167,7 +27167,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "darkvision 30', tremorsense 120', passive Perception 13",
   "languages": "Terran",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -27245,7 +27245,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 60' or 20' while deafened (blind beyond), passive Perception 17",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Blind Senses",
@@ -27319,7 +27319,7 @@
   "condition_immunities": "blinded, deafened, frightened, prone",
   "senses": "blindsight 120' (blind beyond), passive Perception 9",
   "languages": "Sylvan",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -27393,7 +27393,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "Common, Elvish",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Creeping Mists",
@@ -27474,7 +27474,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "the languages it knew in life",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Experienced Sailor",
@@ -27557,7 +27557,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Danger From Above",
@@ -27632,7 +27632,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, poisoned",
   "senses": "blindsight 120' (blind beyond), passive Perception 15",
   "languages": "understands Common and Void Speech but can’t speak, telepathy 60'",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -27706,7 +27706,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Celestial, Common",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Blur of Motion",
@@ -27799,7 +27799,7 @@
   "condition_immunities": "blinded",
   "senses": "blindsight 60', darkvision 120', passive Perception 31",
   "languages": "Common, Draconic, Terran",
-  "challenge_rating": 23,
+  "challenge_rating": "23",
   "special_abilities": [
    {
     "name": "Legendary Resistance (3/Day)",
@@ -27904,7 +27904,7 @@
   "condition_immunities": "charmed, exhaustion, poisoned",
   "senses": "darkvision 60', passive Perception 17",
   "languages": "Common",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Charge",
@@ -27989,7 +27989,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "Sylvan",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Speak with Frogs and Toads",
@@ -28062,7 +28062,7 @@
   "condition_immunities": "blinded, deafened, frightened",
   "senses": "blindsight 30' (blind beyond), passive Perception 6",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -28122,7 +28122,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 15",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 11,
+  "challenge_rating": "11",
   "special_abilities": [
    {
     "name": "Essential Oiliness",
@@ -28214,7 +28214,7 @@
   "condition_immunities": "poisoned, prone",
   "senses": "blindsight 10', darkvision 60', passive Perception 14",
   "languages": "Draconic",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Poisonous Blood",
@@ -28300,7 +28300,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 17",
   "languages": "Giant, Minotaur",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Charge",
@@ -28389,7 +28389,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Giant",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Arcane Weapons",
@@ -28467,7 +28467,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "Common, Sylvan",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Icy Wrath",
@@ -28547,7 +28547,7 @@
   "condition_immunities": "prone",
   "senses": "blindsight 90' (blind beyond), tremorsense 30', passive Perception 11",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -28623,7 +28623,7 @@
   "condition_immunities": "charmed, poisoned",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Sylvan, telepathy 30'",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Deathly Origins",
@@ -28710,7 +28710,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "darkvision 60', passive Perception 10 ",
   "languages": "Aquan",
-  "challenge_rating": 8,
+  "challenge_rating": "8",
   "special_abilities": [
    {
     "name": "Elemental Nature",
@@ -28785,7 +28785,7 @@
   "condition_immunities": "charmed, frightened, poisoned ",
   "senses": "darkvision 120 ft, passive Perception 13 ",
   "languages": "Common, Infernal, telepathy 120'",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Devil’s Sight",
@@ -28880,7 +28880,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 120', passive Perception 11",
   "languages": "Common",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Aura of Drunkenness",
@@ -28955,7 +28955,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 13",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Keen Smell",
@@ -29021,7 +29021,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 12",
   "languages": "—",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Mirror Scales",
@@ -29100,7 +29100,7 @@
   "condition_immunities": "blinded, deafened, poisoned",
   "senses": "blindsight 60' (blind beyond), passive Perception 15",
   "languages": "understands Sylvan but can’t speak",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "actions": [
    {
     "name": "Multiattack",
@@ -29162,7 +29162,7 @@
   "condition_immunities": "charmed, frightened, exhaustion, poisoned",
   "senses": "darkvision 60', truesight 30', passive Perception 16",
   "languages": "Abyssal, Celestial, Common, Infernal",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Befouling Aura",
@@ -29251,7 +29251,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Elvish, Sylvan",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Hazesight",
@@ -29322,7 +29322,7 @@
   "condition_immunities": "frightened",
   "senses": "darkvision 120', passive Perception 12",
   "languages": "—",
-  "challenge_rating": 15,
+  "challenge_rating": "15",
   "special_abilities": [
    {
     "name": "Magic Resistance",
@@ -29405,7 +29405,7 @@
   "condition_immunities": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned",
   "senses": "passive Perception 12",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "Blood Frenzy",
@@ -29477,7 +29477,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "any two languages",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Ritual Cleansing",
@@ -29547,7 +29547,7 @@
   "condition_immunities": "exhaustion, poisoned",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "Common, Infernal",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Devil’s Sight",
@@ -29634,7 +29634,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, poisoned, prone",
   "senses": "darkvision 120', passive Perception 13",
   "languages": "all, telepathy 60'",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Immortal Nature",
@@ -29714,7 +29714,7 @@
   "condition_immunities": "charmed, poisoned",
   "senses": "darkvision 60', passive Perception 19",
   "languages": "Common, Elvish, Sylvan",
-  "challenge_rating": 9,
+  "challenge_rating": "9",
   "special_abilities": [
    {
     "name": "One with the Woods",
@@ -29802,7 +29802,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Grassland Camouflage",
@@ -29875,7 +29875,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 10",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Shoving Charge",
@@ -29945,7 +29945,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Cueyatl",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Amphibious",
@@ -30047,7 +30047,7 @@
   "condition_immunities": "charmed, frightened",
   "senses": "darkvision 60', passive Perception 17",
   "languages": "Common, Sylvan",
-  "challenge_rating": 13,
+  "challenge_rating": "13",
   "special_abilities": [
    {
     "name": "Draw Life Essence",
@@ -30131,7 +30131,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 13",
   "languages": "any two languages",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Phrenic Weapons",
@@ -30213,7 +30213,7 @@
   "condition_immunities": "charmed, restrained",
   "senses": "darkvision 60', passive Perception 16",
   "languages": "Common, Draconic, + any two languages",
-  "challenge_rating": 10,
+  "challenge_rating": "10",
   "special_abilities": [
    {
     "name": "Pack Tactics",
@@ -30313,7 +30313,7 @@
   "condition_immunities": "poisoned",
   "senses": "darkvision 60', passive Perception 12",
   "languages": "—",
-  "challenge_rating": 2,
+  "challenge_rating": "2",
   "special_abilities": [
    {
     "name": "Spiny Body",
@@ -30385,7 +30385,7 @@
   "condition_immunities": "",
   "senses": "blindsight 120', passive Perception 9",
   "languages": "understands Void Speech but can’t speak",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "actions": [
    {
     "name": "Multiattack",
@@ -30453,7 +30453,7 @@
   "condition_immunities": "blinded, poisoned",
   "senses": "blindsight 30' (blind beyond), tremorsense 120', passive Perception 16",
   "languages": "Giant, Void Speech",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Keen Hearing and Smell",
@@ -30529,7 +30529,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, prone",
   "senses": "blindsight 60' (blind beyond), passive Perception 11",
   "languages": "—",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Amorphous",
@@ -30615,7 +30615,7 @@
   "condition_immunities": "paralyzed, unconscious",
   "senses": "darkvision 60', tremorsense 30', passive Perception 11",
   "languages": "Common, Draconic",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "False Appearance",
@@ -30697,7 +30697,7 @@
   "condition_immunities": "charmed, exhaustion, poisoned",
   "senses": "darkvision 60', passive Perception 15",
   "languages": "—",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Toxic Ichor",
@@ -30772,7 +30772,7 @@
   "condition_immunities": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "Auran, Ignan, Terran",
-  "challenge_rating": 7,
+  "challenge_rating": "7",
   "special_abilities": [
    {
     "name": "Brittle",
@@ -30853,7 +30853,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned ",
   "senses": "darkvision 60', passive Perception 14",
   "languages": "understands those of its creature but can’t speak",
-  "challenge_rating": 6,
+  "challenge_rating": "6",
   "special_abilities": [
    {
     "name": "Book Bound",
@@ -30938,7 +30938,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Common, Dwarven, Giant",
-  "challenge_rating": 4,
+  "challenge_rating": "4",
   "special_abilities": [
    {
     "name": "Magic Resistance",
@@ -31014,7 +31014,7 @@
   "condition_immunities": "blinded, charmed, deafened, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned",
   "senses": "blindsight 120' (blind beyond), passive Perception 9",
   "languages": "understands Common but can’t speak",
-  "challenge_rating": 15,
+  "challenge_rating": "15",
   "special_abilities": [
    {
     "name": "Antimagic Susceptibility",
@@ -31128,7 +31128,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 11",
   "languages": "Common",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Hold Breath",
@@ -31209,7 +31209,7 @@
   "condition_immunities": "",
   "senses": "passive Perception 14",
   "languages": "—",
-  "challenge_rating": 1,
+  "challenge_rating": "1",
   "special_abilities": [
    {
     "name": "Day Hunter",
@@ -31281,7 +31281,7 @@
   "condition_immunities": "",
   "senses": "darkvision 60', passive Perception 13",
   "languages": "Moonsong",
-  "challenge_rating": 0.5,
+  "challenge_rating": "1/2",
   "special_abilities": [
    {
     "name": "Lubricious Plumage",
@@ -31342,7 +31342,7 @@
   "condition_immunities": "poisoned",
   "senses": "truesight 120', passive Perception 13",
   "languages": "Abyssal, telepathy 120'",
-  "challenge_rating": 12,
+  "challenge_rating": "12",
   "special_abilities": [
    {
     "name": "Frozen Aura",
@@ -31413,7 +31413,7 @@
   "condition_immunities": "exhaustion, paralyzed, petrified, poisoned, prone, unconscious",
   "senses": "tremorsense 60', passive Perception 14",
   "languages": "Ignan, Terran",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Lava Walker",
@@ -31490,7 +31490,7 @@
   "condition_immunities": "charmed, exhaustion, frightened, paralyzed, poisoned",
   "senses": "darkvision 60', passive Perception 10",
   "languages": "those it knew in life",
-  "challenge_rating": 5,
+  "challenge_rating": "5",
   "special_abilities": [
    {
     "name": "Bog Melt",
@@ -31555,7 +31555,7 @@
   "condition_immunities": "blinded, charmed, deafened, frightened, grappled, prone",
   "senses": "tremorsense 60', passive Perception 7",
   "languages": "—",
-  "challenge_rating": 3,
+  "challenge_rating": "3",
   "special_abilities": [
    {
     "name": "False",


### PR DESCRIPTION
TOB3 is the only document with numerical CR values (e.g. `0.25`). All other documents use a string representation of a fraction (e.g. `"1/4"`).