### PR TITLE
Fixed Alignment capitalisation

### DIFF
--- a/api_v2/tests/responses/TestObjects.test_alignment_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_alignment_example.approved.json
@@ -3,7 +3,7 @@
     "document": "http://localhost:8000/v2/documents/srd/",
     "key": "chaotic-good",
     "morality": "good",
-    "name": "Chaotic good",
+    "name": "Chaotic Good",
     "short_name": "CG",
     "societal_attitude": "chaotic",
     "url": "http://localhost:8000/v2/alignments/chaotic-good/"

--- a/data/v2/wizards-of-the-coast/srd/Alignment.json
+++ b/data/v2/wizards-of-the-coast/srd/Alignment.json
@@ -3,7 +3,7 @@
   "model": "api_v2.alignment",
   "pk": "chaotic-evil",
   "fields": {
-    "name": "Chaotic evil",
+    "name": "Chaotic Evil",
     "desc": "Chaotic evil (CE) creatures act with arbitrary violence, spurred by their greed, hatred, or bloodlust. Demons, red dragons, and orcs are chaotic evil.",
     "document": "srd"
   }
@@ -12,7 +12,7 @@
   "model": "api_v2.alignment",
   "pk": "chaotic-good",
   "fields": {
-    "name": "Chaotic good",
+    "name": "Chaotic Good",
     "desc": "Chaotic good (CG) creatures act as their conscience directs, with little regard for what others expect.  Copper dragons, many elves, and unicorns are chaotic good.",
     "document": "srd"
   }
@@ -21,7 +21,7 @@
   "model": "api_v2.alignment",
   "pk": "chaotic-neutral",
   "fields": {
-    "name": "Chaotic neutral",
+    "name": "Chaotic Neutral",
     "desc": "Chaotic neutral (CN) creatures follow their whims, holding their personal freedom above all else. Many barbarians and rogues, and some bards, are chaotic neutral.",
     "document": "srd"
   }
@@ -39,7 +39,7 @@
   "model": "api_v2.alignment",
   "pk": "lawful-good",
   "fields": {
-    "name": "Lawful good",
+    "name": "Lawful Good",
     "desc": "Lawful good (LG) creatures can be counted on to do the right thing as expected by society. Gold dragons, paladins, and most dwarves are lawful good.",
     "document": "srd"
   }
@@ -48,7 +48,7 @@
   "model": "api_v2.alignment",
   "pk": "lawful-neutral",
   "fields": {
-    "name": "Lawful neutral",
+    "name": "Lawful Neutral",
     "desc": "Lawful neutral (LN) individuals act in accordance with law, tradition, or personal codes. Many monks and some wizards are lawful neutral.",
     "document": "srd"
   }
@@ -66,7 +66,7 @@
   "model": "api_v2.alignment",
   "pk": "neutral-evil",
   "fields": {
-    "name": "Neutral evil",
+    "name": "Neutral Evil",
     "desc": "Neutral evil (NE) is the alignment of those who do whatever they can get away with, without compassion or qualms. Many drow, some cloud giants, and goblins are neutral evil.",
     "document": "srd"
   }
@@ -75,7 +75,7 @@
   "model": "api_v2.alignment",
   "pk": "neutral-good",
   "fields": {
-    "name": "Neutral good",
+    "name": "Neutral Good",
     "desc": "Neutral good (NG) folk do the best they can to help others according to their needs. Many celestials, some cloud giants, and most gnomes are neutral good.",
     "document": "srd"
   }


### PR DESCRIPTION
## Description

This PR fixes inconsistencies in the capitalisation of the names of alignments returned by the `/v2/alignments` endpoint.

I opted to use title case because they are titles. This is how they are handled in the 2024 SRD also

## Related Issue

Closes #558

## How was this tested

After updating the source data, the test DB was deleted and rebuilt using the `quicksetup` command. I then spun up a Django test server to make sure my change had had the intended effect.

When running Pytest, this caused one of our tests to fail (the alignment endpoint test) due to the text expecting a name of `"Chaotic good"` when `"Chaotic Good"` was returned. As this was an intended change, I updated this line of the test. All other tests were passing