### PR TITLE
V2: added is_subclass filter to `characterclass` view

### DIFF
--- a/api_v2/views/characterclass.py
+++ b/api_v2/views/characterclass.py
@@ -2,12 +2,15 @@
 from rest_framework import viewsets
 
 from django_filters import FilterSet
+from django_filters import BooleanFilter
 
 from api_v2 import models
 from api_v2 import serializers
 
 
 class CharacterClassFilterSet(FilterSet):
+    is_subclass = BooleanFilter(field_name='subclass_of', lookup_expr='isnull', exclude=True)
+
     class Meta:
         model = models.CharacterClass
         fields = {


### PR DESCRIPTION
This PR adds a simple filter to the V2 `characterclass` view to allow API consumers to filter the `/classes` endpoint by whether items are classes or subclasses.

This feature is necessary to preserve the functionality of the `/classes` route on the Open5e website (issue https://github.com/open5e/open5e/issues/568). Formerly this endpoint only returned classes, but now it returns both classes AND subclasses