### PR TITLE
Bugfix: improve results for nested fields returned by `/v2/creatures`

### DIFF
--- a/api_v2/serializers/creature.py
+++ b/api_v2/serializers/creature.py
@@ -67,6 +67,7 @@ class CreatureSerializer(GameContentSerializer):
     skill_bonuses = serializers.SerializerMethodField()
     skill_bonuses_all = serializers.SerializerMethodField()
     damage_immunities = DamageTypeSerializer(many=True)
+    damage_resistances = DamageTypeSerializer(many=True)
     actions = CreatureActionSerializer(many=True, context={'request': {}})
     traits = CreatureTraitSerializer(many=True, read_only=True)
     speed = serializers.SerializerMethodField()

--- a/api_v2/serializers/creature.py
+++ b/api_v2/serializers/creature.py
@@ -8,6 +8,7 @@ from api_v2 import models
 
 from .abstracts import GameContentSerializer
 from .damagetype import DamageTypeSerializer
+from .condition import ConditionSerializer
 from .document import DocumentSerializer
 from .language import LanguageSerializer
 from .environment import EnvironmentSerializer
@@ -69,6 +70,7 @@ class CreatureSerializer(GameContentSerializer):
     damage_immunities = DamageTypeSerializer(many=True)
     damage_resistances = DamageTypeSerializer(many=True)
     damage_vulnerabilities = DamageTypeSerializer(many=True)
+    condition_immunities = ConditionSerializer(many=True)
     actions = CreatureActionSerializer(many=True, context={'request': {}})
     traits = CreatureTraitSerializer(many=True, read_only=True)
     speed = serializers.SerializerMethodField()

--- a/api_v2/serializers/creature.py
+++ b/api_v2/serializers/creature.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 from api_v2 import models
 
 from .abstracts import GameContentSerializer
+from .damagetype import DamageTypeSerializer
 from .document import DocumentSerializer
 from .language import LanguageSerializer
 from .environment import EnvironmentSerializer
@@ -65,6 +66,7 @@ class CreatureSerializer(GameContentSerializer):
     saving_throws_all = serializers.SerializerMethodField()
     skill_bonuses = serializers.SerializerMethodField()
     skill_bonuses_all = serializers.SerializerMethodField()
+    damage_immunities = DamageTypeSerializer(many=True)
     actions = CreatureActionSerializer(many=True, context={'request': {}})
     traits = CreatureTraitSerializer(many=True, read_only=True)
     speed = serializers.SerializerMethodField()

--- a/api_v2/serializers/creature.py
+++ b/api_v2/serializers/creature.py
@@ -68,6 +68,7 @@ class CreatureSerializer(GameContentSerializer):
     skill_bonuses_all = serializers.SerializerMethodField()
     damage_immunities = DamageTypeSerializer(many=True)
     damage_resistances = DamageTypeSerializer(many=True)
+    damage_vulnerabilities = DamageTypeSerializer(many=True)
     actions = CreatureActionSerializer(many=True, context={'request': {}})
     traits = CreatureTraitSerializer(many=True, read_only=True)
     speed = serializers.SerializerMethodField()

--- a/api_v2/tests/responses/TestObjects.test_creature_ancient_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creature_ancient_example.approved.json
@@ -189,7 +189,13 @@
     "condition_immunities": [],
     "creaturesets": [],
     "damage_immunities": [
-        "http://localhost:8000/v2/damagetypes/fire/"
+        {
+            "desc": "Red dragons breathe fire, and many spells conjure flames to deal fire damage.",
+            "document": "http://localhost:8000/v2/documents/srd/",
+            "key": "fire",
+            "name": "Fire",
+            "url": "http://localhost:8000/v2/damagetypes/fire/"
+        }
     ],
     "damage_resistances": [],
     "damage_vulnerabilities": [],


### PR DESCRIPTION
This feautre resolves issue #618 by adding missing nested serializers to the V2 `CreatureSerializer` for the following fields:

- `conditions_immunities`
- `damage_immunities`
- `damage_resistances`
- `damage_vulnerabilities`

This inclusion means that these fields on the `creatures` endpoint will return more helpful fields than just their URL.

For example, on the staging `branch` the query `/v2/creatures/bfrd_aboleth/?fields=name,damage_resistances` currently returns:

```
{
  "name": "Aboleth",
  "damage_resistances": [
         "http://localhost:8000/v2/damagetypes/acid/"
   ]
}
```

The URL returned by the `damage_resistances` field is not especially helpful.

This PR changes the result this same query returns to:
```
{
    "name": "Aboleth",
    "damage_resistances": [
        {
            "url": "http://localhost:8000/v2/damagetypes/acid/",
            "key": "acid",
            "name": "Acid",
            "desc": "The corrosive spray of a black dragon’s breath and the dissolving enzymes secreted by a black pudding deal acid damage.",
            "document": "http://localhost:8000/v2/documents/srd/"
        }
    ]
}
```

Much better. If this is too verbose then the fields returned by the `damage_resistances` field can be modified using the `damage_resistances__fields` parameter.

`/v2/creatures/bfrd_aboleth/?fields=name,damage_resistances&damage_resistances__fields=name`
```
{
    "name": "Aboleth",
    "damage_resistances": [
        {
            "name": "Acid"
        }
    ]
}
```

The `damage_immunities`, `damage_vulnerabilities` and `condition_immunities` fields function the same way.

It looks like these fields are already being pre-fetched by the Creatures view, which should nip any N+1 errors in the bud
