### PR TITLE
Add missing keyword "blindsight" to Vile Barber

### DIFF
--- a/data/tome_of_beasts/monsters.json
+++ b/data/tome_of_beasts/monsters.json
@@ -25356,7 +25356,7 @@
         "stealth": 6,
         "damage_resistances": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered or cold iron weapons",
         "condition_immunities": "frightened",
-        "senses": "60 ft., passive Perception 9",
+        "senses": "blindsight 60 ft., passive Perception 9",
         "languages": "Common, Goblin, Sylvan, Umbral",
         "challenge_rating": "2",
         "special_abilities": [


### PR DESCRIPTION
Previously under "Senses" we just had "60 ft." when it should have read "blindsight 60ft."