### PR TITLE
Fixed N+1 problem on `/v2/backgrounds`

### DIFF
--- a/api_v2/views/background.py
+++ b/api_v2/views/background.py
@@ -27,4 +27,9 @@ class BackgroundViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.BackgroundSerializer
     filterset_class = BackgroundFilterSet
 
-    prefetch_related_fields = ['benefits']
+    prefetch_related_fields = [
+        'benefits',
+        'document',
+        'document__publisher',
+        'document__gamesystem'
+    ]


### PR DESCRIPTION
A step towards resolving #577

This PR resolves N+1 problems on the Background endpoint by expanding the prefetched fields to include the Documents field.

**Before**. ~500 ms query time (153 SQL queries)

**Current**. ~300 ms query time (16 SQL queries)