### PR TITLE
expose ruleset & publisher name/key on documents endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ server/whoosh_index/
 .python-version
 
 api/tests/approved_files/*.recieved.*
+*.sqlite3-journal

--- a/api_v2/serializers/document.py
+++ b/api_v2/serializers/document.py
@@ -30,7 +30,30 @@ class PublisherSerializer(serializers.HyperlinkedModelSerializer):
 
 class DocumentSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
+    stats = serializers.ReadOnlyField()
+    publisher_name = serializers.SerializerMethodField()
+    publisher_key = serializers.SerializerMethodField()
+    ruleset_name = serializers.SerializerMethodField()
+    ruleset_key = serializers.SerializerMethodField()
 
+    def get_publisher_name(self, obj):
+        return obj.publisher.name if obj.publisher else None
+
+    def get_publisher_key(self, obj):
+        return obj.publisher.key if obj.publisher else None
+    
+    def get_publisher_name(self, obj):
+        return obj.publisher.name if obj.publisher else None
+
+    def get_publisher_key(self, obj):
+        return obj.publisher.key if obj.publisher else None
+    
+    def get_ruleset_name(self, obj):
+        return obj.ruleset.name if obj.ruleset else None
+
+    def get_ruleset_key(self, obj):
+        return obj.ruleset.key if obj.ruleset else None
+    
     class Meta:
         model = models.Document
         fields = '__all__'

--- a/api_v2/serializers/document.py
+++ b/api_v2/serializers/document.py
@@ -42,12 +42,6 @@ class DocumentSerializer(GameContentSerializer):
     def get_publisher_key(self, obj):
         return obj.publisher.key if obj.publisher else None
     
-    def get_publisher_name(self, obj):
-        return obj.publisher.name if obj.publisher else None
-
-    def get_publisher_key(self, obj):
-        return obj.publisher.key if obj.publisher else None
-    
     def get_ruleset_name(self, obj):
         return obj.ruleset.name if obj.ruleset else None
 


### PR DESCRIPTION
The most common use-case for documents in practice is selecting content, which is often selected by publisher (expected: ruleset once it is available)

Given that common use-case and the small size of these resources, it seems more user-friendly to expose these properties on the documents endpoint instead of requiring a 2n additional server calls (two per document) to retrieve them.