### PR TITLE
Bugfix: ClassFeature `"gained_at"` and `"table_data"` fields no longer mutually exclusive

### DIFF
--- a/api_v2/models/characterclass.py
+++ b/api_v2/models/characterclass.py
@@ -50,15 +50,6 @@ class ClassFeature(HasName, HasDescription, FromDocument):
 
     parent = models.ForeignKey('CharacterClass', on_delete=models.CASCADE, related_name="features")
 
-    def gained_at(self):
-        return self.feature_items.filter(column_value__isnull=True)
-    
-    def table_data(self):
-        """Returns an array of tabular data relating to the feature. Each
-        array element is a table-row of data. Not needed for most features."""
-
-        return self.feature_items.filter(column_value__isnull=False)
-
     # Infer the type of this feature based on the `key`
     @property
     def feature_type(self):

--- a/api_v2/serializers/characterclass.py
+++ b/api_v2/serializers/characterclass.py
@@ -28,28 +28,35 @@ class ClassFeatureSerializer(GameContentSerializer):
     feature_items = ClassFeaturePrefetchSerializer(many=True, read_only=True)
 
     def to_representation(self, instance):
+        """
+        'feature_items' field contains tabulated and non-tabulated data. These
+        have different uses and must be split into the 'gained_at' and 
+        'table_data' fields before being returned by the serializer
+        """
         # run 'to_representation' on super-class (GameContentSerializer)
         representation = super().to_representation(instance)
+        
+        # Split FeatureItems into tabulated and non-tabulated data arrays
+        table_data = []
+        non_table_data = []
+        for item in instance.feature_items.all():
+            if item.column_value is None:
+                non_table_data.append(item)
+            else:
+                table_data.append(item)
 
-        # Filters non-table data from FeatureItems
-        gained_at = [
-            ClassFeatureItemSerializer(item).data
-            for item in instance.feature_items.all()
-            if item.column_value is None
-        ]
+        # If a feature has tabulated data AND a description, take its lowest 
+        # level FeatureItem and add it to the non-tabulated data.
+        if len(table_data) > 0 and instance.desc != '[Column data]':
+            first_level_gained = min(table_data, key=lambda x: x.level)
+            non_table_data.append(first_level_gained)
 
-        # Filters table data from FeatureItems
-        table_data = [
-            ClassFeatureColumnItemSerializer(item).data
-            for item in instance.feature_items.all()
-            if item.column_value is not None
-        ]
+        # serialize data and add it to representation
+        representation['gained_at'] = [ClassFeatureItemSerializer(item).data for item in non_table_data]
+        representation['table_data'] = [ClassFeatureColumnItemSerializer(item).data for item in table_data]
 
-        # replace 'feature_items' with 'gained_at' and 'column_data' in representation
-        representation['gained_at'] = gained_at
-        representation['table_data'] = table_data
+        # remove feature_items field to avoid data duplication
         del representation['feature_items']
-
         return representation
 
     class Meta:


### PR DESCRIPTION
## Description

This PR fixes a bug on the `/classes` endpoint where ClassFeatures that contained both tabular and non-tabular data would only return the tabular data.

The example used in the issue that this closes was the WOTC SRD Rogue’s Sneak Attack feature, should contains both `”table_data”` to display in the Class Table (a column showing much damage sneak attack deals at each level), and “`gained_at`” information (which levels a feature is gained at).

Previously, the API would only return one or the other. Now it can return both:

`/v2/classes/srd_rogue`

```
"gained_at": [
  {
    "level": 1,
    "detail": null
  }
],
"table_data": [
  {
    "level": 1,
    "column_value": "1d6"
  },
  {
    "level": 10,
     "column_value": "5d6"
  },
  ...
]
```

This fix was made by updating the logic that seperated “gained_at” and “table_data” on the ClassFeature serializer to handle the edge-case where a feature appears a both a table column and a feature in the body text (Rogue’s Sneak Attack, and Monk’s Martial Arts and Unarmored Movement are all examples of this.

## Related Issue

Closes #651

## How has this been tested

The feature was principally tested using A/B testing between the feature and staging branches to make sure that it is working as intended. The `/v2/classes/srd_rogue` endpoint was visited on both branches and the JSON payload compared.

Pytest was also run to make sure that there were no unintended consequences to this fix. No tests needed to be updated.
