### PR TITLE
Bugfix (API V2): Added missing Serializers to `CreatureSerializer`

### DIFF
--- a/api_v2/serializers/creature.py
+++ b/api_v2/serializers/creature.py
@@ -8,6 +8,8 @@ from api_v2 import models
 
 from .abstracts import GameContentSerializer
 from .document import DocumentSerializer
+from .language import LanguageSerializer
+from .environment import EnvironmentSerializer
 from .size import SizeSerializer
 from drf_spectacular.utils import extend_schema_field, inline_serializer
 from drf_spectacular.types import OpenApiTypes
@@ -63,6 +65,8 @@ class CreatureSerializer(GameContentSerializer):
     document = DocumentSerializer()
     type = CreatureTypeSerializer()
     size = SizeSerializer()
+    languages = LanguageSerializer(many=True)
+    environments = EnvironmentSerializer(many=True)
 
     class Meta:
         '''Serializer meta options.'''

--- a/api_v2/tests/responses/TestObjects.test_creature_ancient_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creature_ancient_example.approved.json
@@ -133,16 +133,52 @@
     "darkvision_range": 120.0,
     "document": "http://localhost:8000/v2/documents/srd/",
     "environments": [
-        "http://localhost:8000/v2/environments/hills/",
-        "http://localhost:8000/v2/environments/mountain/"
+        {
+            "aquatic": false,
+            "desc": "[None Provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "hills",
+            "name": "Hills",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/hills/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "mountain",
+            "name": "Mountain",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/mountain/"
+        }
     ],
     "experience_points": 62000,
     "hit_dice": "28d20+252",
     "hit_points": 546,
     "key": "srd_ancient-red-dragon",
     "languages": [
-        "http://localhost:8000/v2/languages/common/",
-        "http://localhost:8000/v2/languages/draconic/"
+        {
+            "desc": "Typical speakers are Humans.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "common",
+            "name": "Common",
+            "script_language": "http://localhost:8000/v2/languages/common/",
+            "url": "http://localhost:8000/v2/languages/common/"
+        },
+        {
+            "desc": "Typical speakers include dragons and dragonborn.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "draconic",
+            "name": "Draconic",
+            "script_language": "http://localhost:8000/v2/languages/draconic/",
+            "url": "http://localhost:8000/v2/languages/draconic/"
+        }
     ],
     "modifiers": {
         "charisma": 6,

--- a/api_v2/tests/responses/TestObjects.test_creature_goblin_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creature_goblin_example.approved.json
@@ -47,27 +47,162 @@
     "darkvision_range": 60.0,
     "document": "http://localhost:8000/v2/documents/srd/",
     "environments": [
-        "http://localhost:8000/v2/environments/arctic/",
-        "http://localhost:8000/v2/environments/caves/",
-        "http://localhost:8000/v2/environments/desert/",
-        "http://localhost:8000/v2/environments/forest/",
-        "http://localhost:8000/v2/environments/grassland/",
-        "http://localhost:8000/v2/environments/hills/",
-        "http://localhost:8000/v2/environments/mountain/",
-        "http://localhost:8000/v2/environments/ruins/",
-        "http://localhost:8000/v2/environments/sewer/",
-        "http://localhost:8000/v2/environments/srd_feywild/",
-        "http://localhost:8000/v2/environments/swamp/",
-        "http://localhost:8000/v2/environments/underworld/",
-        "http://localhost:8000/v2/environments/urban/"
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "arctic",
+            "name": "Arctic or Tundra",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/arctic/"
+        },
+        {
+            "aquatic": false,
+            "desc": "Caves and caverns",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": true,
+            "key": "caves",
+            "name": "Caves",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/caves/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "desert",
+            "name": "Desert",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/desert/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "forest",
+            "name": "Forest or Jungle",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/forest/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "grassland",
+            "name": "Grassland or Plains",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/grassland/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None Provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "hills",
+            "name": "Hills",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/hills/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "mountain",
+            "name": "Mountain",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/mountain/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": true,
+            "key": "ruins",
+            "name": "Ruins",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/ruins/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": true,
+            "key": "sewer",
+            "name": "Sewer",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/sewer/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "srd_feywild",
+            "name": "Feywild",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/srd_feywild/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "swamp",
+            "name": "Swamp or Marsh",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/swamp/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None Provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "underworld",
+            "name": "Underworld",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/underworld/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "urban",
+            "name": "Urban",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/urban/"
+        }
     ],
     "experience_points": 50,
     "hit_dice": "2d6",
     "hit_points": 7,
     "key": "srd_goblin",
     "languages": [
-        "http://localhost:8000/v2/languages/common/",
-        "http://localhost:8000/v2/languages/goblin/"
+        {
+            "desc": "Typical speakers are Humans.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "common",
+            "name": "Common",
+            "script_language": "http://localhost:8000/v2/languages/common/",
+            "url": "http://localhost:8000/v2/languages/common/"
+        },
+        {
+            "desc": "Typical speakers are goblinoids.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "goblin",
+            "name": "Goblin",
+            "script_language": "http://localhost:8000/v2/languages/dwarvish/",
+            "url": "http://localhost:8000/v2/languages/goblin/"
+        }
     ],
     "modifiers": {
         "charisma": -1,

--- a/api_v2/tests/responses/TestObjects.test_creature_guard_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creature_guard_example.approved.json
@@ -35,38 +35,272 @@
     "darkvision_range": null,
     "document": "http://localhost:8000/v2/documents/srd/",
     "environments": [
-        "http://localhost:8000/v2/environments/coast/",
-        "http://localhost:8000/v2/environments/desert/",
-        "http://localhost:8000/v2/environments/forest/",
-        "http://localhost:8000/v2/environments/grassland/",
-        "http://localhost:8000/v2/environments/hills/",
-        "http://localhost:8000/v2/environments/mountain/",
-        "http://localhost:8000/v2/environments/urban/"
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "coast",
+            "name": "Coast",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/coast/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "desert",
+            "name": "Desert",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/desert/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "forest",
+            "name": "Forest or Jungle",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/forest/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "grassland",
+            "name": "Grassland or Plains",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/grassland/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None Provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "hills",
+            "name": "Hills",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/hills/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "mountain",
+            "name": "Mountain",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/mountain/"
+        },
+        {
+            "aquatic": false,
+            "desc": "[None provided]",
+            "document": "http://localhost:8000/v2/documents/open5e-e/",
+            "interior": false,
+            "key": "urban",
+            "name": "Urban",
+            "planar": false,
+            "url": "http://localhost:8000/v2/environments/urban/"
+        }
     ],
     "experience_points": 25,
     "hit_dice": "2d8+2",
     "hit_points": 11,
     "key": "srd_guard",
     "languages": [
-        "http://localhost:8000/v2/languages/abyssal/",
-        "http://localhost:8000/v2/languages/celestial/",
-        "http://localhost:8000/v2/languages/common/",
-        "http://localhost:8000/v2/languages/deep-speech/",
-        "http://localhost:8000/v2/languages/draconic/",
-        "http://localhost:8000/v2/languages/druidic/",
-        "http://localhost:8000/v2/languages/dwarvish/",
-        "http://localhost:8000/v2/languages/elvish/",
-        "http://localhost:8000/v2/languages/giant/",
-        "http://localhost:8000/v2/languages/gnomish/",
-        "http://localhost:8000/v2/languages/goblin/",
-        "http://localhost:8000/v2/languages/halfling/",
-        "http://localhost:8000/v2/languages/infernal/",
-        "http://localhost:8000/v2/languages/orc/",
-        "http://localhost:8000/v2/languages/primordial/",
-        "http://localhost:8000/v2/languages/sylvan/",
-        "http://localhost:8000/v2/languages/thieves-cant/",
-        "http://localhost:8000/v2/languages/undercommon/",
-        "http://localhost:8000/v2/languages/void-speech/"
+        {
+            "desc": "Typical speakers are demons.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "abyssal",
+            "name": "Abyssal",
+            "script_language": "http://localhost:8000/v2/languages/infernal/",
+            "url": "http://localhost:8000/v2/languages/abyssal/"
+        },
+        {
+            "desc": "Typical speakers are celestials",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "celestial",
+            "name": "Celestial",
+            "script_language": "http://localhost:8000/v2/languages/celestial/",
+            "url": "http://localhost:8000/v2/languages/celestial/"
+        },
+        {
+            "desc": "Typical speakers are Humans.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "common",
+            "name": "Common",
+            "script_language": "http://localhost:8000/v2/languages/common/",
+            "url": "http://localhost:8000/v2/languages/common/"
+        },
+        {
+            "desc": "Typical speakers include aboleths and cloakers. It is only spoken.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "deep-speech",
+            "name": "Deep Speech",
+            "script_language": null,
+            "url": "http://localhost:8000/v2/languages/deep-speech/"
+        },
+        {
+            "desc": "Typical speakers include dragons and dragonborn.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "draconic",
+            "name": "Draconic",
+            "script_language": "http://localhost:8000/v2/languages/draconic/",
+            "url": "http://localhost:8000/v2/languages/draconic/"
+        },
+        {
+            "desc": "The secret language of druids. Those who know it can speak the language and use it to leave hidden\r\nmessages. Those who know this language automatically spot such a message. Others spot the message\u2019s presence with a successful DC 15 Wisdom (Perception) check but can\u2019t decipher it without magic.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": true,
+            "key": "druidic",
+            "name": "Druidic",
+            "script_language": null,
+            "url": "http://localhost:8000/v2/languages/druidic/"
+        },
+        {
+            "desc": "Typical speakers are dwarves.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "dwarvish",
+            "name": "Dwarvish",
+            "script_language": "http://localhost:8000/v2/languages/dwarvish/",
+            "url": "http://localhost:8000/v2/languages/dwarvish/"
+        },
+        {
+            "desc": "Typical speakers are elves.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "elvish",
+            "name": "Elvish",
+            "script_language": "http://localhost:8000/v2/languages/elvish/",
+            "url": "http://localhost:8000/v2/languages/elvish/"
+        },
+        {
+            "desc": "Typical speakers include ogres, and giants.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "giant",
+            "name": "Giant",
+            "script_language": "http://localhost:8000/v2/languages/dwarvish/",
+            "url": "http://localhost:8000/v2/languages/giant/"
+        },
+        {
+            "desc": "Typical speakers are gnomes.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "gnomish",
+            "name": "Gnomish",
+            "script_language": "http://localhost:8000/v2/languages/dwarvish/",
+            "url": "http://localhost:8000/v2/languages/gnomish/"
+        },
+        {
+            "desc": "Typical speakers are goblinoids.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "goblin",
+            "name": "Goblin",
+            "script_language": "http://localhost:8000/v2/languages/dwarvish/",
+            "url": "http://localhost:8000/v2/languages/goblin/"
+        },
+        {
+            "desc": "Typical speakers are halflings.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "halfling",
+            "name": "Halfling",
+            "script_language": "http://localhost:8000/v2/languages/common/",
+            "url": "http://localhost:8000/v2/languages/halfling/"
+        },
+        {
+            "desc": "Typical speakers are devils.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "infernal",
+            "name": "Infernal",
+            "script_language": "http://localhost:8000/v2/languages/infernal/",
+            "url": "http://localhost:8000/v2/languages/infernal/"
+        },
+        {
+            "desc": "Typical speakers are orcs",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": false,
+            "key": "orc",
+            "name": "Orc",
+            "script_language": "http://localhost:8000/v2/languages/dwarvish/",
+            "url": "http://localhost:8000/v2/languages/orc/"
+        },
+        {
+            "desc": "Typical speakers are elementals.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "primordial",
+            "name": "Primordial",
+            "script_language": "http://localhost:8000/v2/languages/dwarvish/",
+            "url": "http://localhost:8000/v2/languages/primordial/"
+        },
+        {
+            "desc": "Typical speakers are fey creatures.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "sylvan",
+            "name": "Sylvan",
+            "script_language": "http://localhost:8000/v2/languages/elvish/",
+            "url": "http://localhost:8000/v2/languages/sylvan/"
+        },
+        {
+            "desc": "A secret mix of dialect, jargon, and code that allows the speaker to hide messages in seemingly normal conversation. Only another creature that knows thieves\u2019 cant understands such messages. It takes four times longer to convey such a message than it does to speak the same idea plainly.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": false,
+            "is_secret": true,
+            "key": "thieves-cant",
+            "name": "Thieves' Cant",
+            "script_language": null,
+            "url": "http://localhost:8000/v2/languages/thieves-cant/"
+        },
+        {
+            "desc": "Typical speakers are underworld traders.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "undercommon",
+            "name": "Undercommon",
+            "script_language": "http://localhost:8000/v2/languages/elvish/",
+            "url": "http://localhost:8000/v2/languages/undercommon/"
+        },
+        {
+            "desc": "Void speech is a rename of Deep Speech from Tome of Beasts.",
+            "document": "http://localhost:8000/v2/documents/tob/",
+            "is_exotic": true,
+            "is_secret": false,
+            "key": "void-speech",
+            "name": "Void Speech",
+            "script_language": null,
+            "url": "http://localhost:8000/v2/languages/void-speech/"
+        }
     ],
     "modifiers": {
         "charisma": 0,

--- a/api_v2/tests/responses/TestObjects.test_creatureset_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creatureset_example.approved.json
@@ -39,8 +39,26 @@
             "darkvision_range": null,
             "document": "http://localhost:8000/v2/documents/srd/",
             "environments": [
-                "http://localhost:8000/v2/environments/desert/",
-                "http://localhost:8000/v2/environments/urban/"
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "desert",
+                    "name": "Desert",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/desert/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "urban",
+                    "name": "Urban",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/urban/"
+                }
             ],
             "experience_points": 25,
             "hit_dice": "2d10+4",
@@ -297,7 +315,16 @@
             "darkvision_range": null,
             "document": "http://localhost:8000/v2/documents/srd/",
             "environments": [
-                "http://localhost:8000/v2/environments/urban/"
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "urban",
+                    "name": "Urban",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/urban/"
+                }
             ],
             "experience_points": 50,
             "hit_dice": "3d10+3",
@@ -445,9 +472,36 @@
             "darkvision_range": null,
             "document": "http://localhost:8000/v2/documents/srd/",
             "environments": [
-                "http://localhost:8000/v2/environments/desert/",
-                "http://localhost:8000/v2/environments/forest/",
-                "http://localhost:8000/v2/environments/grassland/"
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "desert",
+                    "name": "Desert",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/desert/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "forest",
+                    "name": "Forest or Jungle",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/forest/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "grassland",
+                    "name": "Grassland or Plains",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/grassland/"
+                }
             ],
             "experience_points": 1100,
             "hit_dice": "8d12+24",
@@ -583,9 +637,36 @@
             "darkvision_range": null,
             "document": "http://localhost:8000/v2/documents/srd/",
             "environments": [
-                "http://localhost:8000/v2/environments/forest/",
-                "http://localhost:8000/v2/environments/hills/",
-                "http://localhost:8000/v2/environments/urban/"
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "forest",
+                    "name": "Forest or Jungle",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/forest/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None Provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "hills",
+                    "name": "Hills",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/hills/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "urban",
+                    "name": "Urban",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/urban/"
+                }
             ],
             "experience_points": 25,
             "hit_dice": "1d8+1",
@@ -721,9 +802,36 @@
             "darkvision_range": null,
             "document": "http://localhost:8000/v2/documents/srd/",
             "environments": [
-                "http://localhost:8000/v2/environments/grassland/",
-                "http://localhost:8000/v2/environments/hills/",
-                "http://localhost:8000/v2/environments/urban/"
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "grassland",
+                    "name": "Grassland or Plains",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/grassland/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None Provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "hills",
+                    "name": "Hills",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/hills/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "urban",
+                    "name": "Urban",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/urban/"
+                }
             ],
             "experience_points": 25,
             "hit_dice": "2d8+2",
@@ -859,8 +967,26 @@
             "darkvision_range": null,
             "document": "http://localhost:8000/v2/documents/srd/",
             "environments": [
-                "http://localhost:8000/v2/environments/mountain/",
-                "http://localhost:8000/v2/environments/urban/"
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "mountain",
+                    "name": "Mountain",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/mountain/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "urban",
+                    "name": "Urban",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/urban/"
+                }
             ],
             "experience_points": 25,
             "hit_dice": "2d8+2",
@@ -996,8 +1122,26 @@
             "darkvision_range": null,
             "document": "http://localhost:8000/v2/documents/srd/",
             "environments": [
-                "http://localhost:8000/v2/environments/grassland/",
-                "http://localhost:8000/v2/environments/urban/"
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "grassland",
+                    "name": "Grassland or Plains",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/grassland/"
+                },
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "urban",
+                    "name": "Urban",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/urban/"
+                }
             ],
             "experience_points": 50,
             "hit_dice": "2d10+2",
@@ -1133,7 +1277,16 @@
             "darkvision_range": null,
             "document": "http://localhost:8000/v2/documents/srd/",
             "environments": [
-                "http://localhost:8000/v2/environments/urban/"
+                {
+                    "aquatic": false,
+                    "desc": "[None provided]",
+                    "document": "http://localhost:8000/v2/documents/open5e-e/",
+                    "interior": false,
+                    "key": "urban",
+                    "name": "Urban",
+                    "planar": false,
+                    "url": "http://localhost:8000/v2/environments/urban/"
+                }
             ],
             "experience_points": 100,
             "hit_dice": "3d10+3",


### PR DESCRIPTION
This PR fixes a bug where the `environments` and `languages` fields of the `/creatures` endpoint could not be filtered via query parameter.

eg. `v2/creature/?environment__fields=name` and  `v2/creature/?languages__field=name` had no effect on the API response.

This was because the `LanguageSerializer` and `EnvironmentSerializer` were not included on the `CreatureSerializer`, so these fields did not correctly inherit the logic defined in the `GameContentSerializer` abstract class for managing filtering nested fields.

Now, the query parameters for a creature of the form `/?fields=languages,environments&languages__fields=name&environments__fields=name` will generate a response of the form:

```
{
    "languages": [
        {
            "name": "Common"
        },
        {
            "name": "Draconic"
        },
        ...
     ],
    "environments": [
        {
            "name": "Arctic or Tundra"
        },
        {
            "name": "Caves"
        },
        ...
    ],
```