### PR TITLE
Refactored views to use `EagerLoadingMixin`

### DIFF
--- a/api_v2/views/ability.py
+++ b/api_v2/views/ability.py
@@ -4,7 +4,7 @@ from django_filters import FilterSet
 
 from api_v2 import models
 from api_v2 import serializers
-
+from .mixins import EagerLoadingMixin
 
 class AbilityFilterSet(FilterSet):
     class Meta:
@@ -37,7 +37,7 @@ class SkillFilterSet(FilterSet):
         }
 
 
-class SkillViewSet(viewsets.ReadOnlyModelViewSet):
+class SkillViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of skills.
     retrieve: API endpoint for returning a particular skill.

--- a/api_v2/views/alignment.py
+++ b/api_v2/views/alignment.py
@@ -5,6 +5,7 @@ from django_filters import FilterSet
 from api_v2 import models
 from api_v2 import serializers
 
+from .mixins import EagerLoadingMixin
 
 class AlignmentFilterSet(FilterSet):
     class Meta:
@@ -16,7 +17,7 @@ class AlignmentFilterSet(FilterSet):
             'document__gamesystem__key': ['in','iexact','exact'],
         }
 
-class AlignmentViewSet(viewsets.ReadOnlyModelViewSet):
+class AlignmentViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of alignments.
     retrieve: API endpoint for returning a particular alignment.
@@ -24,3 +25,5 @@ class AlignmentViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Alignment.objects.all().order_by('pk')
     serializer_class = serializers.AlignmentSerializer
     filterset_class = AlignmentFilterSet
+
+    prefetch_related_fields = ['document']

--- a/api_v2/views/background.py
+++ b/api_v2/views/background.py
@@ -5,7 +5,7 @@ from django_filters import FilterSet
 
 from api_v2 import models
 from api_v2 import serializers
-
+from .mixins import EagerLoadingMixin
 
 class BackgroundFilterSet(FilterSet):
     class Meta:
@@ -18,7 +18,7 @@ class BackgroundFilterSet(FilterSet):
         }
 
 
-class BackgroundViewSet(viewsets.ReadOnlyModelViewSet):
+class BackgroundViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of backgrounds.
     retrieve: API endpoint for returning a particular background.
@@ -27,15 +27,4 @@ class BackgroundViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.BackgroundSerializer
     filterset_class = BackgroundFilterSet
 
-    def get_queryset(self):
-        depth = int(self.request.query_params.get('depth', 0)) # get 'depth' from query params
-        return BackgroundViewSet.setup_eager_loading(super().get_queryset(), self.action, depth)
-
-    @staticmethod
-    def setup_eager_loading(queryset, action, depth):
-        # Apply select_related and prefetch_related based on action and depth
-        if action == 'list':
-            selects = []
-            prefetches = ['benefits'] # Many-to-many/rvrs relationships to prefetch
-            queryset = queryset.select_related(*selects).prefetch_related(*prefetches)
-        return queryset
+    prefetch_related_fields = ['benefits']

--- a/api_v2/views/condition.py
+++ b/api_v2/views/condition.py
@@ -4,7 +4,7 @@ from django_filters import FilterSet
 
 from api_v2 import models
 from api_v2 import serializers
-
+from .mixins import EagerLoadingMixin
 
 class ConditionFilterSet(FilterSet):
     class Meta:
@@ -17,7 +17,7 @@ class ConditionFilterSet(FilterSet):
         }
 
 
-class ConditionViewSet(viewsets.ReadOnlyModelViewSet):
+class ConditionViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of conditions.
     retrieve: API endpoint for returning a particular condition.
@@ -26,18 +26,5 @@ class ConditionViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.ConditionSerializer
     filterset_class = ConditionFilterSet
 
-    """
-    Set up selects and prefetching nested joins to mitigate N+1 problems
-    """
-    def get_queryset(self):
-        depth = int(self.request.query_params.get('depth', 0)) # get 'depth' from query params
-        return ConditionViewSet.setup_eager_loading(super().get_queryset(), self.action, depth)
-
-    @staticmethod
-    def setup_eager_loading(queryset, action, depth):
-        # Apply select_related and prefetch_related based on action and depth
-        if action == 'list':
-            selects = ['document', 'document__gamesystem', 'document__publisher']
-            prefetches = [] # Many-to-many/rvrs relationships to prefetch
-            queryset = queryset.select_related(*selects).prefetch_related(*prefetches)
-        return queryset
+    select_related_fields = []
+    prefetch_related_fields = ['document__gamesystem']

--- a/api_v2/views/creature.py
+++ b/api_v2/views/creature.py
@@ -5,6 +5,7 @@ from django_filters import FilterSet
 from api_v2 import models
 from api_v2 import serializers
 
+from .mixins import EagerLoadingMixin
 
 class CreatureFilterSet(FilterSet):
     '''This is the filterset class for creatures.'''
@@ -56,7 +57,7 @@ class CreatureFilterSet(FilterSet):
         }
 
 
-class CreatureViewSet(viewsets.ReadOnlyModelViewSet):
+class CreatureViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of creatures.
     retrieve: API endpoint for returning a particular creature.
@@ -65,38 +66,22 @@ class CreatureViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.CreatureSerializer
     filterset_class = CreatureFilterSet
 
-    def get_queryset(self):       
-        depth = int(self.request.query_params.get('depth', 0)) # get 'depth' from query params
-        return CreatureViewSet.setup_eager_loading(super().get_queryset(), self.action, depth)
-
-    @staticmethod
-    def setup_eager_loading(queryset, action, depth):
-        # Apply select_related and prefetch_related based on action and depth
-        if action == 'list':
-            selects = [
-                'document',
-                'document__gamesystem',
-                'document',
-                'document__publisher',
-                'size',
-                'type',
-            ]
-            
-            # Many-to-many and reverse relationships for prefetching
-            prefetches = [
-                'creatureaction_set',
-                'condition_immunities',
-                'damage_immunities',
-                'damage_resistances',
-                'damage_vulnerabilities',
-                'environments',
-                'languages',
-                'languages__document',
-                'traits'
-            ] 
-
-            queryset = queryset.select_related(*selects).prefetch_related(*prefetches)
-        return queryset
+    prefetch_related_fields = [
+        'condition_immunities',
+        'creatureaction_set',
+        'damage_immunities',
+        'damage_resistances',
+        'damage_vulnerabilities',
+        'document',
+        'document__gamesystem',
+        'document__publisher',
+        'environments',
+        'languages',
+        'languages__document',
+        'type',
+        'size',
+        'traits',
+    ]
 
 
 class CreatureTypeFilterSet(FilterSet):

--- a/api_v2/views/feat.py
+++ b/api_v2/views/feat.py
@@ -1,10 +1,9 @@
 from rest_framework import viewsets
-
 from django_filters import FilterSet
 
 from api_v2 import models
 from api_v2 import serializers
-
+from .mixins import EagerLoadingMixin
 
 class FeatFilterSet(FilterSet):
     class Meta:
@@ -17,7 +16,7 @@ class FeatFilterSet(FilterSet):
         }
 
 
-class FeatViewSet(viewsets.ReadOnlyModelViewSet):
+class FeatViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of feats.
     retrieve: API endpoint for returning a particular feat.
@@ -26,19 +25,6 @@ class FeatViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.FeatSerializer
     filterset_class = FeatFilterSet
 
-    """
-    Set up selects and prefetching nested joins to mitigate N+1 problems
-    """
-    def get_queryset(self):
-        depth = int(self.request.query_params.get('depth', 0))  # get 'depth' from query param
-        return FeatViewSet.setup_eager_loading(super().get_queryset(), self.action, depth)
-
-    @staticmethod
-    def setup_eager_loading(queryset, action, depth):
-        # Apply select_related and prefetch_related based on action and depth
-        if action == 'list':
-            selects = ['document', 'document__gamesystem', 'document__publisher']
-            prefetches = ['benefits'] # Many-to-many/rvrs relationships to prefetch
-            queryset = queryset.select_related(*selects).prefetch_related(*prefetches)
-        return queryset
+    select_related_fields = []
+    prefetch_related_fields = ['benefits', 'document']
 

--- a/api_v2/views/rule.py
+++ b/api_v2/views/rule.py
@@ -5,30 +5,20 @@ from django_filters import FilterSet
 from api_v2 import models
 from api_v2 import serializers
 
+from .mixins import EagerLoadingMixin
+
 class RuleViewSet(viewsets.ReadOnlyModelViewSet):
   queryset = models.Rule.objects.all()
   serializer_class = serializers.RuleSerializer
 
-class RuleSetViewSet(viewsets.ReadOnlyModelViewSet):
+class RuleSetViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
   queryset = models.RuleSet.objects.all()
   serializer_class = serializers.RuleSetSerializer
 
-  """
-  Set up selects and prefetching nested joins to mitigate N+1 problems
-  """
-  def get_queryset(self):
-      depth = int(self.request.query_params.get('depth', 0)) # get 'depth' from query param
-      return RuleSetViewSet.setup_eager_loading(super().get_queryset(), self.action, depth)
-
-  @staticmethod
-  def setup_eager_loading(queryset, action, depth):
-      # Apply select_related and prefetch_related based on action and depth
-      if action == 'list':
-          selects = [
-              'document',
-              'document__gamesystem',
-              'document__publisher',
-          ]
-          prefetches = ['rules'] # Many-to-many/rvrs relationships to prefetch
-          queryset = queryset.select_related(*selects).prefetch_related(*prefetches)
-      return queryset
+  select_related_fields = []
+  prefetch_related_fields = [
+    'document',
+    'document__gamesystem',
+    'document__publisher',
+    'rules',
+  ]

--- a/api_v2/views/size.py
+++ b/api_v2/views/size.py
@@ -4,7 +4,7 @@ from django_filters import FilterSet
 
 from api_v2 import models
 from api_v2 import serializers
-
+from .mixins import EagerLoadingMixin
 
 class SizeFilterSet(FilterSet):
     class Meta:
@@ -17,7 +17,7 @@ class SizeFilterSet(FilterSet):
         }
 
 
-class SizeViewSet(viewsets.ReadOnlyModelViewSet):
+class SizeViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of damage types.
     retrieve: API endpoint for returning a particular damage type.
@@ -26,23 +26,6 @@ class SizeViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.SizeSerializer
     filterset_class = SizeFilterSet
 
-    """
-    Set up selects and prefetching nested joins to mitigate N+1 problems
-    """
-    def get_queryset(self):
-        depth = int(self.request.query_params.get('depth', 0)) # get 'depth' from query param
-        return SizeViewSet.setup_eager_loading(super().get_queryset(), self.action, depth)
-
-    @staticmethod
-    def setup_eager_loading(queryset, action, depth):
-        # Apply select_related and prefetch_related based on action and depth
-        if action == 'list':
-            selects = [
-                'document',
-                'document__gamesystem',
-                'document__publisher',
-            ]
-            prefetches = [] # Many-to-many/rvrs relationships to prefetch
-            queryset = queryset.select_related(*selects).prefetch_related(*prefetches)
-        return queryset
+    select_related_fields = []
+    prefetch_related_fields = ['document__gamesystem', 'document__publisher']
 


### PR DESCRIPTION
Closes #645 

This PR refactors the various selecting and prefetching optimisations in out API V2 views using the new `EagerLoadingMixin`. All functionality is retained, but now the optimisation logic has been centralised in a single place.