### PR TITLE
Query Monsters by size and hit points

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -91,6 +91,7 @@ class MonsterFilter(CommonFilterSet):
             "hit_points": ["exact", "range", "gt", "gte", "lt", "lte"],
             "armor_class": ["exact", "range", "gt", "gte", "lt", "lte"],
             "type": ["iexact", "exact", "in", "icontains"],
+            "size": ["iexact", "exact", "in", "icontains"],
             "page_no": ["exact", "range", "gt", "gte", "lt", "lte"],
             "document__slug": [
                 "iexact",

--- a/api/filters.py
+++ b/api/filters.py
@@ -88,6 +88,7 @@ class MonsterFilter(CommonFilterSet):
             "name": ["iexact", "exact", "icontains"],
             "desc": ["iexact", "exact", "in", "icontains"],
             "cr": ["exact", "range", "gt", "gte", "lt", "lte"],
+            "hit_points": ["exact", "range", "gt", "gte", "lt", "lte"],
             "armor_class": ["exact", "range", "gt", "gte", "lt", "lte"],
             "type": ["iexact", "exact", "in", "icontains"],
             "page_no": ["exact", "range", "gt", "gte", "lt", "lte"],


### PR DESCRIPTION
These fields were not searchable. This created a problem for the new [Pagination](https://github.com/open5e/open5e/pull/530) feature for the Open5e site, which now relies on the API for filtering.