### PR TITLE
Adding in migrations check.

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -29,7 +29,8 @@ jobs:
           pipenv run pytest
       - name: Validate Data
         run: |
-          pipenv run python ./scripts/data_test.py --dir ./data/v2
+          pipenv run python ./scripts/data_test.py --dir ./data/v2 &
+          pipenv run python ./manage.py 
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This should fail the PR validation if there are migrations that have not been generated as of the PR.