### PR TITLE
Bugfix: add missing sorting options to V2 Items endpoint

### DIFF
--- a/api_v2/views/item.py
+++ b/api_v2/views/item.py
@@ -13,14 +13,14 @@ class ItemFilterSet(FilterSet):
     class Meta:
         model = models.Item
         fields = {
-            'key': ['in', 'iexact', 'exact' ],
-            'name': ['iexact', 'exact'],
+            'key': ['in', 'iexact', 'exact'],
+            'name': ['iexact', 'exact', 'icontains'],
             'desc': ['icontains'],
             'cost': ['exact', 'range', 'gt', 'gte', 'lt', 'lte'],
             'weight': ['exact', 'range', 'gt', 'gte', 'lt', 'lte'],
-#            'rarity': ['exact', 'in', ],
+            'rarity': ['exact', 'in'],
             'requires_attunement': ['exact'],
-            #'category': ['in', 'iexact', 'exact'],
+            'category': ['in', 'exact'],
             'document__key': ['in','iexact','exact'],
             'document__ruleset__key': ['in','iexact','exact'],
         }


### PR DESCRIPTION
This PR adds back a few sort options to the `/items` endpoint that were present on API V1 but missing on V2.

I encountered these discrepancies while updating the `/magic-items` route on the front-end to pull its data from API V2. The filtering UI, which made use of these filter parameters, were torpedoed until these changes were made.