### PR TITLE
added name icontains and type exact to creature filterset

### DIFF
--- a/api_v2/views/creature.py
+++ b/api_v2/views/creature.py
@@ -13,10 +13,11 @@ class CreatureFilterSet(FilterSet):
         model = models.Creature
         fields = {
             'key': ['in', 'iexact', 'exact' ],
-            'name': ['iexact', 'exact'],
+            'name': ['iexact', 'exact', 'icontains'],
             'document__key': ['in','iexact','exact'],
             'document__ruleset__key': ['in','iexact','exact'],
             'size': ['exact'],
+            'type': ['exact'],
             'challenge_rating_decimal': ['exact','lt','lte','gt','gte'],
             'armor_class': ['exact','lt','lte','gt','gte'],
             'ability_score_strength': ['exact','lt','lte','gt','gte'],


### PR DESCRIPTION
Close #529 by adding additional filtering options to the Creature filterset. User will name be able query for partial matches on article name and exact matches for creature type using the `?name_icontains` and `?type` query parameters