### PR TITLE
V2 Feature: filtering `/classes` endpoint by `?subclass_of` query param

### DIFF
--- a/api_v2/views/characterclass.py
+++ b/api_v2/views/characterclass.py
@@ -18,6 +18,7 @@ class CharacterClassFilterSet(FilterSet):
             'name': ['iexact', 'exact','contains'],
             'document__key': ['in','iexact','exact'],
             'document__ruleset__key': ['in','iexact','exact'],
+            'subclass_of': ['exact']
         }
 
 


### PR DESCRIPTION
This PR adds support for filtering subclasses returned by the V2 `/classes` endpoint by which base class they are a subclass of.

While PR #531 added for filtering for only base-classes or sub-classes via the query parameters, this PR allows the API to request the subclasses of a specific class via the `?subclass_of=` query parameter. This feature is currently used on the front end V2 dev branch to render a list of subclasses on their base class's page.