### PR TITLE
V2 Feature: `/search` now returns more helpful data

### DIFF
--- a/api_v2/models/characterclass.py
+++ b/api_v2/models/characterclass.py
@@ -113,4 +113,12 @@ class CharacterClass(HasName, FromDocument):
 
         return text
 
+    def search_result_extra_fields(self):
+        return {
+            "subclass_of": { 
+                "name": self.subclass_of.name,
+                "key": self.subclass_of.key
+            } if self.subclass_of else None
+        }
+    
     #TODO add verbose name plural

--- a/api_v2/models/creature.py
+++ b/api_v2/models/creature.py
@@ -82,10 +82,10 @@ class Creature(Object, HasAbilities, HasSenses, HasLanguage, HasSpeed, FromDocum
 
     def search_result_extra_fields(self):
         return {
-            "armor_class":self.armor_class,
-            "hit_points":self.hit_points,
-            "ability_scores":self.get_ability_scores(),
-              }
+            "cr": self.challenge_rating_text,
+            "type": self.type.name,
+            "size": self.size.name,   
+        }
 
     @property
     def creatureset(self):

--- a/api_v2/models/item.py
+++ b/api_v2/models/item.py
@@ -81,11 +81,11 @@ class Item(Object, HasDescription, FromDocument):
         return self.rarity is not None
 
     def search_result_extra_fields(self):
-        fields = {"type":self.category.key}
-        if self.is_magic_item:
-            fields["rarity"]=self.rarity.key
-        return fields
-
+        return {
+            "is_magic_item": self.is_magic_item,
+            "type": self.category.name if self.is_magic_item else None,
+            "rarity": self.rarity.name if self.is_magic_item else None,
+        }
 
 
 class ItemSet(HasName, HasDescription, FromDocument):

--- a/api_v2/models/race.py
+++ b/api_v2/models/race.py
@@ -39,6 +39,13 @@ class Race(HasName, HasDescription, FromDocument):
         """Returns the set of traits that are related to this race."""
         return self.racetrait_set
 
+    def search_result_extra_fields(self):
+        return {
+            "subrace_of": { 
+                "name": self.subrace_of.name,
+                "key": self.subrace_of.key
+            } if self.subrace_of else None
+        }
     class Meta:
         """To assist with the UI layer."""
 

--- a/api_v2/models/spell.py
+++ b/api_v2/models/spell.py
@@ -142,7 +142,12 @@ class Spell(HasName, HasDescription, FromDocument):
             return self.document.distance_unit
         return self.range_unit
 
-
+    def search_result_extra_fields(self):
+        return {
+            "school": self.school.name,
+            "level": self.level,
+        }
+        
 class SpellCastingOption(models.Model):
     """An object representing an alternative way to cast a spell."""
 

--- a/api_v2/serializers/search.py
+++ b/api_v2/serializers/search.py
@@ -49,6 +49,8 @@ class SearchResultSerializer(serializers.ModelSerializer):
                 result_detail = models.Spell.objects.get(pk=obj.object_pk)
             if obj.object_model == 'CharacterClass':
                 result_detail = models.CharacterClass.objects.get(pk=obj.object_pk)
+            if obj.object_model == 'Race':
+                result_detail = models.Race.objects.get(pk=obj.object_pk)
 
         if result_detail is not None:
             return result_detail.search_result_extra_fields()

--- a/api_v2/serializers/search.py
+++ b/api_v2/serializers/search.py
@@ -39,7 +39,7 @@ class SearchResultSerializer(serializers.ModelSerializer):
                 result_detail = v1.Spell.objects.get(slug=obj.object_pk)
             if obj.object_model == 'Section':
                 result_detail = v1.Section.objects.get(slug=obj.object_pk)
-
+        
         if obj.schema_version == 'v2':
             if obj.object_model == 'Item':
                 result_detail = models.Item.objects.get(pk=obj.object_pk)
@@ -47,6 +47,8 @@ class SearchResultSerializer(serializers.ModelSerializer):
                 result_detail = models.Creature.objects.get(pk=obj.object_pk)
             if obj.object_model == 'Spell':
                 result_detail = models.Spell.objects.get(pk=obj.object_pk)
+            if obj.object_model == 'CharacterClass':
+                result_detail = models.CharacterClass.objects.get(pk=obj.object_pk)
 
         if result_detail is not None:
             return result_detail.search_result_extra_fields()


### PR DESCRIPTION
This PR was created to address minor errorsin how the Open5e API V2 `/search` endpoint functioned which were exposed during the front-end migration over to V2.

These changes update which fields are included in the `object` properties of results returned by the `/search` endpoint. In some cases these were  changed to improve aesthetics and navigation on the front-end (ie. for a creature, it is much more important to sees its Type on the /search page, rather than, say, its AC), but in other cases these extra fields are vital to link to the correct page on the website (ie. the CharacterClass endpoint now returns both base- and sub- classes, these resources are accessed via different URL structures, so it is critical to have this information on the FE if we want to link to the searched resource)