### PR TITLE
Minor docs improvement

### DIFF
--- a/docs/v2/data.md
+++ b/docs/v2/data.md
@@ -17,7 +17,7 @@ The actual data.
 
 ## Import
 To import data, there's a new django command.
-> python manage.py import --dir data/v2/
+> pipenv run python manage.py import --dir data/v2/
 
 This is based on logic found here, and leverages django's built-in concept of fixtures.
 > /api_v2/management/commands/import.py
@@ -30,10 +30,10 @@ V2 data can be edited using the built-in django admin interface. This allows for
 To setup the admin interface, first, follow the setup instructions in Readme.md. Then try the following commands.
 
 This will force a prompt to create a custom superuser for the local instance.
-> python manage.py createsuperuser
+> pipenv run python manage.py createsuperuser
 
 Once done, you should be able to run the server.
-> python manage.py runserver
+> pipenv run python manage.py runserver
 
 Then you can aim your browser at the default admin interface, and log in using the credentials you just created.
 > http://localhost:8000/admin/
@@ -42,7 +42,7 @@ You will see forms and lists of objects that are editable. These edits will appl
 
 ## Export
 To export data, there's a new django command. For now only models used in the v2 API are supported for export.
-> python manage.py export --dir data/
+> pipenv run python manage.py export --dir data
 
 This is based on logic found here, and leverages django's built-in concept of fixtures, but structures the folders in a way that's consistent and flexible.
 > /api_v2/management/commands/export.py


### PR DESCRIPTION
add pipenv run to each of the commands in docs/v2/data.md. This ensures that the .env file is loaded which is required as it asks for the SECRET_KEY env variable.

Remove trailing / on the export command as it is not required and just doubles up the slash.