### PR TITLE
Minor docs/env improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,9 @@ server/whoosh_index/
 
 .vscode/
 
+# pycharm config
+.idea/
+# pyenv env file
+.python-version
+
 api/tests/approved_files/*.recieved.*

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ The API uses the Django REST Framework for it's browsability and ease of use whe
 
 - [Python 3.11](https://www.python.org/downloads/)
 
-- [Pipenv](https://pipenv.pypa.io/en/latest/installation/)
+- [Pipenv](https://pipenv.pypa.io/en/latest/installation.html)
 
-## Modules
+## Dependencies
 
 Pipenv is used to install all required packages from the `Pipfile` at the project root. Use the following command after cloning the project or switching branches.
 


### PR DESCRIPTION
Changes:

- adds two lines to the gitignore for PyCharm and pyenv dev environment files and folders.
- fixes the pipenv installation link. Current one leads to 404 which lead me to the main page where installation is done via apt package manager, this again caused issues as it was an older incompatible version. Potentially could expand here to make it clear that pipenv needs to be installed with pip.
- Rename Modules to Dependencies as that is what you do there.
