### PR TITLE
Bugfix: null Foreign Keys on `/v2/items` remain null when depth>0

### DIFF
--- a/api_v2/serializers/item.py
+++ b/api_v2/serializers/item.py
@@ -63,7 +63,16 @@ class ItemSerializer(GameContentSerializer):
     document = DocumentSerializer()
     category = ItemCategorySerializer()
     rarity = ItemRaritySerializer()
+    
+    def to_representation(self, instance):
+        """Ensures weapon/armor remain null instead of empty objects at depth>0."""
+        data = super().to_representation(instance)
 
+        for field in ["weapon", "armor"]:
+            if getattr(instance, field, None) is None:
+                data[field] = None
+        return data
+    
     class Meta:
         model = models.Item
         fields = '__all__'


### PR DESCRIPTION
Closes #621 

This PR addresses a bug on the `/v2/items` endpoint where the `weapon` and `armor` fields where returning inconsistant results when different depth query parameters were passed with API requests. These fields might have returned `null` at depth=0, but instead returned a large object with mostly empty keys.

Follow this bugfix, null `"weapon"` and `"armor"` fields now remain null at all depths.

`/v2/items/srd_alchemists-fire-flask/?fields=name,weapon,armor&depth=1`

```
{
    "weapon": null,
    "armor": null,
    "name": "Alchemist's Fire (Flask)"
}
```

Items with a defined `"armor"` or `"weapon"` work as they did before:

`/v2/items/srd_longsword/?fields=name,weapon,armor&depth=1`
```
{
    "weapon": {
        "key": "srd_longsword",
        "is_versatile": true,
         ...
    },
    "armor": null,
    "name": "Longsword"
}
```

`/v2/items/srd_chain-mail/?fields=name,weapon,armor&depth=1`
```
{
    "weapon": null,
    "armor": {
        "key": "srd_chain-mail",
        "ac_display": "16",
        "category": "heavy",
        ...
    },
    "name": "Chain mail"
}
```