### PR TITLE
Bugfix: V2 Documents - filtering by query param

### DIFF
--- a/api_v2/serializers/document.py
+++ b/api_v2/serializers/document.py
@@ -1,5 +1,6 @@
 """Serializers for Ruleset, License, Publisher, and Document models."""
 from rest_framework import serializers
+from .abstracts import GameContentSerializer
 
 from api_v2 import models
 
@@ -27,10 +28,9 @@ class PublisherSerializer(serializers.HyperlinkedModelSerializer):
         fields = '__all__'
 
 
-class DocumentSerializer(serializers.HyperlinkedModelSerializer):
+class DocumentSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
-    stats = serializers.ReadOnlyField()
 
     class Meta:
         model = models.Document
-        fields = "__all__"
+        fields = '__all__'

--- a/api_v2/views/document.py
+++ b/api_v2/views/document.py
@@ -1,7 +1,7 @@
 """Viewsets for the Document, Ruleset, Publisher, and License Serializers."""
 from rest_framework import viewsets
-
-from django_filters import FilterSet
+from django_filters import FilterSet, CharFilter
+from django.db.models import JSONField
 
 from api_v2 import models
 from api_v2 import serializers
@@ -18,6 +18,18 @@ class RulesetViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.RulesetSerializer
 
 
+class DocumentFilterSet(FilterSet):
+    '''This is the filterset class for Documents.'''
+    
+    class Meta:
+        model = models.Document
+        fields = '__all__'
+        filter_overrides = {
+            JSONField: {
+                'filter_class': CharFilter
+            }
+        }
+
 class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of documents.
@@ -25,7 +37,7 @@ class DocumentViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = models.Document.objects.all().order_by('pk')
     serializer_class = serializers.DocumentSerializer
-    #filterset_fields = '__all__'
+    filterset_class = DocumentFilterSet
 
 
 class PublisherViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
This PR closes #518 by:

- Updating the V2 Documents serializer to inherit from `GameContentSerializer`, where the filtering by query parameter logic is implemented
- Add a filter override to the Document view so that Django knows how to deal with JSONFields

Tests are passing and all appears to work well on local: `http://localhost:8000/v2/documents/?fields=key` returns only keys, `http://localhost:8000/v2/documents/?fields=key,name`  returns only keys and name, &c