### PR TITLE
Added 'feature_type' field to ClassFeature serializer

### DIFF
--- a/api_v2/models/characterclass.py
+++ b/api_v2/models/characterclass.py
@@ -54,6 +54,17 @@ class ClassFeature(HasName, HasDescription, FromDocument):
     def columnitems(self):
         return self.classfeatureitem_set.exclude(column_value__isnull=True)
 
+    # Infer the type of this feature based on the `key`
+    @property
+    def feature_type(self):
+        if "proficiency-bonus" in self.key: return "PROFICIENCY_BONUS"
+        if "proficiencies" in self.key:     return "PROFICIENCIES"
+        if "equipment" in self.key:         return "STARTING_EQUIPMENT"
+        if "_slots-" in self.key:           return "SPELL_SLOTS"
+        if "_spells-known" in self.key:     return "SPELLS_KNOWN"
+        if "_cantrips-known" in self.key:   return "CANTRIPS_KNOWN"
+        return "CLASS_FEATURE"              # <- base-case
+
     def __str__(self):
         return "{} ({})".format(self.name,self.parent.name)
 

--- a/api_v2/serializers/characterclass.py
+++ b/api_v2/serializers/characterclass.py
@@ -31,7 +31,7 @@ class ClassFeatureSerializer(GameContentSerializer):
 
     class Meta:
         model = models.ClassFeature
-        fields = ['key', 'name', 'desc','featureitems','columnitems']
+        fields = ['key', 'name', 'desc','featureitems','columnitems', 'feature_type']
 
 class CharacterClassSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()


### PR DESCRIPTION
Closes #626

This PR closes #626 by adding the `feature_type` field to the ClassFeature serializer.

This property is defined on the model, and is extrapolated by checking against the feature's `"key"` property. The DB hasn't been touched and no migrations have been made.

N.B. This PR doesn't currently pass testing, but then neither is the `staging` branch (as per issue #623). Getting these tests to the point where they are functioning as intended is far beyond the scope of this PR