### PR TITLE
Fixed N+1 problems on Items sub-views

### DIFF
--- a/api_v2/views/item.py
+++ b/api_v2/views/item.py
@@ -70,7 +70,7 @@ class ItemSetFilterSet(FilterSet):
         }
 
 
-class ItemSetViewSet(viewsets.ReadOnlyModelViewSet):
+class ItemSetViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """"
     list: API Endpoint for returning a set of itemsets.
 
@@ -80,6 +80,17 @@ class ItemSetViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.ItemSetSerializer
     filterset_class = ItemSetFilterSet
 
+    prefetch_related_fields = [
+        'items',
+        'items__document',
+        'items__damage_resistances',
+        'items__damage_immunities',
+        'items__damage_vulnerabilities',
+        'items__armor',
+        'items__category',
+        'items__weapon',
+        'items__weapon__document'
+    ]
 
 class ItemCategoryViewSet(viewsets.ReadOnlyModelViewSet):
     """"
@@ -119,7 +130,7 @@ class WeaponFilterSet(FilterSet):
             }
 
 
-class WeaponViewSet(viewsets.ReadOnlyModelViewSet):
+class WeaponViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
     list: API endpoint for returning a list of weapons.
     retrieve: API endpoint for returning a particular weapon.
@@ -128,6 +139,7 @@ class WeaponViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.WeaponSerializer
     filterset_class = WeaponFilterSet
 
+    prefetch_related_fields = ['document']
 
 class ArmorFilterSet(FilterSet):
 


### PR DESCRIPTION
A step toward fixing #577 

This follows the same pattern as previous PRs that address the N+1 problems we are experiencing on the server. By adding prefetching of related fields to our views (using the `EagerLoadingMixin`), we can greatly improve response times and server resource usage of our API endpoints.

The two views that this feature touches, `/itemsets` and `/weapons` are both defined in the Items views file. It made sense to me to update them in the same PR to avoid unnecesary merge conflicts.

By prefetching related fields, big performance improvements were made to the `/itemsets` endpoint and more modest but still considerable improves were made to the `/weapons` endpoint

`.../v2/itemsets/`

**Staging**. Response time: ~3400 ms. SQL Queries generated: 1155
**Feature Branch**. Response time: ~500 ms, SQL Queries generated: 13

`.../v2/weapons/`

**Staging**. Response time: ~150 ms. SQL Queries generated: 39
**Feature Branch**. Reponse time: ~110 ms. SQL Queries: 3
