### PR TITLE
Query monster name by partial match

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -85,12 +85,11 @@ class MonsterFilter(CommonFilterSet):
                 "exact",
                 "in",
             ],
-            "name": ["iexact", "exact"],
+            "name": ["iexact", "exact", "icontains"],
             "desc": ["iexact", "exact", "in", "icontains"],
             "cr": ["exact", "range", "gt", "gte", "lt", "lte"],
             "armor_class": ["exact", "range", "gt", "gte", "lt", "lte"],
             "type": ["iexact", "exact", "in", "icontains"],
-            "name": ["iexact", "exact"],
             "page_no": ["exact", "range", "gt", "gte", "lt", "lte"],
             "document__slug": [
                 "iexact",


### PR DESCRIPTION
Adding in the ability to perform a query against monster name to find partial matches.

The following url will return all monsters that have "orc" in the name.
http://api.open5e.com/v1/monsters/?name__icontains=orc
