### PR TITLE
Stoor Halfling subrace

### DIFF
--- a/data/open5e_original/races.json
+++ b/data/open5e_original/races.json
@@ -1,0 +1,21 @@
+[
+    {
+        "name": "Halfling",
+        "subtypes": [
+            {
+                "name": "Stoor Halfling",
+                "desc": "Stoor halflings earn their moniker from an archaic word for \"strong\" or \"large,\" and indeed the average stoor towers some six inches taller than their lightfoot cousins. They are also particularly hardy by halfling standards, famous for being able to hold down the strongest dwarven ales, for which they have also earned a reputation of relative boorishness. Still, most stoor halflings are good natured and simple folk, and any lightfoot would be happy to have a handful of stoor cousins to back them up in a barroom brawl.",
+                "asi-desc": "**_Ability Score Increase._** Your Constitution score increases by 1.",
+                "asi": [
+                    {
+                        "attributes": [
+                            "Constitution"
+                        ],
+                        "value": 1
+                    }
+                ],
+                "traits": "**_Stoor Hardiness._** You gain resistance to poison damage, and you make saving throws against poison with advantage."
+            }
+        ]
+    }
+]

--- a/data/open5e_original/races.json
+++ b/data/open5e_original/races.json
@@ -1,5 +1,15 @@
 [
     {
+        "name": "Dwarf",
+        "subtypes": [
+        ]
+    },
+    {
+        "name": "Elf",
+        "subtypes": [
+        ]
+    },
+    {
         "name": "Halfling",
         "subtypes": [
             {


### PR DESCRIPTION
This Halfling subrace replaces a similar core subrace not available in the SRD.