### PR TITLE
fix: Remove Extra Mage Reaction

### DIFF
--- a/data/menagerie/monsters.json
+++ b/data/menagerie/monsters.json
@@ -26343,10 +26343,6 @@
       {
         "name": "Shield (1st-Level; V",
         "desc": "When the mage is hit by an attack or targeted by magic missile, they gain a +5 bonus to AC (including against the triggering attack) and immunity to magic missile. These benefits last until the start of their next turn."
-      },
-      {
-        "name": "Misty Step (2nd-Level; V)",
-        "desc": "The mage teleports to an unoccupied space they can see within 30 feet. The mage can't cast this spell and a 1st-level or higher spell on the same turn."
       }
     ],
     "speed_json": {


### PR DESCRIPTION
Fix after bug report from Trick on the Discord:

> Need to remove the spell Misty Step from the reactions of the Mage in the Level Up A5E Monsterous Menagerie.
> Found on Page 482 of said book. 
https://discord.com/channels/470638316103008268/1166787857625657424