### PR TITLE
Search now returns a sections parent

### DIFF
--- a/api/search_indexes.py
+++ b/api/search_indexes.py
@@ -60,6 +60,7 @@ class SectionIndex(indexes.SearchIndex, indexes.Indexable):
   name = indexes.EdgeNgramField(model_attr='name', )
   route = indexes.CharField(model_attr='route', indexed=False)
   slug = indexes.CharField(model_attr='slug', indexed=False)
+  parent = indexes.CharField(model_attr='parent', indexed=False)
 
 
   def get_model(self):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -440,6 +440,7 @@ class AggregateSerializer(HighlighterMixin, HaystackSerializer):
             'source',
             'requires_attunement',
             'document_slug',
-            'document_title'
+            'document_title',
+            'parent',
         ]
         


### PR DESCRIPTION
This PR fixes a bug with the search view not returning the `parent` attribute of of the Section model. As a sections parent is essentially the category that the section falls under it would be very useful to have access to this information on the front end.

### Recreation

If you navigate to https://api.open5e.com/sections/ you can see that the API returns the `parent` field of the Section model:

<img width="480" alt="Screenshot 2023-08-25 at 12 08 01" src="https://github.com/open5e/open5e-api/assets/47755775/e62264c7-67ba-4315-898f-3186520df784">

But when using the `/search` endpoint (ie. https://api.open5e.com/search/?text=mounted+combat/) the `parent` field is not returned as part of the the response:

<img width="480" alt="Screenshot 2023-08-25 at 12 12 49" src="https://github.com/open5e/open5e-api/assets/47755775/250ab75f-3ce7-4124-bc45-ced0cfa786d9">

### Solution

Adding the `parent` field to the serializer and search index seems to have fixed this problem.

<img width="480" alt="Screenshot 2023-08-25 at 12 18 55" src="https://github.com/open5e/open5e-api/assets/47755775/88b983fe-1e24-4366-b555-e53f36f38653">

