### PR TITLE
Fixing up spell endpoint to fetch all needed data beforehand

### DIFF
--- a/api_v2/views/spell.py
+++ b/api_v2/views/spell.py
@@ -38,3 +38,23 @@ class SpellViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.SpellSerializer
     filterset_class = SpellFilterSet
 
+    def get_queryset(self):
+        queryset = models.Spell.objects.all().order_by('pk')
+        depth = self.get_serializer().Meta.depth
+        queryset = SpellViewSet.setup_eager_loading(queryset, depth)
+        return queryset
+
+    @staticmethod
+    def setup_eager_loading(queryset, depth):
+        selects = ['document', 'school']
+        prefetches = ['classes', 'spellcastingoption_set']
+
+        if depth >= 1:
+            prefetches = prefetches + ['document__licenses']
+        
+        if depth >= 2:
+            prefetches = prefetches + ['document__gamesystem', 'document__publisher']
+
+        queryset = queryset.select_related(*selects).prefetch_related(*prefetches)
+        return queryset
+


### PR DESCRIPTION
Added in the related tables that were being fetched row by row when querying spells.  Locally, the speed went from 263 ms to 51 ms with these changes.  Data returned is the same, but performs 5 queries versus >250.

We should be able to apply this to other endpoints, but I first wanted to test this change out to see if it's working better.