### PR TITLE
Fix overwritten magicitems

### DIFF
--- a/api/management/commands/importer.py
+++ b/api/management/commands/importer.py
@@ -299,7 +299,11 @@ class Importer:
         """Create or update a single MagicItem model from a JSON object."""
         new = False
         exists = False
-        slug = slugify(magic_item_json["name"])
+        slug = ""
+        if "slug" in magic_item_json:
+            slug = magic_item_json["slug"]
+        else:
+            slug = slugify(magic_item_json["name"])
         if models.MagicItem.objects.filter(slug=slug).exists():
             i = models.MagicItem.objects.get(slug=slug)
             exists = True

--- a/api/tests/approved_files/TestAPIRoot.test_magicitems.approved.json
+++ b/api/tests/approved_files/TestAPIRoot.test_magicitems.approved.json
@@ -1,5 +1,5 @@
 {
-    "count": 1388,
+    "count": 1619,
     "next": "http://localhost:8000/magicitems/?page=2",
     "previous": null,
     "results": [
@@ -15,543 +15,543 @@
             "type": "Armor (medium or heavy)"
         },
         {
-            "desc": "Wearing this amulet increases your Constitution score to 19\\. It has no effect if your Constitution is equal to or greater than 19.",
+            "desc": "Your Constitution score is 19 while you wear this amulet. It has no effect on you if your Constitution is already 19 or higher.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Amulet of Health",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "amulet-of-health",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "You are hidden from divination magic while wearing this amulet, including any form of _scrying_  (magical scrying sensors are unable to perceive you).",
+            "desc": "While wearing this amulet, you are hidden from divination magic. You can't be targeted by such magic or perceived through magical scrying sensors.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Amulet of Proof against Detection and Location",
-            "rarity": "Rare",
+            "rarity": "uncommon",
             "requires_attunement": "requires attunement",
             "slug": "amulet-of-proof-against-detection-and-location",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing this amulet, you can use an action and name a location that you are familiar with on another plane of existence, making a DC 15 Intelligence check. On a success you cast the _plane shift_  spell, but on a failure you and every creature and object within a 15-foot radius are transported to a random location determined with a d100 roll. On a 1\u201360 you transport to a random location on the plane you named, or on a 61\u2013100 you are transported to a randomly determined plane of existence.",
+            "desc": "While wearing this amulet, you can use an action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence check. On a successful check, you cast the _plane shift_ spell. On a failure, you and each creature and object within 15 feet of you travel to a random destination. Roll a d100. On a 1-60, you travel to a random location on the plane you named. On a 61-100, you travel to a randomly determined plane of existence.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Amulet of the Planes",
-            "rarity": "Very Rare",
+            "rarity": "very rare",
             "requires_attunement": "requires attunement",
             "slug": "amulet-of-the-planes",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "As a bonus action, you can verbally command the shield to animate and float in your space, or for it to stop doing so. The shield continues to act as if you were wielding it, but with your hands free. The shield remains animated for 1 minute, or until you are _incapacitated_  or die. It then returns to your free hand, if you have one, or else it falls to the ground. You can benefit from only one shield at a time.",
+            "desc": "While holding this shield, you can speak its command word as a bonus action to cause it to animate. The shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The shield remains animated for 1 minute, until you use a bonus action to end this effect, or until you are incapacitated or die, at which point the shield falls to the ground or into your hand if you have one free.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Animated Shield",
-            "rarity": "Very Rare",
+            "rarity": "very rare",
             "requires_attunement": "requires attunement",
             "slug": "animated-shield",
-            "type": "Armor"
+            "type": "Armor (shield)"
         },
         {
-            "desc": "This ingeniously crafted item (known by some as the crabaratus) is a tightly shut 500 pound iron barrel. Making a DC 20 Investigation check reveals a hidden catch which unlocks one end of the barrel\u2014a hatch. Two Medium or smaller creatures can crawl inside where there are 10 levers in a row at the far end. Each lever is in a neutral position but can move up or down. Use of these levers makes the barrel reconfigure to resemble a giant metal crab.\n\nThis item is a Large object with the following statistics:\n\n**Armor Class:** 20\n\n**Hit Points:** 200\n\n**Speed:** 30 ft., swim 30 ft. (both are 0 ft. without legs and tail extended)\n\n**Damage Immunities:** poison, psychic\n\nThe item requires a pilot to be used as a vehicle. The hatch must be closed for it to be airtight and watertight. The apparatus holds 10 hours worth of air for breathing, dividing by the number of breathing creatures inside.\n\nThe apparatus floats on water and may dive underwater down to 900 feet, taking 2d6 bludgeoning damage at the end of each minute spent at a lower depth.\n\nAny creature inside the apparatus can use an action to position up to two of the levers either up or down, with the lever returning to its neutral position upon use. From left to right, the Apparatus of the Crab table shows how each lever functions.\n\n  \n**Table: Apparatus of the Crab**\n\n| **Lever** | **Up**                                                                                                                            | **Down**                                                                                                                    |\n| --------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |\n| 1         | Extends legs and tail.                                                                                                            | Retracts legs and tail. Speed is 0 ft. and it cannot benefit from bonuses to Speed.                                         |\n| 2         | Shutter on forward window opens.                                                                                                  | Shutter on forward window closes.                                                                                           |\n| 3         | Shutters (two each side) on side windows open.                                                                                    | Shutters on side windows close.                                                                                             |\n| 4         | Two claws extend, one on each front side.                                                                                         | The claws retract.                                                                                                          |\n| 5         | Each extended claw makes a melee attack: +8 to hit, reach 5 ft., one target. Hit: 7 (2d6) bludgeoning damage.                     | Each extended claw makes a melee attack: +8 to hit, reach 5 ft., one target. Hit: The target is _grappled_  (escape DC 15). |\n| 6         | The apparatus moves forward.                                                                                                      | The apparatus moves backward.                                                                                               |\n| 7         | The apparatus turns 90 degrees left.                                                                                              | The apparatus turns 90 degrees right.                                                                                       |\n| 8         | Bright light shines from fixtures resembling eyes, shedding bright light in a 30-foot radius and dim light an additional 30 feet. | The light extinguishes.                                                                                                     |\n| 9         | If in liquid, the apparatus sinks 20 feet.                                                                                        | If in liquid, the apparatus rises 20 feet.                                                                                  |\n| 10        | The hatch opens.                                                                                                                  | The hatch closes.                                                                                                           |",
+            "desc": "This item first appears to be a Large sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move either up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.\n\nThe apparatus of the Crab is a Large object with the following statistics:\n\n**Armor Class:** 20\n\n**Hit Points:** 200\n\n**Speed:** 30 ft., swim 30 ft. (or 0 ft. for both if the legs and tail aren't extended)\n\n**Damage Immunities:** poison, psychic\n\nTo be used as a vehicle, the apparatus requires one pilot. While the apparatus's hatch is closed, the compartment is airtight and watertight. The compartment holds enough air for 10 hours of breathing, divided by the number of breathing creatures inside.\n\nThe apparatus floats on water. It can also go underwater to a depth of 900 feet. Below that, the vehicle takes 2d6 bludgeoning damage per minute from pressure.\n\nA creature in the compartment can use an action to move as many as two of the apparatus's levers up or down. After each use, a lever goes back to its neutral position. Each lever, from left to right, functions as shown in the Apparatus of the Crab Levers table.\n\n**Apparatus of the Crab Levers (table)**\n\n| Lever | Up                                                                                                                               | Down                                                                                                                                        |\n|-------|----------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|\n| 1     | Legs and tail extend, allowing the apparatus to walk and swim.                                                                   | Legs and tail retract, reducing the apparatus's speed to 0 and making it unable to benefit from bonuses to speed.                           |\n| 2     | Forward window shutter opens.                                                                                                    | Forward window shutter closes.                                                                                                              |\n| 3     | Side window shutters open (two per side).                                                                                        | Side window shutters close (two per side).                                                                                                  |\n| 4     | Two claws extend from the front sides of the apparatus.                                                                          | The claws retract.                                                                                                                          |\n| 5     | Each extended claw makes the following melee weapon attack: +8 to hit, reach 5 ft., one target. Hit: 7 (2d6) bludgeoning damage. | Each extended claw makes the following melee weapon attack: +8 to hit, reach 5 ft., one target. Hit: The target is grappled (escape DC 15). |\n| 6     | The apparatus walks or swims forward.                                                                                            | The apparatus walks or swims backward.                                                                                                      |\n| 7     | The apparatus turns 90 degrees left.                                                                                             | The apparatus turns 90 degrees right.                                                                                                       |\n| 8     | Eyelike fixtures emit bright light in a 30-foot radius and dim light for an additional 30 feet.                                  | The light turns off.                                                                                                                        |\n| 9     | The apparatus sinks as much as 20 feet in liquid.                                                                                | The apparatus rises up to 20 feet in liquid.                                                                                                |\n| 10    | The rear hatch unseals and opens.                                                                                                | The rear hatch closes and seals.                                                                                                            |",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Apparatus of the Crab",
-            "rarity": "Legendary",
+            "rarity": "legendary",
             "requires_attunement": "",
             "slug": "apparatus-of-the-crab",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This armor grants you resistance to nonmagical damage. Once between _long rests_ , you can use an action to become immune to nonmagical damage for 10 minutes or until you are no longer wearing the armor.",
+            "desc": "You have resistance to nonmagical damage while you wear this armor. Additionally, you can use an action to make yourself immune to nonmagical damage for 10 minutes or until you are no longer wearing the armor. Once this special action is used, it can't be used again until the next dawn.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Armor of Invulnerability",
-            "rarity": "Legendary",
+            "rarity": "legendary",
             "requires_attunement": "requires attunement",
             "slug": "armor-of-invulnerability",
-            "type": "Armor"
+            "type": "Armor (plate)"
         },
         {
-            "desc": "This armor grants you resistance to one type of damage. The type of damage is determined when the armor is created, from the following list: acid, cold, fire, force, lightning, necrotic, poison, psychic, radiant, thunder.\n\nA suit of light or medium _armor of resistance_ is rare, and a heavy suit is very rare.",
+            "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Armor of Resistance",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "armor-of-resistance",
-            "type": "Armor"
+            "type": "Armor (light)"
         },
         {
-            "desc": "This armor grants you resistance to one of the following damage types: bludgeoning, piercing, or slashing. The type of damage is determined when the armor is created.\n\n**Cursed.** Once attuned to this armor, you are _cursed_  until you are targeted by __remove curse_ or similar magic; removing the armor does not end it. While cursed, you have vulnerability to the other two damage types this armor does not protect against.",
+            "desc": "While wearing this armor, you have resistance to one of the following damage types: bludgeoning, piercing, or slashing. The GM chooses the type or determines it randomly.\n\n**_Curse_**. This armor is cursed, a fact that is revealed only when an _identify_ spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the _remove curse_ spell or similar magic; removing the armor fails to end the curse. While cursed, you have vulnerability to two of the three damage types associated with the armor (not the one to which it grants resistance).",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Armor of Vulnerability",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "armor-of-vulnerability",
-            "type": "Armor"
+            "type": "Armor (plate)"
         },
         {
-            "desc": "This shield grants you +2 to AC against ranged attacks, in addition to the shield\u2019s normal bonus to AC. In addition, whenever a target within 5 feet of you is targeted by a ranged attack, you can use your reaction to become the target of the attack instead.",
+            "desc": "You gain a +2 bonus to AC against ranged attacks while you wield this shield. This bonus is in addition to the shield's normal bonus to AC. In addition, whenever an attacker makes a ranged attack against a target within 5 feet of you, you can use your reaction to become the target of the attack instead.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Arrow-Catching Shield",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "arrow-catching-shield",
-            "type": "Armor"
+            "type": "Armor (shield)"
         },
         {
-            "desc": "A particular kind of creature is chosen when this magic arrow is created. When the _arrow of slaying_ damages a creature belonging to the chosen type, heritage, or group, the creature makes a DC 17 Constitution _saving throw_ , taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one. Once the _arrow of slaying_ deals its extra damage to a creature, it loses its magical properties. \n\nOther types of magic ammunition of this kind exist, such as bolts meant for a crossbow, or bullets for a firearm or sling.",
+            "desc": "An _arrow of slaying_ is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both _arrows of dragon slaying_ and _arrows of blue dragon slaying_. If a creature belonging to the type, race, or group associated with an _arrow of slaying_ takes damage from the arrow, the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.\n\nOnce an _arrow of slaying_ deals its extra damage to a creature, it becomes a nonmagical arrow.\n\nOther types of magic ammunition of this kind exist, such as _bolts of slaying_ meant for a crossbow, though arrows are most common.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Arrow of Slaying",
-            "rarity": "Very Rare",
+            "rarity": "very rare",
             "requires_attunement": "",
             "slug": "arrow-of-slaying",
-            "type": "Weapon"
+            "type": "Weapon (arrow)"
         },
         {
-            "desc": "This cloth bag contains 3d4 dry beans and weighs \u00bd pound plus \u00bc pound for each bean inside.\n\nDumping the bag\u2019s contents on the ground creates a fiery 10-foot radius explosion. The fire ignites unattended flammable objects. Each creature in the area makes a DC 15 Dexterity _saving throw_ , taking 5d4 fire damage on a failure, or half damage on a success. \n\nYou may also take a bean from the bag and plant it in dirt or sand and water it, producing an effect 1 minute later centered on where it was planted.\n\nTo determine the effect the Narrator may create something entirely new, choose one from the following table, or roll.\n\nTable: Bag of Beans\n\n| 1     | 5d4 toadstools with strange markings appear. When a creature eats a toadstool (raw or cooked), roll any die. An even result grants 5d6 temporary hit points for 1 hour, and an odd result requires the creature to make a DC 15 Constitution _saving throw_  or take 5d6 poison damage and become _poisoned_  for 1 hour.                                                                                                                                                                                                                                                                                                                                                                                                                                        |\n| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |\n| 2\u201310  | 1d4+1 geysers erupt. Each one spews a different liquid (chosen by the Narrator) 30 feet into the air for 1d6 rounds: beer, berry juice, cooking oil, tea, vinegar, water, or wine.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |\n| 11\u201320 | A fully developed _treant_  appears. There is a 50% chance it is chaotic evil, in which case it immediately attacks the nearest creature.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |\n| 21\u201330 | A stone statue in your likeness with an angry countenance rises. The statue is immobile except for its mouth, which can move and speak. It constantly rails threats and insults against you. If you leave the statue, it knows where you are (if you are on the same plane of existence) and tells anyone who comes near that you are the worst of villains, urging them to kill you. The statue attempts to cast _geas_ (save DC 10) on any nearby creature that can speak a language you do (and isn\u2019t your friend or companion) with the command to find and kill you. After 24 hours, the statue loses the ability to speak and cast geas, becoming completely inanimate.                                                                                    |\n| 31\u201340 | A campfire with green flames appears for 24 hours or until it is extinguished. The area in a 10-foot radius is a haven.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |\n| 41\u201350 | 1d6+6 fully developed _shriekers_  appear.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |\n| 51\u201360 | 1d4+8 small pods sprout, which then unfurl to allow a luminescent pink toad to crawl out of each one. A toad transforms into a Large or smaller beast (determined by the Narrator) whenever touched. The beast remains for 1 minute, then disappears in a puff of luminescent pink smoke.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |\n| 61\u201370 | A fully developed _shambling mound_  appears. It is not hostile but appears perplexed as it is _stunned_  for 1d4 rounds. Once the stun effect ends, it is _frightened_  for 1d10+1 rounds. The source of its fear is one randomly determined creature it can see.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |\n| 71\u201380 | A tree with tantalizing fruit appears, but then turns into glass that refracts light in a dazzlingly beautiful manner. The glass tree evaporates over the next 24 hours.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |\n| 81\u201390 | A nest appears containing 1d4+3 vibrantly multicolored eggs with equally multicolored yolks. Any creature that eats an egg (raw or cooked) makes a DC 20 Constitution _saving throw_ . On a success, the creature's lowest ability score permanently increases by 1 (randomly choosing among equally low scores). On a failure, the creature takes 10d6 force damage from an internal magical explosion.                                                                                                                                                                                                                                                                                                                                                         |\n| 91\u201399 | A 5-foot hole with swirling multicolored vapors inside appears. All creatures within 10 feet of the hole that have an Intelligence of 6 or higher hear urgent, loving whispers from within in a language they understand. Each creature makes a DC 15 Wisdom _saving throw_  or try to leap into the hole. The first creature to jump into the hole (or more than one, if multiple creatures jump in simultaneously) disappears for 1 day before reappearing. A creature has no memory of the previous 24 hours when it reappears, but finds a new randomly determined magic item of uncommon rarity among its possessions. It also gains the benefits of a _long rest_ . The hole disappears after 1 minute, or as soon as a creature jumps completely into it. |\n| 100   | A fantastic, gargantuan beanstalk erupts and grows to a height determined by the Narrator. The Narrator also chooses where the top leads. These options (and more) are possible: the castle of a giant, a magnificent view, a different plane of existence.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |",
+            "desc": "Inside this heavy cloth bag are 3d4 dry beans. The bag weighs 1/2 pound plus 1/4 pound for each bean it contains.\n\nIf you dump the bag's contents out on the ground, they explode in a 10-foot radius, extending from the beans. Each creature in the area, including you, must make a DC 15 Dexterity saving throw, taking 5d4 fire damage on a failed save, or half as much damage on a successful one. The fire ignites flammable objects in the area that aren't being worn or carried.\n\nIf you remove a bean from the bag, plant it in dirt or sand, and then water it, the bean produces an effect 1 minute later from the ground where it was planted. The GM can choose an effect from the following table, determine it randomly, or create an effect.\n\n| d100  | Effect                                                                                                                                                                                                                                                                                                                                                                |\n|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n| 01    | 5d4 toadstools sprout. If a creature eats a toadstool, roll any die. On an odd roll, the eater must succeed on a DC 15 Constitution saving throw or take 5d6 poison damage and become poisoned for 1 hour. On an even roll, the eater gains 5d6 temporary hit points for 1 hour.                                                                                      |\n| 02-10 | A geyser erupts and spouts water, beer, berry juice, tea, vinegar, wine, or oil (GM's choice) 30 feet into the air for 1d12 rounds.                                                                                                                                                                                                                                   |\n| 11-20 | A treant sprouts. There's a 50 percent chance that the treant is chaotic evil and attacks.                                                                                                                                                                                                                                                                            |\n| 21-30 | An animate, immobile stone statue in your likeness rises. It makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows where you are. The statue becomes inanimate after 24 hours. |\n| 31-40 | A campfire with blue flames springs forth and burns for 24 hours (or until it is extinguished).                                                                                                                                                                                                                                                                       |\n| 41-50 | 1d6 + 6 shriekers sprout                                                                                                                                                                                                                                                                                                                                              |\n| 51-60 | 1d4 + 8 bright pink toads crawl forth. Whenever a toad is touched, it transforms into a Large or smaller monster of the GM's choice. The monster remains for 1 minute, then disappears in a puff of bright pink smoke.                                                                                                                                                |\n| 61-70 | A hungry bulette burrows up and attacks. 71-80 A fruit tree grows. It has 1d10 + 20 fruit, 1d8 of which act as randomly determined magic potions, while one acts as an ingested poison of the GM's choice. The tree vanishes after 1 hour. Picked fruit remains, retaining any magic for 30 days.                                                                     |\n| 81-90 | A nest of 1d4 + 3 eggs springs up. Any creature that eats an egg must make a DC 20 Constitution saving throw. On a successful save, a creature permanently increases its lowest ability score by 1, randomly choosing among equally low scores. On a failed save, the creature takes 10d6 force damage from an internal magical explosion.                            |\n| 91-99 | A pyramid with a 60-foot-square base bursts upward. Inside is a sarcophagus containing a mummy lord. The pyramid is treated as the mummy lord's lair, and its sarcophagus contains treasure of the GM's choice.                                                                                                                                                       |\n| 100   | A giant beanstalk sprouts, growing to a height of the GM's choice. The top leads where the GM chooses, such as to a great view, a cloud giant's castle, or a different plane of existence.                                                                                                                                                                            |",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Bag of Beans",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "",
             "slug": "bag-of-beans",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This item is actually an aperture for the mouth of an immense extradimensional creature and is often mistaken for a _bag of holding_ . \n\nThe creature can perceive everything placed inside the bag. Up to a cubic foot of inanimate objects can be stored inside, however once per day the creature swallows any inanimate objects inside and spews them into another plane of existence (with the Narrator deciding the plane and time of day). Animal or vegetable matter placed completely inside is instead ingested and destroyed. \n\nThis item can be very dangerous. When part of a creature is inside the bag (including a creature reaching a hand inside) there is a 50% chance the bag pulls it inside. A creature that ends its turn inside the bag is ingested and destroyed. \n\nA creature inside the bag can try to escape by using an action and making a DC 15 Strength check. Creatures outside the bag may use an action to attempt to reach in and pull a creature out with a DC 20 Strength check. This rescue attempt is subject to the same 50% chance to be pulled inside.\n\nPiercing or tearing the item destroys it, with anything currently inside shifted to a random location on the Astral Plane. Turning the bag inside out closes the mouth.",
+            "desc": "This bag superficially resembles a _bag of holding_ but is a feeding orifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.\n\nThe extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can use its action to try to escape with a successful DC 15 Strength check. Another creature can use its action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength check (provided it isn't pulled inside the bag first). Any creature that starts its turn inside the bag is devoured, its body destroyed.\n\nInanimate objects can be stored in the bag, which can hold a cubic foot of such material. However, once each day, the bag swallows any objects inside it and spits them out into another plane of existence. The GM determines the time and plane.\n\nIf the bag is pierced or torn, it is destroyed, and anything contained within it is transported to a random location on the Astral Plane.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Bag of Devouring",
-            "rarity": "Very Rare",
+            "rarity": "very rare",
             "requires_attunement": "",
             "slug": "bag-of-devouring",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This bag\u2019s interior space is significantly larger than its apparent size of roughly 2 feet at the mouth and 4 feet deep. The bag can hold up to 500 pounds and has an internal volume of 64 cubic feet. Regardless of its contents, it weighs 15 pounds. Retrieving an item from the bag requires an action. If you have never interacted with a specific bag of holding before, the first time you use it, it requires 1d4 rounds to take stock of its contents before anything can be retrieved from the bag.\n\nFood or water placed in the bag immediately and permanently lose all nourishing qualities\u2014after being in the bag, water no longer slakes thirst and food does not sate hunger or nourish. In a similar fashion, the body of a dead creature placed in the bag cannot be restored to life by __revivify , raise dead ,_ or other similar magic. Breathing creatures inside the bag can survive for up to 2d4 minutes divided by the number of creatures (minimum 1 minute), after which time they begin to suffocate.\n\nThe bag cannot hold any item that would not fit in a normal bag of its apparent size or any item with the Bulky quality. \n\nIf the bag is punctured, torn, or otherwise structurally damaged, it ruptures and is destroyed, and the contents are scattered throughout the Astral Plane.\n\nPlacing a _bag of holding_ inside another extradimensional storage device such as a _portable hole_  or __handy haversack_ results in planar rift that destroys both items and pulls everything within 10 feet into the Astral Plane. The rift then closes and disappears.",
+            "desc": "This bag has an interior space considerably larger than its outside dimensions, roughly 2 feet in diameter at the mouth and 4 feet deep. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 15 pounds, regardless of its contents. Retrieving an item from the bag requires an action.\n\nIf the bag is overloaded, pierced, or torn, it ruptures and is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth, unharmed, but the bag must be put right before it can be used again. Breathing creatures inside the bag can survive up to a number of minutes equal to 10 divided by the number of creatures (minimum 1 minute), after which time they begin to suffocate.\n\nPlacing a _bag of holding_ inside an extradimensional space created by a _handy haversack_, _portable hole_, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Bag of Holding",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "",
             "slug": "bag-of-holding",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This seemingly empty cloth bag comes in several colors and has a small, fuzzy object inside. \n\nYou can use an action to pull a fuzzy object from the bag and throw it up to 20 feet. Upon landing, it becomes a creature determined by a roll on the Bag of Tricks table (depending on the bag\u2019s color). \n\nThe resulting creature is friendly to you and any companions you have. It acts on your turn, during which you can use a bonus action to give it simple commands such as \u201cattack that creature\u201d or \u201cmove over there\u201d. If the creature dies or if you use the bag again, it disappears without a trace. After the first use each day, there is a 50% chance that a creature from the bag is hostile instead of friendly and obedient.\n\nOnce you have used the bag three times, you cannot do so again until the next dawn.\n\n__**Table: Bags of Tricks**__\n| Blue bag of tricks (uncommon; cost 400 gp) |                     | Gray bag of tricks (uncommon; cost 350 gp) |                | Green bag of tricks (rare; cost 800 gp) |                   | Rust bag of tricks (uncommon; cost 400 gp**)** |              | Tan bag of tricks (uncommon; cost 300 gp) |                |\n| ------------------------------------------ | ------------------- | ------------------------------------------ | -------------- | --------------------------------------- | ----------------- | ---------------------------------------------- | ------------ | ----------------------------------------- | -------------- |\n| **d8**                                     | **Creatu**re        | d8                                         | **Creature**   | **d8**                                  | **Creature**      | **d8**                                         | **Creature** | **d8**                                    | **Creature**   |\n| 1                                          | _Quipper_           | 1                                          | _Weasel_       | 1                                       | _Giant Crocodile_ | 1                                              | _Rat_        | 1                                         | _Jackal_       |\n| 2                                          | _Octopus_           | 2                                          | _Giant rat_    | 2                                       | _Allosaurus_      | 2                                              | _Owl_        | 2                                         | _Ape_          |\n| 3                                          | _Seahorse_          | 3                                          | _Badger_       | 3                                       | _Ankylosaurus_    | 3                                              | _Mastiff_    | 3                                         | _Baboon_       |\n| 4                                          | _Hunter Shark_      | 4                                          | _Boar_         | 4                                       | _Raptor_          | 4                                              | _Goat_       | 4                                         | _Axe Beak_     |\n| 5                                          | _Swarm of quippers_ | 5                                          | _Panther_      | 5                                       | _Giant lizard_    | 5                                              | _Giant Goat_ | 5                                         | _Black Bear_   |\n| 6                                          | _Reef shark_        | 6                                          | _Giant Badger_ | 6                                       | _Triceratops_     | 6                                              | _Giant Boar_ | 6                                         | _Giant Weasel_ |\n| 7                                          | _Giant Seahorse_    | 7                                          | _Dire Wolf_    | 7                                       | _Plesiosaurus_    | 7                                              | _Lion_       | 7                                         | _Giant Hyena_  |\n| 8                                          | _Giant Octopus_     | 8                                          | _Giant Elk_    | 8                                       | _Pteranodon_      | 8                                              | _Brown Bear_ | 8                                         | _Tiger_        |",
+            "desc": "This ordinary bag, made from gray, rust, or tan cloth, appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object. The bag weighs 1/2 pound.\n\nYou can use an action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling a d8 and consulting the table that corresponds to the bag's color.\n\nThe creature is friendly to you and your companions, and it acts on your turn. You can use a bonus action to command how the creature moves and what action it takes on its next turn, or to give it general orders, such as to attack your enemies. In the absence of such orders, the creature acts in a fashion appropriate to its nature.\n\nOnce three fuzzy objects have been pulled from the bag, the bag can't be used again until the next dawn.\n\n**Gray Bag of Tricks (table)**\n\n| d8 | Creature     |\n|----|--------------|\n| 1  | Weasel       |\n| 2  | Giant rat    |\n| 3  | Badger       |\n| 4  | Boar         |\n| 5  | Panther      |\n| 6  | Giant badger |\n| 7  | Dire wolf    |\n| 8  | Giant elk    |\n\n**Rust Bag of Tricks (table)**\n\n| d8 | Creature   |\n|----|------------|\n| 1  | Rat        |\n| 2  | Owl        |\n| 3  | Mastiff    |\n| 4  | Goat       |\n| 5  | Giant goat |\n| 6  | Giant boar |\n| 7  | Lion       |\n| 8  | Brown bear |\n\n**Tan Bag of Tricks (table)**\n\n| d8 | Creature     |\n|----|--------------|\n| 1  | Jackal       |\n| 2  | Ape          |\n| 3  | Baboon       |\n| 4  | Axe beak     |\n| 5  | Black bear   |\n| 6  | Giant weasel |\n| 7  | Giant hyena  |\n| 8  | Tiger        |",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Bag of Tricks",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "",
             "slug": "bag-of-tricks",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This sphere of black glass is \u00be an inch in diameter and can be thrown up to 60 feet as an action. On impact it creates a 10-foot radius explosion. Creatures in the area make a DC 15 Dexterity _saving throw_ , taking 5d4 force damage on a failure. A sphere of force then encloses the same area for 1 minute. Any creature that is completely in the area and fails its save is trapped within the sphere. Creatures that succeed on the save or that are only partially within the area are pushed away from the point of impact until they are outside the sphere instead. \n\nThe wall of the sphere only allows air to pass, stopping all other attacks and effects. A creature inside the sphere can use its action to push against the sides of the sphere, moving up to half its Speed. The sphere only weighs 1 pound if lifted, regardless of the weight of the creatures inside.",
+            "desc": "This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 _beads of force_ are found together.\n\nYou can use an action to throw the bead up to 60 feet. The bead explodes on impact and is destroyed. Each creature within a 10-foot radius of where the bead landed must succeed on a DC 15 Dexterity saving throw or take 5d4 force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save, or are partially within the area, are pushed away from the center of the sphere until they are no longer inside it. Only breathable air can pass through the sphere's wall. No attack or other effect can.\n\nAn enclosed creature can use its action to push against the sphere's wall, moving the sphere up to half the creature's walking speed. The sphere can be picked up, and its magic causes it to weigh only 1 pound, regardless of the weight of creatures inside.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Bead of Force",
-            "rarity": "Rare",
-            "requires_attunement": "requires attunement",
+            "rarity": "rare",
+            "requires_attunement": "",
             "slug": "bead-of-force",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing this belt, you gain the following benefits:\n\n* Your Constitution score increases by 2, to a maximum of 20.\n* _Advantage_  on Charisma (Persuasion) checks made against dwarves.\n* _Advantage_  on saving throws against poison, and resistance to poison damage.\n* Darkvision to a range of 60 feet.\n* The ability to speak, read, sign, and write Dwarvish.\n\nIn addition, while you are attuned to this belt there is a 50% chance at dawn each day that you grow a full beard (or a noticeably thicker beard if you have one already).",
+            "desc": "While wearing this belt, you gain the following benefits:\n\n* Your Constitution score increases by 2, to a maximum of 20.\n* You have advantage on Charisma (Persuasion) checks made to interact with dwarves.\n\nIn addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you're capable of growing one, or a visibly thicker beard if you already have one.\n\nIf you aren't a dwarf, you gain the following additional benefits while wearing the belt:\n\n* You have advantage on saving throws against poison, and you have resistance against poison damage.\n* You have darkvision out to a range of 60 feet.\n* You can speak, read, and write Dwarvish.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Belt of Dwarvenkind",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "belt-of-dwarvenkind",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "Braided rope made of hair from the same kind of giant as the belt to be made\n\nWearing this belt increases your Strength score to the score granted by the belt. It has no effect if your Strength is equal to or greater than the belt\u2019s score.\n\nEach variety of belt corresponds with a different kind of giant.\n\n__**Table: Belts of Giant Strength**__\n| **Type**                  | **Strength** | **Rarity** | **Cost**   |\n| ------------------------- | ------------ | ---------- | ---------- |\n| _Hill giant_              | 20           | Rare       | 4,000 gp   |\n| _Frost_  or _stone giant_ | 23           | Very rare  | 9,000 gp   |\n| _Fire giant_              | 25           | Very rare  | 20,000 gp  |\n| _Cloud giant_             | 27           | Legendary  | 55,000 gp  |\n| _Storm giant_             | 29           | Legendary  | 150,000 gp |",
+            "desc": "While wearing this belt, your Strength score changes to a score granted by the belt. If your Strength is already equal to or greater than the belt's score, the item has no effect on you.\n\nSix varieties of this belt exist, corresponding with and having rarity according to the six kinds of true giants. The _belt of stone giant strength_ and the _belt of frost giant strength_ look different, but they have the same effect.\n\n| Type              | Strength | Rarity    |\n|-------------------|----------|-----------|\n| Hill giant        | 21       | Rare      |\n| Stone/frost giant | 23       | Very rare |\n| Fire giant        | 25       | Very rare |\n| Cloud giant       | 27       | Legendary |\n| Storm giant       | 29       | Legendary |",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Belt of Giant Strength",
-            "rarity": "Rare",
+            "rarity": "varies",
             "requires_attunement": "requires attunement",
             "slug": "belt-of-giant-strength",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "You gain +1 bonus to attack and damage rolls made with this magic axe, and while you are attuned to it your hit point maximum is increased by 1 for each level you have attained. \n\n**Curse.** After you attune to this axe you are unwilling to part with it, keeping it within reach at all times. In addition, you have _disadvantage_  on attack rolls with weapons other than this one unless the nearest foe you are aware of is 60 feet or more away from you.\n\nIn addition, when you are damaged by a hostile creature you make a DC 15 Wisdom _saving throw_  or go berserk. While berserk, on your turn each round you move to the nearest creature and take the Attack action against it, moving to attack the next nearest creature after you _incapacitate_  your current target. When there is more than one possible target, you randomly determine which to attack. You continue to be berserk until there are no creatures you can see or hear within 60 feet of you at the start of your turn. ",
+            "desc": "You gain a +1 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.\n\n**_Curse_**. This axe is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the axe, keeping it within reach at all times. You also have disadvantage on attack rolls with weapons other than this one, unless no foe is within 60 feet of you that you can see or hear.\n\nWhenever a hostile creature damages you while the axe is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. While berserk, you must use your action each round to attack the creature nearest to you with the axe. If you can make extra attacks as part of the Attack action, you use those extra attacks, moving to attack the next nearest creature after you fell your current target. If you have multiple possible targets, you attack one at random. You are berserk until you start your turn with no creatures within 60 feet of you that you can see or hear.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Berserker Axe",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "berserker-axe",
-            "type": "Weapon"
+            "type": "Weapon (any axe)"
         },
         {
-            "desc": "These boots cause your steps to make no sound, no matter the material stepped upon. While wearing these boots, you gain _advantage_  on Dexterity (Stealth) checks to move silently.",
+            "desc": "While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have advantage on Dexterity (Stealth) checks that rely on moving silently.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Boots of Elvenkind",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "",
             "slug": "boots-of-elvenkind",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing these boots, up to 3 times between _long rests_  you can use an action to cast __levitate_  on yourself.",
+            "desc": "While you wear these boots, you can use an action to cast the _levitate_ spell on yourself at will.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Boots of Levitation",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "boots-of-levitation",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing these boots, you can use a bonus action to click the heels together. You double your base Speed, and opportunity attacks made against you have _disadvantage_ . You can end the effect as a bonus action.\n\nOnce the boots have been used in this way for a total of 10 minutes (each use expends a minimum of 1 minute), they cease to function until you finish a _long rest_ .",
+            "desc": "While you wear these boots, you can use a bonus action and click the boots' heels together. If you do, the boots double your walking speed, and any creature that makes an opportunity attack against you has disadvantage on the attack roll. If you click your heels together again, you end the effect.\n\nWhen the boots' property has been used for a total of 10 minutes, the magic ceases to function until you finish a long rest.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Boots of Speed",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "boots-of-speed",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing these boots, your Speed increases to 30 feet, unless it is higher, regardless of encumbrance or armor. In addition, your jump distances increase 15 feet vertically and 30 feet horizontally (as the _jump_  spell).",
+            "desc": "While you wear these boots, your walking speed becomes 30 feet, unless your walking speed is higher, and your speed isn't reduced if you are encumbered or wearing heavy armor. In addition, you can jump three times the normal distance, though you can't jump farther than your remaining movement would allow.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Boots of Striding and Springing",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "requires attunement",
             "slug": "boots-of-striding-and-springing",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing these boots, you gain the following benefits:\n\n* Resistance to cold damage.\n* You ignore _difficult terrain_  caused by ice or snow.\n* You can survive temperatures as low as \u201350\u00b0 Fahrenheit (\u201346\u00b0 Celsius) without effect, or as low as \u2013100\u00b0 Fahrenheit (\u201374\u00b0 Celsius) with heavy clothes.",
+            "desc": "These furred boots are snug and feel quite warm. While you wear them, you gain the following benefits:\n\n* You have resistance to cold damage.\n* You ignore difficult terrain created by ice or snow.\n* You can tolerate temperatures as low as -50 degrees Fahrenheit without any additional protection. If you wear heavy clothes, you can tolerate temperatures as low as -100 degrees Fahrenheit.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Boots of the Winterlands",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "requires attunement",
             "slug": "boots-of-the-winterlands",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This heavy glass bowl weighs 3 pounds and can hold 3 gallons of water. While it is filled, you can use an action to summon a _water elemental_  as if you had cast the _conjure elemental_  spell. Once used, you must wait until the next dawn to use it again.",
+            "desc": "While this bowl is filled with water, you can use an action to speak the bowl's command word and summon a water elemental, as if you had cast the _conjure elemental_ spell. The bowl can't be used this way again until the next dawn.\n\nThe bowl is about 1 foot in diameter and half as deep. It weighs 3 pounds and holds about 3 gallons.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Bowl of Commanding Water Elementals",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "",
             "slug": "bowl-of-commanding-water-elementals",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing these bracers, you gain proficiency with the longbow and shortbow, and you gain a +2 bonus on damage rolls on ranged attacks made with them.",
+            "desc": "While wearing these bracers, you have proficiency with the longbow and shortbow, and you gain a +2 bonus to damage rolls on ranged attacks made with such weapons.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Bracers of Archery",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "requires attunement",
             "slug": "bracers-of-archery",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing these bracers, you gain a +2 bonus to AC if you are not wearing armor or using a shield.",
+            "desc": "While wearing these bracers, you gain a +2 bonus to AC if you are wearing no armor and using no shield.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Bracers of Defense",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "bracers-of-defense",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While fire burns in this 5 pound brass brazier, you can use an action to summon a _fire elemental_  as if you had cast the __conjure elemental_  spell. Once used, you must wait until the next dawn to use it again.",
+            "desc": "While a fire burns in this brass brazier, you can use an action to speak the brazier's command word and summon a fire elemental, as if you had cast the _conjure elemental_ spell. The brazier can't be used this way again until the next dawn.\n\nThe brazier weighs 5 pounds.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Brazier of Commanding Fire Elementals",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "",
             "slug": "brazier-of-commanding-fire-elementals",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing this brooch, you gain resistance to force damage and immunity to the _magic missile_  spell.",
+            "desc": "While wearing this brooch, you have resistance to force damage, and you have immunity to damage from the _magic missile_ spell.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Brooch of Shielding",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "requires attunement",
             "slug": "brooch-of-shielding",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "You can sit astride this ordinary-seeming 3 pound broom and speak its command word, causing it to hover. While it is hovering you can ride the broom to fly through the air. The broom can carry up to 200 pounds at a speed of 40 feet, or up to 400 pounds at a speed of 20 feet. It stops hovering if you land.\n\nYou can send the broom up to 1 mile from you by speaking its command word and naming a location you are familiar with. It can also be called back from up to a mile away with a different command word.",
+            "desc": "This wooden broom, which weighs 3 pounds, functions like a mundane broom until you stand astride it and speak its command word. It then hovers beneath you and can be ridden in the air. It has a flying speed of 50 feet. It can carry up to 400 pounds, but its flying speed becomes 30 feet while carrying over 200 pounds. The broom stops hovering when you land.\n\nYou can send the broom to travel alone to a destination within 1 mile of you if you speak the command word, name the location, and are familiar with that place. The broom comes back to you when you speak another command word, provided that the broom is still within 1 mile of you.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Broom of Flying",
-            "rarity": "Rare",
+            "rarity": "uncommon",
             "requires_attunement": "",
             "slug": "broom-of-flying",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This golden candle is infused with raw divine magic. When attuned to by a cleric or druid, it takes on a color appropriate to the cleric\u2019s deity. \n\nYou can use an action to light the candle and activate its magic. The candle can burn for a total of 4 hours in 1 minute increments before being used up. \n\nWhile lit, the candle sheds dim light in a 30-foot radius. Any creature within the area who worships the same deity as the attuned creature (or at the Narrator\u2019s discretion, an allied deity) has _advantage_  on _attack rolls_ , _saving throws_ , and ability checks. If one of the creatures gaining the prior benefit is also a cleric, druid, or herald, they can cast 1st-level spells from one of those classes at that spell level without expending spell slots.\n\nAlternatively, one of these candles that has not yet been lit can be used to cast the __gate_ spell. Doing so consumes the candle.",
+            "desc": "This slender taper is dedicated to a deity and shares that deity's alignment. The candle's alignment can be detected with the _detect evil and good_ spell. The GM chooses the god and associated alignment or determines the alignment randomly.\n\n| d20   | Alignment       |\n|-------|-----------------|\n| 1-2   | Chaotic evil    |\n| 3-4   | Chaotic neutral |\n| 5-7   | Chaotic good    |\n| 8-9   | Neutral evil    |\n| 10-11 | Neutral         |\n| 12-13 | Neutral good    |\n| 14-15 | Lawful evil     |\n| 16-17 | Lawful neutral  |\n| 18-20 | Lawful good     |\n\nThe candle's magic is activated when the candle is lit, which requires an action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time. Deduct the time it burned in increments of 1 minute from the candle's total burn time.\n\nWhile lit, the candle sheds dim light in a 30-foot radius. Any creature within that light whose alignment matches that of the candle makes attack rolls, saving throws, and ability checks with advantage. In addition, a cleric or druid in the light whose alignment matches the candle's can cast 1st* level spells he or she has prepared without expending spell slots, though the spell's effect is as if cast with a 1st-level slot.\n\nAlternatively, when you light the candle for the first time, you can cast the _gate_ spell with it. Doing so destroys the candle.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Candle of Invocation",
-            "rarity": "Very Rare",
+            "rarity": "very rare",
             "requires_attunement": "requires attunement",
             "slug": "candle-of-invocation",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing this cape, you can use an action to cast _dimension door_  once between _long rests_ . You disappear and reappear in a cloud of smoke which dissipates at the end of your next turn, or sooner if conditions are windy.",
+            "desc": "This cape smells faintly of brimstone. While wearing it, you can use it to cast the _dimension door_ spell as an action. This property of the cape can't be used again until the next dawn.\n\nWhen you disappear, you leave behind a cloud of smoke, and you appear in a similar cloud of smoke at your destination. The smoke lightly obscures the space you left and the space you appear in, and it dissipates at the end of your next turn. A light or stronger wind disperses the smoke.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cape of the Mountebank",
-            "rarity": "Rare",
-            "requires_attunement": "requires attunement",
+            "rarity": "rare",
+            "requires_attunement": "",
             "slug": "cape-of-the-mountebank",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "You can use an action to speak this carpet\u2019s command word, making it hover and fly. It moves according to your verbal commands as long as you are within 30 feet of it. \n\nThese carpets come in four sizes. The Narrator can choose or randomly determine which size a given carpet is.\n\nIf the carpet is carrying half its capacity or less, its Speed is doubled.\n\n__**Table: Carpet of Flying**__\n| **d20** | **Size**      | **Capacity** | **Flying Speed** | **Cost**  |\n| ------- | ------------- | ------------ | ---------------- | --------- |\n| 1-4     | 3 ft. x 5 ft. | 250 lb.      | 30 ft.           | 15,000 gp |\n| 5-11    | 4 ft. x 6 ft. | 500 lb.      | 25 ft.           | 20,000 gp |\n| 12-16   | 5 ft. x 7 ft. | 800 lb.      | 20 ft.           | 25,000 gp |\n| 17-20   | 6 ft. x 9 ft. | 1,000 lb.    | 15 ft.           | 30,000 gp |",
+            "desc": "You can speak the carpet's command word as an action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.\n\nFour sizes of _carpet of flying_ exist. The GM chooses the size of a given carpet or determines it randomly.\n\n| d100   | Size          | Capacity | Flying Speed |\n|--------|---------------|----------|--------------|\n| 01-20  | 3 ft. \u00d7 5 ft. | 200 lb.  | 80 feet      |\n| 21-55  | 4 ft. \u00d7 6 ft. | 400 lb.  | 60 feet      |\n| 56-80  | 5 ft. \u00d7 7 ft. | 600 lb.  | 40 feet      |\n| 81-100 | 6 ft. \u00d7 9 ft. | 800 lb.  | 30 feet      |\n\nA carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Carpet of Flying",
-            "rarity": "Very Rare",
+            "rarity": "very rare",
             "requires_attunement": "",
             "slug": "carpet-of-flying",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While incense burns in this 1 pound censer, you can use an action to summon an _air elemental_  as if you had cast the __conjure elemental_ spell. Once used, you must wait until the next dawn to use it again.",
+            "desc": "While incense is burning in this censer, you can use an action to speak the censer's command word and summon an air elemental, as if you had cast the _conjure elemental_ spell. The censer can't be used this way again until the next dawn.\n\nThis 6-inch-wide, 1-foot-high vessel resembles a chalice with a decorated lid. It weighs 1 pound.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Censer of Controlling Air Elementals",
-            "rarity": "Rare",
-            "requires_attunement": "requires attunement",
+            "rarity": "rare",
+            "requires_attunement": "",
             "slug": "censer-of-controlling-air-elementals",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "You can use an action to strike this foot-long metal tube while pointing it at an object that can be opened (such as a lid, lock, or window) within 120 feet. The chime sounds and one lock or latch on the object opens as long as the sound can reach the object. If no closures remain, the object itself opens. After being struck 10 times, the chime cracks and becomes useless.",
+            "desc": "This hollow metal tube measures about 1 foot long and weighs 1 pound. You can strike it as an action, pointing it at an object within 120 feet of you that can be opened, such as a door, lid, or lock. The chime issues a clear tone, and one lock or latch on the object opens unless the sound can't reach the object. If no locks or latches remain, the object itself opens.\n\nThe chime can be used ten times. After the tenth time, it cracks and becomes useless.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Chime of Opening",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "",
             "slug": "chime-of-opening",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "Once per dawn, while wearing this circlet you can use an action to cast _scorching ray_ . The attack bonus for the spell when cast this way is +5.",
+            "desc": "While wearing this circlet, you can use an action to cast the _scorching ray_ spell with it. When you make the spell's attacks, you do so with an attack bonus of +5. The circlet can't be used this way again until the next dawn.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Circlet of Blasting",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "",
             "slug": "circlet-of-blasting",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing this cloak, you gain the following benefits:\n\n* Resistance to poison damage.\n* A climbing speed equal to your base Speed, allowing hands-free movement across vertical and upside down surfaces.\n* The ability to ignore the effects of webs and move through them as if they were _difficult terrain_ .\n\nOnce between long rests you can use an action to cast the __web_  spell (save DC 13), except it fills double the normal area.",
+            "desc": "This fine garment is made of black silk interwoven with faint silvery threads. While wearing it, you gain the following benefits:\n\n* You have resistance to poison damage.\n* You have a climbing speed equal to your walking speed.\n* You can move up, down, and across vertical surfaces and upside down along ceilings, while leaving your hands free.\n* You can't be caught in webs of any sort and can move through webs as if they were difficult terrain.\n* You can use an action to cast the _web_ spell (save DC 13). The web created by the spell fills twice its normal area. Once used, this property of the cloak can't be used again until the next dawn.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cloak of Arachnida",
-            "rarity": "Very Rare",
+            "rarity": "very rare",
             "requires_attunement": "requires attunement",
             "slug": "cloak-of-arachnida",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This cloak creates a visual illusion that distorts your position. _Attack rolls_  against you have _disadvantage_  unless the attacker does not rely on sight. When you take damage, this property stops until the start of your next turn, and it is otherwise negated if you are _incapacitated_ , _restrained_ , or unable to move.",
+            "desc": "While you wear this cloak, it projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while you are incapacitated, restrained, or otherwise unable to move.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cloak of Displacement",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "cloak-of-displacement",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While you wear this cloak with its hood up, its color changes to camouflage you. While camouflaged, you gain _advantage_  on Dexterity (Stealth) checks made to hide and creatures have _disadvantage_  on Wisdom (Perception) checks made to see you. You can use an action to put the hood up or down.",
+            "desc": "While you wear this cloak with its hood up, Wisdom (Perception) checks made to see you have disadvantage, and you have advantage on Dexterity (Stealth) checks made to hide, as the cloak's color shifts to camouflage you. Pulling the hood up or down requires an action.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cloak of Elvenkind",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "requires attunement",
             "slug": "cloak-of-elvenkind",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing this cloak, you gain a +1 bonus to Armor Class and _saving throws_ .",
+            "desc": "You gain a +1 bonus to AC and saving throws while you wear this cloak.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cloak of Protection",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "requires attunement",
             "slug": "cloak-of-protection",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While wearing this cloak, you gain _advantage_  on Dexterity (Stealth) checks. In addition, while in an area of _dim light or darkness_ , you gain the following benefits:\n\n* A fly speed of 40 feet while gripping the edges of the cloak with both hands.\n* Once between _long rests_  you can use an action to cast _polymorph_  on yourself, transforming into a bat. Unlike normal, you retain your Intelligence, Wisdom, and Charisma scores.",
+            "desc": "While wearing this cloak, you have advantage on Dexterity (Stealth) checks. In an area of dim light or darkness, you can grip the edges of the cloak with both hands and use it to fly at a speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in dim light or darkness, you lose this flying speed.\n\nWhile wearing the cloak in an area of dim light or darkness, you can use your action to cast _polymorph_ on yourself, transforming into a bat. While you are in the form of the bat, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cloak of the Bat",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "cloak-of-the-bat",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "While you wear this cloak with its hood up, you gain a swim speed of 60 feet and can breathe water. You can use an action to put the hood up or down.",
+            "desc": "While wearing this cloak with its hood up, you can breathe underwater, and you have a swimming speed of 60 feet. Pulling the hood up or down requires an action.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cloak of the Manta Ray",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "",
             "slug": "cloak-of-the-manta-ray",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "A typical enchanted _crystal ball_ can be used to cast the __scrying_ spell (save DC 17) once between _short rests_  while touching it. \n\nThree legendary variations exist. In all cases, the legendary variants have an alignment (Chaotic, Evil, Good, or Lawful). If you do not have an alignment trait that matches the _crystal ball\u2019s_, after using it you take 6d6 psychic damage and gain a level of _strife_ .\n\n**Crystal Ball of Mind Reading**. You can use an action to cast __detect thoughts_  (save DC 17) on a creature within 30 feet of the spell\u2019s sensor. This effect does not require concentration, but it ends when the _scrying_ does.\n\n**Crystal Ball of Telepathy**. While the __scrying_ is active, you can communicate telepathically with creatures within 30 feet of the spell\u2019s sensor, and you can use an action to cast sugges_tion_ (save DC 17) through the sensor on one of them. This effect does not require concentration, but it ends when the _scrying_ does.\n\n**Crystal Ball of True Seeing**. In addition to the normal benefits of __scrying_ , you gain _truesight_ through the spell\u2019s sensor out to a range of 120 feet.",
+            "desc": "The typical _crystal ball_, a very rare item, is about 6 inches in diameter. While touching it, you can cast the _scrying_ spell (save DC 17) with it.\n\nThe following _crystal ball_ variants are legendary items and have additional properties.\n\n**_Crystal Ball of Mind Reading_**. You can use an action to cast the _detect thoughts_ spell (save DC 17) while you are scrying with the _crystal ball_, targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this _detect thoughts_ to maintain it during its duration, but it ends if _scrying_ ends.\n\n**_Crystal Ball of Telepathy_**. While scrying with the crystal ball, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also use an action to cast the _suggestion_ spell (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this _suggestion_ to maintain it during its duration, but it ends if _scrying_ ends. Once used, the _suggestion_ power of the _crystal ball_ can't be used again until the next dawn.\n\n**_Crystal Ball of True Seeing_**. While scrying with the crystal ball, you have truesight with a radius of 120 feet centered on the spell's sensor.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Crystal Ball",
-            "rarity": "Very Rare",
+            "rarity": "very rare or legendary",
             "requires_attunement": "requires attunement",
             "slug": "crystal-ball",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This inch-long cube has a recessed button with a distinct marking on each face. It starts with 36 charges and regains 1d20 of them at dawn. \n\nYou can use an action to press one of the buttons, expending charges as shown on the Cube of Force table. If the cube has insufficient charges, nothing happens.\n\nOtherwise, the cube creates a 15-foot cube of force that is centered on you and moves with you. It lasts for 1 minute, until you use an action to press another button, or the cube\u2019s charges are depleted. \n\nYou can change the cube\u2019s effect by pressing a different button. Doing so expends the requisite number of charges and resets the duration.\n\nIf moving causes the cube to come into contact with a solid object that can't pass through the cube, you cannot move any closer to that object while the cube is active.\n\nThe cube loses charges when targeted by effects from the following spells or magic items: _disintegrate_ (1d12 charges), __horn of blasting_ (1d10 charges), __passwall_  (1d6 charges), __prismatic spray_  (1d20 charges), __wall of fire_  (1d4 charges).\n\n__**Table: Cube of Force**__\n| **Face** | **Charges** | **Effect**                                                                                              |\n| -------- | ----------- | ------------------------------------------------------------------------------------------------------- |\n| 1        | 1           | Gasses, wind, and fog can\u2019t penetrate the cube.                                                         |\n| 2        | 2           | Nonliving matter can\u2019t penetrate the cube, except for walls, floors, and ceilings (at your discretion). |\n| 3        | 3           | Living matter can\u2019t penetrate the cube.                                                                 |\n| 4        | 4           | Spell effects can\u2019t penetrate the cube.                                                                 |\n| 5        | 5           | Nothing penetrates the cube (exception for walls, floors, and ceilings at your discretion).             |\n| 6        | 0           | Deactivate the cube.                                                                                    |",
+            "desc": "This cube is about an inch across. Each face has a distinct marking on it that can be pressed. The cube starts with 36 charges, and it regains 1d20 expended charges daily at dawn.\n\nYou can use an action to press one of the cube's faces, expending a number of charges based on the chosen face, as shown in the Cube of Force Faces table. Each face has a different effect. If the cube has insufficient charges remaining, nothing happens. Otherwise, a barrier of invisible force springs into existence, forming a cube 15 feet on a side. The barrier is centered on you, moves with you, and lasts for 1 minute, until you use an action to press the cube's sixth face, or the cube runs out of charges. You can change the barrier's effect by pressing a different face of the cube and expending the requisite number of charges, resetting the duration.\n\nIf your movement causes the barrier to come into contact with a solid object that can't pass through the cube, you can't move any closer to that object as long as the barrier remains.\n\n**Cube of Force Faces (table)**\n\n| Face | Charges | Effect                                                                                                            |\n|------|---------|-------------------------------------------------------------------------------------------------------------------|\n| 1    | 1       | Gases, wind, and fog can't pass through the barrier.                                                              |\n| 2    | 2       | Nonliving matter can't pass through the barrier. Walls, floors, and ceilings can pass through at your discretion. |\n| 3    | 3       | Living matter can't pass through the barrier.                                                                     |\n| 4    | 4       | Spell effects can't pass through the barrier.                                                                     |\n| 5    | 5       | Nothing can pass through the barrier. Walls, floors, and ceilings can pass through at your discretion.            |\n| 6    | 0       | The barrier deactivates.                                                                                          |\n\nThe cube loses charges when the barrier is targeted by certain spells or comes into contact with certain spell or magic item effects, as shown in the table below.\n\n| Spell or Item    | Charges Lost |\n|------------------|--------------|\n| Disintegrate     | 1d12         |\n| Horn of blasting | 1d10         |\n| Passwall         | 1d6          |\n| Prismatic spray  | 1d20         |\n| Wall of fire     | 1d4          |",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cube of Force",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "requires attunement",
             "slug": "cube-of-force",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This 3-inch cube has 3 charges and regains 1d3 charges each dawn. Each side of the cube is keyed to a different plane, one of which is the Material Plane. The other five sides are determined by the Narrator.\n\nAs an action, you may press one side of the cube and spend a charge to cast the _gate  s_pell, expending a charge and opening a portal to the associated plane. You may instead press a side twice, expending 2 charges and casting _plane shift_ (save DC 17) which sends the targets to the associated plane.",
+            "desc": "This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the GM.\n\nYou can use an action to press one side of the cube to cast the _gate_ spell with it, opening a portal to the plane keyed to that side. Alternatively, if you use an action to press one side twice, you can cast the _plane shift_ spell (save DC 17) with the cube and transport the targets to the plane keyed to that side.\n\nThe cube has 3 charges. Each use of the cube expends 1 charge. The cube regains 1d3 expended charges daily at dawn.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Cubic Gate",
-            "rarity": "Legendary",
+            "rarity": "legendary",
             "requires_attunement": "",
             "slug": "cubic-gate",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "You gain a +1 bonus to attack and damage rolls made with this magic blade. In addition, once each dawn you can use an action to poison the dagger\u2019s blade for 1 minute or until it is used to damage a creature. When a creature is damaged by the blade\u2019s poison, it makes a DC 15 Constitution _saving throw_  or takes 2d10 poison damage and becomes _poisoned_  for 1 minute.",
+            "desc": "You gain a +1 bonus to attack and damage rolls made with this magic weapon.\n\nYou can use an action to cause thick, black poison to coat the blade. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 poison damage and become poisoned for 1 minute. The dagger can't be used this way again until the next dawn.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Dagger of Venom",
-            "rarity": "Rare",
+            "rarity": "rare",
             "requires_attunement": "",
             "slug": "dagger-of-venom",
-            "type": "Weapon"
+            "type": "Weapon (dagger)"
         },
         {
-            "desc": "While you are attuned to this magic sword, you can use a bonus action to speak the command word and throw it into the air. The sword hovers, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it (using your _attack roll_  and ability score modifier to damage rolls). On each of your turns you can use a bonus action to make the sword fly up to 30 feet to attack another creature within 5 feet of it. \n\nAfter the sword attacks for the fourth time, it tries to return to your hand. It flies 30 feet towards you, moving as close as it can before either being caught in your free hand or falling to the ground.\n\nThe sword ceases to hover if you move more than 30 feet away from it or grasp it.",
+            "desc": "You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.\n\nWhile the sword hovers, you can use a bonus action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same bonus action, you can cause the sword to attack one creature within 5 feet of it.\n\nAfter the hovering sword attacks for the fourth time, it flies up to 30 feet and tries to return to your hand. If you have no hand free, it falls to the ground at your feet. If the sword has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or move more than 30 feet away from it.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Dancing Sword",
-            "rarity": "Very Rare",
+            "rarity": "very rare",
             "requires_attunement": "requires attunement",
             "slug": "dancing-sword",
-            "type": "Weapon"
+            "type": "Weapon (any sword)"
         },
         {
-            "desc": "This flask sloshes when shaken as if full of water. You can use an action to remove the stopper and speak a command word, causing undrinkable water to flow out of the flask. It stops at the start of your next turn. \n\n**Stream**. This command word produces 1 gallon of water.\n\n**Fountain.** This command word produces 5 gallons of water.\n\n**Geyser.** This command word produces 30 gallons of water that manifests as a geyser 30 feet long and 1 foot wide. As a bonus action, you can aim the geyser at a target within 30 feet, forcing it to make a DC 13 Strength _saving throw_  or take 1d4 bludgeoning damage and be knocked _prone_ . Any object less than 200 pounds is knocked over or pushed up to 15 feet away.",
+            "desc": "This stoppered flask sloshes when shaken, as if it contains water. The decanter weighs 2 pounds.\n\nYou can use an action to remove the stopper and speak one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following options:\n\n* \"Stream\" produces 1 gallon of water.\n* \"Fountain\" produces 5 gallons of water.\n* \"Geyser\" produces 30 gallons of water that gushes forth in a geyser 30 feet long and 1 foot wide. As a bonus action while holding the decanter, you can aim the geyser at a creature you can see within 30 feet of you. The target must succeed on a DC 13 Strength saving throw or take 1d4 bludgeoning damage and fall prone. Instead of a creature, you can target an object that isn't being worn or carried and that weighs no more than 200 pounds. The object is either knocked over or pushed up to 15 feet away from you.",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Decanter of Endless Water",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "",
             "slug": "decanter-of-endless-water",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "This box houses a set of 34 illustrated cards when new. A found deck is typically missing 1d20 cards. \n\nAs an action, you can draw a random card (one manually selected does nothing) and throw it up to 30 feet from you. \n\nUpon landing, the card creates an illusion of one or more creatures. These illusions are of normal size for the creatures depicted and act normally, but are insubstantial and harmless. While you are within 120 feet of the illusion, you can use an action to move it anywhere within 30 feet from its card. \n\nThe illusions are revealed to a creature when it uses an action to make a DC 15 Investigation check or automatically upon any physical interaction. Once revealed, an illusion becomes translucent.\n\nThe illusion lasts until its card is moved or it is dispelled. In either case the card disappears and cannot be reused.\n\n__**Table: Deck of Illusions**__\n| **Playing Card**    | **Illusion**                 |\n| ------------------- | ---------------------------- |\n| \u2663 Ace of Clubs      | Iron golem                   |\n| \u2663 King of Clubs     | Erinyes                      |\n| \u2663 Jack of Clubs     | Berserker                    |\n| \u2663 Ten of Clubs      | Hill giant                   |\n| \u2663 Nine of Clubs     | Ogre                         |\n| \u2663 Eight of Clubs    | Orc                          |\n| \u2663 Two of Clubs      | Kobold                       |\n| \u2666 Ace of Diamonds   | Murmuring worm               |\n| \u2666 King of Diamonds  | Archmage and mage apprentice |\n| \u2666 Queen of Diamonds | Night hag                    |\n| \u2666 Jack of Diamonds  | Assassin                     |\n| \u2666 Ten of Diamonds   | Fire giant                   |\n| \u2666 Nine of Diamonds  | Ogre mage                    |\n| \u2666 Eight of Diamonds | Gnoll                        |\n| \u2666 Two of Diamonds   | Kobold                       |\n| \u2665 Ace of Hearts     | Red dragon                   |\n| \u2665 King of Hearts    | Knight and 4 guards          |\n| \u2665 Queen of Hearts   | Incubus/Succubus             |\n| \u2665 Jack of Hearts    | Druid                        |\n| \u2665 Ten of Hearts     | Cloud giant                  |\n| \u2665 Nine of Hearts    | Ettin                        |\n| \u2665 Eight of Hearts   | Bugbear                      |\n| \u2665 Two of Hearts     | Goblin                       |\n| \u2660 Ace of Spades     | Lich                         |\n| \u2660 King of Spades    | Priest and 2 acolytes        |\n| \u2660 Queen of Spades   | Medusa                       |\n| \u2660 Jack of Spades    | Veteran                      |\n| \u2660 Ten of Spades     | Frost giant                  |\n| \u2660 Nine of Spades    | Troll                        |\n| \u2660 Eight of Spades   | Hobgoblin                    |\n| \u2660 Two of Spades     | Goblin                       |\n| \ud83c\udccf Joker (2)        | The deck\u2019s wielder           |",
+            "desc": "This box contains a set of parchment cards. A full deck has 34 cards. A deck found as treasure is usually missing 1d20 - 1 cards.\n\nThe magic of the deck functions only if cards are drawn at random (you can use an altered deck of playing cards to simulate the deck). You can use an action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of you.\n\nAn illusion of one or more creatures forms over the thrown card and remains until dispelled. An illusory creature appears real, of the appropriate size, and behaves as if it were a real creature except that it can do no harm. While you are within 120 feet of the illusory creature and can see it, you can use an action to move it magically anywhere within 30 feet of its card. Any physical interaction with the illusory creature reveals it to be an illusion, because objects pass through it. Someone who uses an action to visually inspect the creature identifies it as illusory with a successful DC 15 Intelligence (Investigation) check. The creature then appears translucent.\n\nThe illusion lasts until its card is moved or the illusion is dispelled. When the illusion ends, the image on its card disappears, and that card can't be used again.\n\n| Playing Card      | Illusion                         |\n|-------------------|----------------------------------|\n| Ace of hearts     | Red dragon                       |\n| King of hearts    | Knight and four guards           |\n| Queen of hearts   | Succubus or incubus              |\n| Jack of hearts    | Druid                            |\n| Ten of hearts     | Cloud giant                      |\n| Nine of hearts    | Ettin                            |\n| Eight of hearts   | Bugbear                          |\n| Two of hearts     | Goblin                           |\n| Ace of diamonds   | Beholder                         |\n| King of diamonds  | Archmage and mage apprentice     |\n| Queen of diamonds | Night hag                        |\n| Jack of diamonds  | Assassin                         |\n| Ten of diamonds   | Fire giant                       |\n| Nine of diamonds  | Ogre mage                        |\n| Eight of diamonds | Gnoll                            |\n| Two of diamonds   | Kobold                           |\n| Ace of spades     | Lich                             |\n| King of spades    | Priest and two acolytes          |\n| Queen of spades   | Medusa                           |\n| Jack of spades    | Veteran                          |\n| Ten of spades     | Frost giant                      |\n| Nine of spades    | Troll                            |\n| Eight of spades   | Hobgoblin                        |\n| Two of spades     | Goblin                           |\n| Ace of clubs      | Iron golem                       |\n| King of clubs     | Bandit captain and three bandits |\n| Queen of clubs    | Erinyes                          |\n| Jack of clubs     | Berserker                        |\n| Ten of clubs      | Hill giant                       |\n| Nine of clubs     | Ogre                             |\n| Eight of clubs    | Orc                              |\n| Two of clubs      | Kobold                           |\n| Jokers (2)        | You (the deck's owner)           |",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Deck of Illusions",
-            "rarity": "Uncommon",
+            "rarity": "uncommon",
             "requires_attunement": "",
             "slug": "deck-of-illusions",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         },
         {
-            "desc": "A legend of ruination and wonder to those that have heard of it, the _Deck of Many Things_ is the fickle power of fate distilled. Most were created by gods of luck and are found in small and ornately carved coffers and have only 13 cards, but some have the full 22\\. The Narrator may decide, or roll 1d4 to determine randomly (a partial deck on a 1\u20133, or a full deck on a 4).\n\nBefore drawing, you must declare the number of cards that you intend to draw. A modified poker deck can be used to create your own physical deck using the substitutions below. A card's magic takes effect as soon as it is drawn. Once you begin drawing, each subsequent card must be drawn within an hour of the card that came before it. Failure to do so causes all of your remaining draws to fly out of the deck and take effect immediately. Once a card is drawn, if it is not a joker it is reshuffled into the deck, making it possible to draw the same card twice.\n\nOnce you have drawn the number of cards that you\u2019ve declared, the deck resets and you may never draw from that deck again. Once all individuals present when the deck is discovered have drawn their cards, roll 1d4\\. On a 1\u20133 the deck vanishes, or on a 4 it returns to its coffer, allowing you to transport it should you so choose.\n\nThe Balance, Comet, Donjon, Fates, Fool, Gem, Idiot, Talons, and Vizier cards only appear in the 22 card deck.\n\n---\n\n\u2663 **Ace of Clubs: Talons.** Every magical item that you own is immediately destroyed. Artifacts are not destroyed and are instead cast into the multiverse.\n\n\u2663 **King of Clubs: Void.** Your soul is torn from your body and trapped in an object in a location of the Narrator\u2019s choosing where it is guarded by powerful beings. While your soul is trapped, your body is incapacitated. Even a _wish_ cannot restore your soul, but it can reveal its location. Any remaining draws from the deck are lost.\n\n\u2663 **Queen of Clubs: Flames.** You gain the enmity of a powerful devil. It seeks to destroy you along with all that you love or have built, inflicting as much misery upon you and your loved ones as possible before finally slaying you. This antagonism lasts until either you or the devil perish.\n\n\u2663 **Jack of Clubs: Skull.** A merciless harbinger of death appears and attempts to slay you. The harbinger appears in an unoccupied space within 10 feet and immediately attacks. A sense of mortal dread fills any allies present, warning them to stay away. The harbinger fights until you die or it is reduced to 0 hit points. It cannot be harmed by anyone other than you, and if anyone other than you attempts to harm it, another harbinger of death is summoned for them. Creatures slain by a harbinger cannot be restored to life by any means.\n\n\u2663 **Two of Clubs: Idiot.** Your Intelligence score is permanently reduced by 1d4+1, to a minimum of 1\\. You may draw one additional card beyond what you declared.\n\n\u2666 **Ace of Diamonds: Vizier.** At any point within a year of drawing this card, you may ask a question while meditating and immediately receive a truthful answer that helps you to solve a problem or dilemma as well as the wisdom and the knowledge to apply it.\n\n\u2666 **King of Diamonds: Sun.** You gain 50,000 XP, and a randomly determined wondrous item appears in your hands.\n\n\u2666 **Queen of Diamonds: Moon.** You are granted 1d3 wishes (as the __wish_ spell).\n\n\u2666 **Jack of Diamonds: Star.** Increase an ability score of your choice by 2\\. The score cannot exceed 24.\n\n\u2666 **Two of Diamonds: Comet.** Defeating the next hostile monster or group of monsters alone will grant you enough experience points to advance to the next level.\n\n\u2665 **Ace of Hearts: Fates.** You are granted the ability to reweave the fabric of reality, allowing you to circumvent or erase a single event as though it had never happened. You may use this ability immediately upon drawing the card or at any point prior to your death.\n\n\u2665 **King of Hearts: Throne.** You are granted proficiency in the Persuasion skill and gain a 1d6 expertise die on all Charisma (Persuasion) checks. You are also granted legal domain over a small keep or fortress on the plane that your character inhabits. Your new domain is overrun by monsters and must be liberated before it can be inhabited.\n\n\u2665 **Queen of Hearts: Key.** A magic weapon of at least rare rarity that you are proficient with appears in your hand. The weapon is chosen by the Narrator.\n\n\u2665 **Jack of Hearts: Knight.** A _veteran_  appears and offers you their service, believing it to be destiny, and will serve you loyalty unto death. You control this character.\n\n\u2665 **Two of Hearts: Gem.** You are showered in wealth. A total of 25 trinkets, easily portable pieces of art, or jewelry worth 2,000 gold each, or 50 gems worth 1,000 gold each appear directly in front of you. \n\n\u2660 **Ace of Spades: Donjon.** You vanish and are trapped in an extradimensional space. You are either unconscious in a sphere (50%) or trapped in a nightmare realm drawn from your own experiences and fears (50%). You remain in your prison until you are freed. While divination magics cannot locate you, a wish spell reveals the location of your prison. You cannot draw any more cards.\n\n\u2660 **King of Spades: Ruin.** All nonmagical wealth that you own is lost. Material items vanish. Property and other holdings are lost along with any documentation. You are destitute.\n\n\u2660 **Queen of Spades: Euryale.** You are _cursed_  by the card. You suffer a permanent \u20132 penalty to all _saving throws_ . Only a god or the Fates Card can end this curse.\n\n\u2660 **Jack of Spades: Rogue.** A trusted ally, friend, or other NPC (chosen by the Narrator) becomes a bitter enemy, although their identity is not revealed. They will act against you based upon their abilities and resources, and will try to utterly destroy you. Only a _wish_ spell or divine intervention can end the NPC\u2019s hostility. \n\n\u2660 **Two of Spades: Balance.** Your history rewrites itself. You gain a randomly determined background, replacing your background feature with the new background feature. You do not change the skill proficiencies or ability score increases from your previous background, or gain new skill proficiencies or ability score increases.\n\n\ud83c\udccf **Joker with Trademark: Fool.** You lose 10,000 xp and must immediately draw again. If the experience lost in this manner would cause you to lose a level, you are instead reduced to the beginning of your current level instead.\n\n\ud83c\udccf **Joker without Trademark: Jester.** Fortune smiles on the foolish. Either gain 10,000 XP or draw twice more from the deck beyond what you declared.\n\n---\n\n**Harbinger of Death Challenge** \u2014\n\n_Medium undead_ 0 XP\n\n**Armor Class** 20\n\n**Hit Points** half the hit point maximum of its summoner\n\n**Speed** 60 ft., fly 60 ft. (hover)\n\n**STR DEX CON INT WIS CHA**\n\n16 (+3) 16 (+3) 16 (+3) 16 (+3) 16 (+3) 16 (+3)\n\n**Proficiency** +3; **Maneuver** DC 14\n\n**Damage Immunities** necrotic, poison\n\n**Condition Immunities** _charmed_ , _frightened_ , _paralyzed_ , _petrified_ , _poisoned_ , _unconscious_ \n\n**Senses** darkvision 60 ft., truesight 60 ft., passive Perception 13\n\n**Languages** all languages known to its summoner\n\n_**Incorporeal Movement.**_ The harbinger can move through other creatures and objects as if they were _difficult terrain_ . It takes 5 (1d10) force damage if it ends its turn inside an object.\n\n_**Turning Immunity**_. The harbinger is immune to features that turn undead.\n\nACTIONS\n\n**_Reaping Scythe_**. The harbinger sweeps its spectral scythe through a creature within 5 feet of it, dealing 7 (1d8+3) slashing damage plus 4 (1d8) necrotic damage. The sixth time and each subsequent time that a creature is damaged by this attack, it makes a DC 14 Charisma _saving throw_  or becomes _doomed_ .",
+            "desc": "Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have only thirteen cards, but the rest have twenty-two.\n\nBefore you draw a card, you must declare how many cards you intend to draw and then draw them randomly (you can use an altered deck of playing cards to simulate the deck). Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.\n\nOnce a card is drawn, it fades from existence. Unless the card is the Fool or the Jester, the card reappears in the deck, making it possible to draw the same card twice.\n\n| Playing Card       | Card        |\n|--------------------|-------------|\n| Ace of diamonds    | Vizier\\*    |\n| King of diamonds   | Sun         |\n| Queen of diamonds  | Moon        |\n| Jack of diamonds   | Star        |\n| Two of diamonds    | Comet\\*     |\n| Ace of hearts      | The Fates\\* |\n| King of hearts     | Throne      |\n| Queen of hearts    | Key         |\n| Jack of hearts     | Knight      |\n| Two of hearts      | Gem\\*       |\n| Ace of clubs       | Talons\\*    |\n| King of clubs      | The Void    |\n| Queen of clubs     | Flames      |\n| Jack of clubs      | Skull       |\n| Two of clubs       | Idiot\\*     |\n| Ace of spades      | Donjon\\*    |\n| King of spades     | Ruin        |\n| Queen of spades    | Euryale     |\n| Jack of spades     | Rogue       |\n| Two of spades      | Balance\\*   |\n| Joker (with TM)    | Fool\\*      |\n| Joker (without TM) | Jester      |\n\n\\*Found only in a deck with twenty-two cards\n\n**_Balance_**. Your mind suffers a wrenching alteration, causing your alignment to change. Lawful becomes chaotic, good becomes evil, and vice versa. If you are true neutral or unaligned, this card has no effect on you.\n\n**_Comet_**. If you single-handedly defeat the next hostile monster or group of monsters you encounter, you gain experience points enough to gain one level. Otherwise, this card has no effect.\n\n**_Donjon_**. You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you were wearing and carrying stays behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any divination magic, but a _wish_ spell can reveal the location of your prison. You draw no more cards.\n\n**_Euryale_**. The card's medusa-like visage curses you. You take a -2 penalty on saving throws while cursed in this way. Only a god or the magic of The Fates card can end this curse.\n\n**_The Fates_**. Reality's fabric unravels and spins anew, allowing you to avoid or erase one event as if it never happened. You can use the card's magic as soon as you draw the card or at any other time before you die.\n\n**_Flames_**. A powerful devil becomes your enemy. The devil seeks your ruin and plagues your life, savoring your suffering before attempting to slay you. This enmity lasts until either you or the devil dies.\n\n**_Fool_**. You lose 10,000 XP, discard this card, and draw from the deck again, counting both draws as one of your declared draws. If losing that much XP would cause you to lose a level, you instead lose an amount that leaves you with just enough XP to keep your level.\n\n**_Gem_**. Twenty-five pieces of jewelry worth 2,000 gp each or fifty gems worth 1,000 gp each appear at your feet.\n\n**_Idiot_**. Permanently reduce your Intelligence by 1d4 + 1 (to a minimum score of 1). You can draw one additional card beyond your declared draws.\n\n**_Jester_**. You gain 10,000 XP, or you can draw two additional cards beyond your declared draws.\n\n**_Key_**. A rare or rarer magic weapon with which you are proficient appears in your hands. The GM chooses the weapon.\n\n**_Knight_**. You gain the service of a 4th-level fighter who appears in a space you choose within 30 feet of you. The fighter is of the same race as you and serves you loyally until death, believing the fates have drawn him or her to you. You control this character.\n\n**_Moon_**. You are granted the ability to cast the _wish_ spell 1d3 times.\n\n**_Rogue_**. A nonplayer character of the GM's choice becomes hostile toward you. The identity of your new enemy isn't known until the NPC or someone else reveals it. Nothing less than a _wish_ spell or divine intervention can end the NPC's hostility toward you.\n\n**_Ruin_**. All forms of wealth that you carry or own, other than magic items, are lost to you. Portable property vanishes. Businesses, buildings, and land you own are lost in a way that alters reality the least. Any documentation that proves you should own something lost to this card also disappears.\n\n**_Skull_**. You summon an avatar of death-a ghostly humanoid skeleton clad in a tattered black robe and carrying a spectral scythe. It appears in a space of the GM's choice within 10 feet of you and attacks you, warning all others that you must win the battle alone. The avatar fights until you die or it drops to 0 hit points, whereupon it disappears. If anyone tries to help you, the helper summons its own avatar of death. A creature slain by an avatar of death can't be restored to life.\n\n#",
             "document__slug": "wotc-srd",
             "document__title": "5e Core Rules",
             "document__url": "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
             "name": "Deck of Many Things",
-            "rarity": "Legendary",
+            "rarity": "legendary",
             "requires_attunement": "",
             "slug": "deck-of-many-things",
-            "type": "Wondrous Item"
+            "type": "Wondrous item"
         }
     ]
 }


### PR DESCRIPTION
The slug field for magic items was not read, causing magic items with the same name from different publishers to overwrite each other. Using the slug field again adds back about 300 items which were previously not showing.

Thanks to @mshea for the detailed bug report on Discord.