### PR TITLE
Data: added missing `"detail"`s to WotC SRD base-classes ClassFeatureItems

### DIFF
--- a/api_v2/tests/responses/TestObjects.test_class_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_class_example.approved.json
@@ -36,15 +36,15 @@
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
                 {
-                    "detail": null,
+                    "detail": "2 dice",
                     "level": 13
                 },
                 {
-                    "detail": null,
+                    "detail": "3 dice",
                     "level": 17
                 },
                 {
-                    "detail": null,
+                    "detail": "1 dice",
                     "level": 9
                 }
             ],

--- a/data/v2/wizards-of-the-coast/srd/ClassFeatureItem.json
+++ b/data/v2/wizards-of-the-coast/srd/ClassFeatureItem.json
@@ -50,6 +50,7 @@
   "fields": {
     "parent": "srd_barbarian_brutal-critical",
     "level": 13,
+    "detail": "2 dice",
     "column_value": null
   }
 },
@@ -59,6 +60,7 @@
   "fields": {
     "parent": "srd_barbarian_brutal-critical",
     "level": 17,
+    "detail": "3 dice",
     "column_value": null
   }
 },
@@ -68,6 +70,7 @@
   "fields": {
     "parent": "srd_barbarian_brutal-critical",
     "level": 9,
+    "detail": "1 dice",
     "column_value": null
   }
 },
@@ -779,6 +782,7 @@
   "fields": {
     "parent": "srd_bard_bardic-inspiration",
     "level": 1,
+    "detail": "d6",
     "column_value": null
   }
 },
@@ -788,6 +792,7 @@
   "fields": {
     "parent": "srd_bard_bardic-inspiration",
     "level": 10,
+    "detail": "d10",
     "column_value": null
   }
 },
@@ -797,6 +802,7 @@
   "fields": {
     "parent": "srd_bard_bardic-inspiration",
     "level": 15,
+    "detail": "d12",
     "column_value": null
   }
 },
@@ -806,6 +812,7 @@
   "fields": {
     "parent": "srd_bard_bardic-inspiration",
     "level": 5,
+    "detail": "d8",
     "column_value": null
   }
 },
@@ -2219,6 +2226,7 @@
   "fields": {
     "parent": "srd_bard_song-of-rest",
     "level": 13,
+    "detail": "d10",
     "column_value": null
   }
 },
@@ -2228,6 +2236,7 @@
   "fields": {
     "parent": "srd_bard_song-of-rest",
     "level": 17,
+    "detail": "d12",
     "column_value": null
   }
 },
@@ -2237,6 +2246,7 @@
   "fields": {
     "parent": "srd_bard_song-of-rest",
     "level": 2,
+    "detail": "d6",
     "column_value": null
   }
 },
@@ -2246,6 +2256,7 @@
   "fields": {
     "parent": "srd_bard_song-of-rest",
     "level": 9,
+    "detail": "d8",
     "column_value": null
   }
 },
@@ -2795,6 +2806,7 @@
   "fields": {
     "parent": "srd_cleric_channel-divinity",
     "level": 18,
+    "detail": "3/rest",
     "column_value": null
   }
 },
@@ -2804,6 +2816,7 @@
   "fields": {
     "parent": "srd_cleric_channel-divinity",
     "level": 2,
+    "detail": "1/rest",
     "column_value": null
   }
 },
@@ -2813,6 +2826,17 @@
   "fields": {
     "parent": "srd_cleric_channel-divinity",
     "level": 6,
+    "detail": "2/rest",
+    "column_value": null
+  }
+},
+{
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd_cleric_destroy-undead_11",
+  "fields": {
+    "parent": "srd_cleric_destroy-undead",
+    "level": 11,
+    "detail": "CR 2",
     "column_value": null
   }
 },
@@ -2822,6 +2846,7 @@
   "fields": {
     "parent": "srd_cleric_destroy-undead",
     "level": 14,
+    "detail": "CR 3",
     "column_value": null
   }
 },
@@ -2831,6 +2856,7 @@
   "fields": {
     "parent": "srd_cleric_destroy-undead",
     "level": 17,
+    "detail": "CR 4",
     "column_value": null
   }
 },
@@ -2840,6 +2866,7 @@
   "fields": {
     "parent": "srd_cleric_destroy-undead",
     "level": 5,
+    "detail": "CR 1/2",
     "column_value": null
   }
 },
@@ -2849,6 +2876,7 @@
   "fields": {
     "parent": "srd_cleric_destroy-undead",
     "level": 8,
+    "detail": "CR 1",
     "column_value": null
   }
 },
@@ -11866,6 +11894,7 @@
   "fields": {
     "parent": "srd_warlock_mystic-arcanum",
     "level": 11,
+    "detail": "6th level",
     "column_value": null
   }
 },
@@ -11875,6 +11904,7 @@
   "fields": {
     "parent": "srd_warlock_mystic-arcanum",
     "level": 13,
+    "detail": "7th level",
     "column_value": null
   }
 },
@@ -11884,6 +11914,7 @@
   "fields": {
     "parent": "srd_warlock_mystic-arcanum",
     "level": 15,
+    "detail": "8th level",
     "column_value": null
   }
 },
@@ -11893,6 +11924,7 @@
   "fields": {
     "parent": "srd_warlock_mystic-arcanum",
     "level": 17,
+    "detail": "9th level",
     "column_value": null
   }
 },


### PR DESCRIPTION
Closes #640

Adds missing details information from the WotC SRD classes. This field is used to store additional parathetical information that follows class features as they appear in that class's features table