### PR TITLE
Set up job for clearing cloudflare cache

### DIFF
--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -4,20 +4,25 @@ on:
   push: {}  # For testing - change to specific branches later
 
 jobs:
-  wait-and-clear-cache:
+  clear-cache:
     runs-on: ubuntu-latest
     steps:
       - name: Initial delay
-        run: sleep 120
+        run: |
+          echo "Waiting 2 minutes for potential deployments to start..."
+          sleep 120
 
       - name: Check deployment status
         id: check-deployments
         env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
         run: |
+          echo "Checking deployments on branch: ${{ github.ref_name }}"
+          
           APP_IDS="52a99a96-7e6a-4258-b523-23d615c05571,7917c4fa-2426-4f51-b8cd-15a680fcaf1f,7f68aa01-e022-4244-81a4-0e5a50893703,476726eb-3be5-4b53-abeb-fba6db77786e"
           
           for app_id in ${APP_IDS//,/ }; do
+            echo "Checking app: $app_id"
             response=$(curl -s \
               -H "Authorization: Bearer $DIGITALOCEAN_ACCESS_TOKEN" \
               -H "Content-Type: application/json" \
@@ -26,21 +31,35 @@ jobs:
             created_at=$(echo $response | jq -r '.deployments[0].created_at')
             status=$(echo $response | jq -r '.deployments[0].phase')
             
+            echo "Latest deployment status: $status (created: $created_at)"
+            
             # Check if deployment is from last 10 minutes and is active
             if [ "$status" = "ACTIVE" ] && [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ]; then
+              echo "Found recent successful deployment"
               echo "status=success" >> $GITHUB_OUTPUT
               exit 0
             fi
           done
+          
+          echo "No recent deployments found"
           echo "status=skip" >> $GITHUB_OUTPUT
 
       - name: Purge Cloudflare cache
         if: steps.check-deployments.outputs.status == 'success'
         env:
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          curl -s -X POST \
+          echo "Purging Cloudflare cache..."
+          response=$(curl -s -X POST \
             "https://api.cloudflare.com/client/v4/zones/04102fd3a28043d9d40a2688282d688a/purge_cache" \
             -H "Authorization: Bearer $CLOUDFLARE_TOKEN" \
             -H "Content-Type: application/json" \
-            --data '{"purge_everything":true}'
+            --data '{"purge_everything":true}')
+          
+          if [ "$(echo $response | jq -r '.success')" = "true" ]; then
+            echo "Successfully purged Cloudflare cache"
+          else
+            echo "Failed to purge cache:"
+            echo $response
+            exit 1
+          fi

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -29,31 +29,17 @@ jobs:
                 -H "Content-Type: application/json" \
                 "https://api.digitalocean.com/v2/apps/$app_id/deployments?page=1&per_page=1")
               
-              echo "Raw API Response:"
-              echo "$response" | jq '.'
-              
               created_at=$(echo $response | jq -r '.deployments[0].created_at')
               status=$(echo $response | jq -r '.deployments[0].phase')
+              commit_hash=$(echo $response | jq -r '.deployments[0].services[0].source_commit_hash')
               
-              # Try different possible commit hash fields
-              commit_hash=$(echo $response | jq -r '.deployments[0].source_commit_hash')
-              echo "source_commit_hash: $commit_hash"
+              echo "Latest deployment status: $status (created: $created_at, commit: $commit_hash)"
               
-              commit_hash=$(echo $response | jq -r '.deployments[0].commit_hash')
-              echo "commit_hash: $commit_hash"
-              
-              commit_hash=$(echo $response | jq -r '.deployments[0].source.commit_hash')
-              echo "source.commit_hash: $commit_hash"
-              
-              commit_hash=$(echo $response | jq -r '.deployments[0].source.commit')
-              echo "source.commit: $commit_hash"
-              
-              echo "Latest deployment status: $status (created: $created_at)"
-              
-              # Check if deployment is from last 10 minutes and is active
+              # Check if deployment is from last 10 minutes, is active, and matches our commit
               if [ "$status" = "ACTIVE" ] && \
-                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 300 ]; then
-                echo "Found recent successful deployment"
+                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 300 ] && \
+                 [ "$commit_hash" = "$CURRENT_COMMIT" ]; then
+                echo "Found recent successful deployment matching current commit"
                 echo "status=success" >> $GITHUB_OUTPUT
                 exit 0
               fi

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -35,11 +35,11 @@ jobs:
               
               echo "Latest deployment status: $status (created: $created_at, commit: $commit_hash)"
               
-              # Check if deployment is from last 10 minutes, is active, and matches our commit
+              # Check if deployment is from last 10 minutes, is active, and either matches our commit or is null (manual deployments)
               if [ "$status" = "ACTIVE" ] && \
                  [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 300 ] && \
-                 [ "$commit_hash" = "$CURRENT_COMMIT" ]; then
-                echo "Found recent successful deployment matching current commit"
+                 ( [ "$commit_hash" = "$CURRENT_COMMIT" ] || [ "$commit_hash" = "null" ] ); then
+                echo "Found recent successful deployment matching our criteria"
                 echo "status=success" >> $GITHUB_OUTPUT
                 exit 0
               fi

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -51,7 +51,7 @@ jobs:
           done
 
       - name: Purge Cloudflare cache
-        if: steps.check-deployments.outputs.status == 'success'
+        if: steps.poll-deployments.outputs.status == 'success'
         env:
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -1,4 +1,4 @@
-name: Clear cache
+name: Clear Cloudflare Cache After Deployments
 
 on:
   push: {}  # For testing - change to specific branches later
@@ -7,42 +7,48 @@ jobs:
   clear-cache:
     runs-on: ubuntu-latest
     steps:
-      - name: Initial delay
-        run: |
-          echo "Waiting 2 minutes for potential deployments to start..."
-          sleep 120
-
-      - name: Check deployment status
-        id: check-deployments
+      - name: Poll deployments
+        id: poll-deployments
         env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
         run: |
-          echo "Checking deployments on branch: ${{ github.ref_name }}"
+          echo "Initial 30 second delay..."
+          sleep 30
           
           APP_IDS="52a99a96-7e6a-4258-b523-23d615c05571,7917c4fa-2426-4f51-b8cd-15a680fcaf1f,7f68aa01-e022-4244-81a4-0e5a50893703,476726eb-3be5-4b53-abeb-fba6db77786e"
           
-          for app_id in ${APP_IDS//,/ }; do
-            echo "Checking app: $app_id"
-            response=$(curl -s \
-              -H "Authorization: Bearer $DIGITALOCEAN_ACCESS_TOKEN" \
-              -H "Content-Type: application/json" \
-              "https://api.digitalocean.com/v2/apps/$app_id/deployments?page=1&per_page=1")
+          for attempt in {1..20}; do
+            echo "Check attempt $attempt of 40..."
             
-            created_at=$(echo $response | jq -r '.deployments[0].created_at')
-            status=$(echo $response | jq -r '.deployments[0].phase')
+            for app_id in ${APP_IDS//,/ }; do
+              echo "Checking app: $app_id"
+              response=$(curl -s \
+                -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+                -H "Content-Type: application/json" \
+                "https://api.digitalocean.com/v2/apps/$app_id/deployments?page=1&per_page=1")
+              
+              created_at=$(echo $response | jq -r '.deployments[0].created_at')
+              status=$(echo $response | jq -r '.deployments[0].phase')
+              
+              echo "Latest deployment status: $status (created: $created_at)"
+              
+              # Check if deployment is from last 10 minutes and is active
+              if [ "$status" = "ACTIVE" ] && [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ]; then
+                echo "Found recent successful deployment"
+                echo "status=success" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            done
             
-            echo "Latest deployment status: $status (created: $created_at)"
-            
-            # Check if deployment is from last 10 minutes and is active
-            if [ "$status" = "ACTIVE" ] && [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ]; then
-              echo "Found recent successful deployment"
-              echo "status=success" >> $GITHUB_OUTPUT
-              exit 0
+            if [ $attempt -eq 40 ]; then
+              echo "Timeout after 10 minutes - no successful deployments found"
+              echo "status=timeout" >> $GITHUB_OUTPUT
+              exit 1
             fi
+            
+            echo "No successful deployments yet, waiting 15 seconds..."
+            sleep 30
           done
-          
-          echo "No recent deployments found"
-          echo "status=skip" >> $GITHUB_OUTPUT
 
       - name: Purge Cloudflare cache
         if: steps.check-deployments.outputs.status == 'success'

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -37,7 +37,7 @@ jobs:
               
               # Check if deployment is from last 10 minutes, is active, and matches our commit
               if [ "$status" = "ACTIVE" ] && \
-                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ] && \
+                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 300 ] && \
                  [ "$commit_hash" = "$CURRENT_COMMIT" ]; then
                 echo "Found recent successful deployment matching current commit"
                 echo "status=success" >> $GITHUB_OUTPUT

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -2,78 +2,21 @@ name: Clear Cloudflare Cache After Deployments
 
 on:
   push:
-    branches:
-      - main
-      - staging
+    # Run on all branches
+    branches-ignore: []
 
 jobs:
   clear-cache:
     runs-on: ubuntu-latest
     steps:
-      - name: Poll deployments
-        id: poll-deployments
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Make script executable
+        run: chmod +x scripts/clear_cloudflare_cache.sh
+
+      - name: Run cache clearing script
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
-        run: |
-          echo "Initial 30 second delay..."
-          sleep 30
-          
-          APP_IDS="52a99a96-7e6a-4258-b523-23d615c05571,7917c4fa-2426-4f51-b8cd-15a680fcaf1f,7f68aa01-e022-4244-81a4-0e5a50893703,476726eb-3be5-4b53-abeb-fba6db77786e"
-          CURRENT_COMMIT="${{ github.sha }}"
-          echo "Current commit: $CURRENT_COMMIT"
-          
-          for attempt in {1..20}; do
-            echo "Check attempt $attempt of 20..."
-            
-            for app_id in ${APP_IDS//,/ }; do
-              echo "Checking app: $app_id"
-              response=$(curl -s \
-                -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-                -H "Content-Type: application/json" \
-                "https://api.digitalocean.com/v2/apps/$app_id/deployments?page=1&per_page=1")
-              
-              created_at=$(echo $response | jq -r '.deployments[0].created_at')
-              status=$(echo $response | jq -r '.deployments[0].phase')
-              commit_hash=$(echo $response | jq -r '.deployments[0].services[0].source_commit_hash')
-              
-              echo "Latest deployment status: $status (created: $created_at, commit: $commit_hash)"
-              
-              # Check if deployment is from last 10 minutes, is active, and either matches our commit or is null (manual deployments)
-              if [ "$status" = "ACTIVE" ] && \
-                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ] && \
-                 ( [ "$commit_hash" = "$CURRENT_COMMIT" ] || [ "$commit_hash" = "null" ] ); then
-                echo "Found recent successful deployment matching our criteria"
-                echo "status=success" >> $GITHUB_OUTPUT
-                exit 0
-              fi
-            done
-            
-            if [ $attempt -eq 20 ]; then
-              echo "Timeout after 10 minutes - no matching successful deployments found"
-              echo "status=timeout" >> $GITHUB_OUTPUT
-              exit 1
-            fi
-            
-            echo "No matching successful deployments yet, waiting 30 seconds..."
-            sleep 30
-          done
-
-      - name: Purge Cloudflare cache
-        if: steps.poll-deployments.outputs.status == 'success'
-        env:
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: |
-          echo "Purging Cloudflare cache..."
-          response=$(curl -s -X POST \
-            "https://api.cloudflare.com/client/v4/zones/04102fd3a28043d9d40a2688282d688a/purge_cache" \
-            -H "Authorization: Bearer $CLOUDFLARE_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data '{"purge_everything":true}')
-          
-          if [ "$(echo $response | jq -r '.success')" = "true" ]; then
-            echo "Successfully purged Cloudflare cache"
-          else
-            echo "Failed to purge cache:"
-            echo $response
-            exit 1
-          fi
+        run: ./scripts/clear_cloudflare_cache.sh "${{ github.sha }}"

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -31,7 +31,7 @@ jobs:
               
               created_at=$(echo $response | jq -r '.deployments[0].created_at')
               status=$(echo $response | jq -r '.deployments[0].phase')
-              commit_hash=$(echo $response | jq -r '.deployments[0].commit_hash')
+              commit_hash=$(echo $response | jq -r '.deployments[0].source_commit_hash')
               
               echo "Latest deployment status: $status (created: $created_at, commit: $commit_hash)"
               

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -29,17 +29,31 @@ jobs:
                 -H "Content-Type: application/json" \
                 "https://api.digitalocean.com/v2/apps/$app_id/deployments?page=1&per_page=1")
               
+              echo "Raw API Response:"
+              echo "$response" | jq '.'
+              
               created_at=$(echo $response | jq -r '.deployments[0].created_at')
               status=$(echo $response | jq -r '.deployments[0].phase')
+              
+              # Try different possible commit hash fields
               commit_hash=$(echo $response | jq -r '.deployments[0].source_commit_hash')
+              echo "source_commit_hash: $commit_hash"
               
-              echo "Latest deployment status: $status (created: $created_at, commit: $commit_hash)"
+              commit_hash=$(echo $response | jq -r '.deployments[0].commit_hash')
+              echo "commit_hash: $commit_hash"
               
-              # Check if deployment is from last 10 minutes, is active, and matches our commit
+              commit_hash=$(echo $response | jq -r '.deployments[0].source.commit_hash')
+              echo "source.commit_hash: $commit_hash"
+              
+              commit_hash=$(echo $response | jq -r '.deployments[0].source.commit')
+              echo "source.commit: $commit_hash"
+              
+              echo "Latest deployment status: $status (created: $created_at)"
+              
+              # Check if deployment is from last 10 minutes and is active
               if [ "$status" = "ACTIVE" ] && \
-                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 300 ] && \
-                 [ "$commit_hash" = "$CURRENT_COMMIT" ]; then
-                echo "Found recent successful deployment matching current commit"
+                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 300 ]; then
+                echo "Found recent successful deployment"
                 echo "status=success" >> $GITHUB_OUTPUT
                 exit 0
               fi

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -40,7 +40,7 @@ jobs:
               
               # Check if deployment is from last 10 minutes, is active, and either matches our commit or is null (manual deployments)
               if [ "$status" = "ACTIVE" ] && \
-                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 300 ] && \
+                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ] && \
                  ( [ "$commit_hash" = "$CURRENT_COMMIT" ] || [ "$commit_hash" = "null" ] ); then
                 echo "Found recent successful deployment matching our criteria"
                 echo "status=success" >> $GITHUB_OUTPUT

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -1,7 +1,10 @@
 name: Clear Cloudflare Cache After Deployments
 
 on:
-  push: {}  # For testing - change to specific branches later
+  push:
+    branches:
+      - main
+      - staging
 
 jobs:
   clear-cache:

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -2,8 +2,9 @@ name: Clear Cloudflare Cache After Deployments
 
 on:
   push:
-    # Run on all branches
-    branches-ignore: []
+    branches:
+      - main
+      - staging
 
 jobs:
   clear-cache:

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -16,9 +16,11 @@ jobs:
           sleep 30
           
           APP_IDS="52a99a96-7e6a-4258-b523-23d615c05571,7917c4fa-2426-4f51-b8cd-15a680fcaf1f,7f68aa01-e022-4244-81a4-0e5a50893703,476726eb-3be5-4b53-abeb-fba6db77786e"
+          CURRENT_COMMIT="${{ github.sha }}"
+          echo "Current commit: $CURRENT_COMMIT"
           
           for attempt in {1..20}; do
-            echo "Check attempt $attempt of 40..."
+            echo "Check attempt $attempt of 20..."
             
             for app_id in ${APP_IDS//,/ }; do
               echo "Checking app: $app_id"
@@ -29,24 +31,27 @@ jobs:
               
               created_at=$(echo $response | jq -r '.deployments[0].created_at')
               status=$(echo $response | jq -r '.deployments[0].phase')
+              commit_hash=$(echo $response | jq -r '.deployments[0].commit_hash')
               
-              echo "Latest deployment status: $status (created: $created_at)"
+              echo "Latest deployment status: $status (created: $created_at, commit: $commit_hash)"
               
-              # Check if deployment is from last 10 minutes and is active
-              if [ "$status" = "ACTIVE" ] && [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ]; then
-                echo "Found recent successful deployment"
+              # Check if deployment is from last 10 minutes, is active, and matches our commit
+              if [ "$status" = "ACTIVE" ] && \
+                 [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ] && \
+                 [ "$commit_hash" = "$CURRENT_COMMIT" ]; then
+                echo "Found recent successful deployment matching current commit"
                 echo "status=success" >> $GITHUB_OUTPUT
                 exit 0
               fi
             done
             
-            if [ $attempt -eq 40 ]; then
-              echo "Timeout after 10 minutes - no successful deployments found"
+            if [ $attempt -eq 20 ]; then
+              echo "Timeout after 10 minutes - no matching successful deployments found"
               echo "status=timeout" >> $GITHUB_OUTPUT
               exit 1
             fi
             
-            echo "No successful deployments yet, waiting 15 seconds..."
+            echo "No matching successful deployments yet, waiting 30 seconds..."
             sleep 30
           done
 

--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -1,0 +1,46 @@
+name: Clear cache
+
+on:
+  push: {}  # For testing - change to specific branches later
+
+jobs:
+  wait-and-clear-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Initial delay
+        run: sleep 120
+
+      - name: Check deployment status
+        id: check-deployments
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: |
+          APP_IDS="52a99a96-7e6a-4258-b523-23d615c05571,7917c4fa-2426-4f51-b8cd-15a680fcaf1f,7f68aa01-e022-4244-81a4-0e5a50893703,476726eb-3be5-4b53-abeb-fba6db77786e"
+          
+          for app_id in ${APP_IDS//,/ }; do
+            response=$(curl -s \
+              -H "Authorization: Bearer $DIGITALOCEAN_ACCESS_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.digitalocean.com/v2/apps/$app_id/deployments?page=1&per_page=1")
+            
+            created_at=$(echo $response | jq -r '.deployments[0].created_at')
+            status=$(echo $response | jq -r '.deployments[0].phase')
+            
+            # Check if deployment is from last 10 minutes and is active
+            if [ "$status" = "ACTIVE" ] && [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ]; then
+              echo "status=success" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+          echo "status=skip" >> $GITHUB_OUTPUT
+
+      - name: Purge Cloudflare cache
+        if: steps.check-deployments.outputs.status == 'success'
+        env:
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+        run: |
+          curl -s -X POST \
+            "https://api.cloudflare.com/client/v4/zones/04102fd3a28043d9d40a2688282d688a/purge_cache" \
+            -H "Authorization: Bearer $CLOUDFLARE_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}'

--- a/scripts/clear_cloudflare_cache.sh
+++ b/scripts/clear_cloudflare_cache.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Script to poll deployments and clear Cloudflare cache
+# Required environment variables:
+# - DIGITALOCEAN_TOKEN: Your DigitalOcean API token
+# - CLOUDFLARE_TOKEN: Your Cloudflare API token
+# Usage: ./clear_cloudflare_cache.sh [commit_hash]
+#   If commit_hash is not provided, will use current commit
+
+set -e
+
+# Check for required environment variables
+if [ -z "$DIGITALOCEAN_TOKEN" ] || [ -z "$CLOUDFLARE_TOKEN" ]; then
+    echo "Error: Required environment variables are not set"
+    echo "Please set the following environment variables:"
+    echo "- DIGITALOCEAN_TOKEN: Your DigitalOcean API token"
+    echo "- CLOUDFLARE_TOKEN: Your Cloudflare API token"
+    exit 1
+fi
+
+# Use provided commit hash or fall back to current commit
+CURRENT_COMMIT=${1:-$(git rev-parse HEAD)}
+
+echo "Initial 30 second delay..."
+sleep 30
+
+APP_IDS="52a99a96-7e6a-4258-b523-23d615c05571,7917c4fa-2426-4f51-b8cd-15a680fcaf1f,7f68aa01-e022-4244-81a4-0e5a50893703,476726eb-3be5-4b53-abeb-fba6db77786e"
+echo "Current commit: $CURRENT_COMMIT"
+
+for attempt in {1..20}; do
+    echo "Check attempt $attempt of 20..."
+    
+    for app_id in ${APP_IDS//,/ }; do
+        echo "Checking app: $app_id"
+        response=$(curl -s \
+            -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.digitalocean.com/v2/apps/$app_id/deployments?page=1&per_page=1")
+        
+        created_at=$(echo $response | jq -r '.deployments[0].created_at')
+        status=$(echo $response | jq -r '.deployments[0].phase')
+        commit_hash=$(echo $response | jq -r '.deployments[0].services[0].source_commit_hash')
+        
+        echo "Latest deployment status: $status (created: $created_at, commit: $commit_hash)"
+        
+        # Check if deployment is from last 10 minutes, is active, and either matches our commit or is null (manual deployments)
+        if [ "$status" = "ACTIVE" ] && \
+           [ $(( $(date +%s) - $(date -d "$created_at" +%s) )) -lt 600 ] && \
+           ( [ "$commit_hash" = "$CURRENT_COMMIT" ] || [ "$commit_hash" = "null" ] ); then
+            echo "Found recent successful deployment matching our criteria"
+            
+            echo "Purging Cloudflare cache..."
+            response=$(curl -s -X POST \
+                "https://api.cloudflare.com/client/v4/zones/04102fd3a28043d9d40a2688282d688a/purge_cache" \
+                -H "Authorization: Bearer $CLOUDFLARE_TOKEN" \
+                -H "Content-Type: application/json" \
+                --data '{"purge_everything":true}')
+            
+            if [ "$(echo $response | jq -r '.success')" = "true" ]; then
+                echo "Successfully purged Cloudflare cache"
+                exit 0
+            else
+                echo "Failed to purge cache:"
+                echo $response
+                exit 1
+            fi
+        fi
+    done
+    
+    if [ $attempt -eq 20 ]; then
+        echo "Timeout after 10 minutes - no matching successful deployments found"
+        exit 1
+    fi
+    
+    echo "No matching successful deployments yet, waiting 30 seconds..."
+    sleep 30
+done 


### PR DESCRIPTION
This adds a github action to purge our Cloudflare cache after any successful deployment from `staging` or `main`.

It uses DO's recommended method, which is to poll the target app_id s and clear the cache if there has been a deploy within the last 10 minutes that is associated with a relevant PR (or a `null` value, from a recent manual deploy) 

The initial poll starts after 30s and repeats every 30s until an ACTIVE (successful) deploy is found, or it times out. 

When no matching deploy is found:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/6b91be8f-434e-48f6-9e50-431ad2c124af" />


When one is:
<img width="676" alt="image" src="https://github.com/user-attachments/assets/be25a472-7351-405d-bc01-a73988de98f3" />


Verified that this is being performed in Cloudflare
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/4c0e8ca3-128b-4ca3-a523-2684065eb05e" />

This is not set as a required test in Github.

### Additional actions to take

- [ ] After this update, Cloudflare has a draft rule that sets a 12 hour TTL for all calls to the server, and has been adjusted to consider URL query strings for caching purposes. This should be activated after this is deployed to Staging.
- [ ] This action should be duplicated for the site repo (will do this after approval and validation on staging)

Fixes #281