### PR TITLE
Bugfix: typo in Part of the Pack feat

### DIFF
--- a/api/tests/approved_files/TestAPIRoot.test_feats.approved.json
+++ b/api/tests/approved_files/TestAPIRoot.test_feats.approved.json
@@ -608,9 +608,9 @@
                 "* Through growls, barks, and gestures, you can communicate simple ideas with canines. For the purposes of this feat, a \"canine\" is any beast with dog or wolf-like features. You can understand them in return, though this is often limited to knowing the creature's current or most recent state, such as \"hungry\", \"content\", or \"in danger.\"",
                 "* As an action, you can howl to summon a wolf to assist you. The wolf appears in 1d4 rounds and remains within 50 feet of you until 1 hour elapses or until it dies, whichever occurs first. You can't control the wolf, but it doesn't attack you or your companions. It acts on its own initiative, and it attacks creatures attacking you or your companions. If you are 5th level or higher, your howl summons a number of wolves equal to your proficiency bonus. When your howl summons multiple wolves, you have a 50 percent chance that one of the wolves is a dire wolf instead. Your summoned pack can have no more than one dire wolf. While at least one wolf is with you, you have advantage on Wisdom (Survival) checks to hunt for food or to find shelter. At the GM's discretion, you may not be able to summon a wolf or multiple wolves if you are indoors or in a region where wolves aren't native, such as the middle of the sea. Once you have howled to summon a wolf or wolves with this feat, you must finish a long rest before you can do so again."
             ],
-            "name": "Part of the Pact",
+            "name": "Part of the Pack",
             "prerequisite": "*Proficiency in the Animal Handling skill*",
-            "slug": "part-of-the-pact"
+            "slug": "part-of-the-pack"
         },
         {
             "desc": "Your mastery of mundane healing arts borders on the mystical.",

--- a/data/v1/toh/Feat.json
+++ b/data/v1/toh/Feat.json
@@ -113,9 +113,9 @@
 },
 {
   "model": "api.feat",
-  "pk": "part-of-the-pact",
+  "pk": "part-of-the-pack",
   "fields": {
-    "name": "Part of the Pact",
+    "name": "Part of the Pack",
     "desc": "Wolves are never seen to be far from your side and consider you to be a packmate. You gain the following benefits:",
     "document": 44,
     "created_at": "2023-11-05T00:01:41.577",


### PR DESCRIPTION
This PR fixes a typo in the **Part of the Pack** feat from Tome of  Heroes.

It is currently listed erroneously under the name [Part of the Pact](https://open5e.com/feats/part-of-the-pact) on the live site.