### PR TITLE
V2 Classes endpoint improvements

### DIFF
--- a/api_v2/serializers/ability.py
+++ b/api_v2/serializers/ability.py
@@ -23,8 +23,6 @@ class AbilitySerializer(GameContentSerializer):
         fields = '__all__'
 
 class AbilitySummarySerializer(GameContentSerializer):
-    key = serializers.ReadOnlyField
-
     class Meta:
         model = models.Ability
         fields = ['name', 'url']

--- a/api_v2/serializers/ability.py
+++ b/api_v2/serializers/ability.py
@@ -21,3 +21,10 @@ class AbilitySerializer(GameContentSerializer):
     class Meta:
         model = models.Ability
         fields = '__all__'
+
+class AbilitySummarySerializer(GameContentSerializer):
+    key = serializers.ReadOnlyField
+
+    class Meta:
+        model = models.Ability
+        fields = ['name', 'url']

--- a/api_v2/serializers/characterclass.py
+++ b/api_v2/serializers/characterclass.py
@@ -6,7 +6,7 @@ from api_v2 import models
 
 from .abstracts import GameContentSerializer
 from .document import DocumentSummarySerializer
-
+from .ability import AbilitySummarySerializer
 
 class ClassFeatureItemSerializer(GameContentSerializer):
     class Meta:
@@ -74,6 +74,7 @@ class CharacterClassSerializer(GameContentSerializer):
     features = ClassFeatureSerializer(many=True, read_only=True)
     hit_points = serializers.ReadOnlyField()
     document = DocumentSummarySerializer()
+    saving_throws = AbilitySummarySerializer(many=True)
 
     class Meta:
         model = models.CharacterClass

--- a/api_v2/serializers/characterclass.py
+++ b/api_v2/serializers/characterclass.py
@@ -69,11 +69,10 @@ class ClassFeatureSerializer(GameContentSerializer):
             'feature_items'
         ]
 
-class CharacterClassSummarySerializer(GameContentSerializer):
-    key = serializers.ReadOnlyField()
+class CharacterClassSummarySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.CharacterClass
-        fields = ['name', 'key']
+        fields = ['name', 'key', 'url']
 
 class CharacterClassSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
@@ -81,7 +80,7 @@ class CharacterClassSerializer(GameContentSerializer):
     hit_points = serializers.ReadOnlyField()
     document = DocumentSummarySerializer()
     saving_throws = AbilitySummarySerializer(many=True)
-    subclass_of = CharacterClassSummarySerializer(read_only=True)
+    subclass_of = CharacterClassSummarySerializer()
     
     class Meta:
         model = models.CharacterClass

--- a/api_v2/serializers/characterclass.py
+++ b/api_v2/serializers/characterclass.py
@@ -69,19 +69,20 @@ class ClassFeatureSerializer(GameContentSerializer):
             'feature_items'
         ]
 
+class CharacterClassSummarySerializer(GameContentSerializer):
+    key = serializers.ReadOnlyField()
+    class Meta:
+        model = models.CharacterClass
+        fields = ['name', 'key']
+
 class CharacterClassSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
     features = ClassFeatureSerializer(many=True, read_only=True)
     hit_points = serializers.ReadOnlyField()
     document = DocumentSummarySerializer()
     saving_throws = AbilitySummarySerializer(many=True)
-
+    subclass_of = CharacterClassSummarySerializer(read_only=True)
+    
     class Meta:
         model = models.CharacterClass
         fields = '__all__'
-
-class CharacterClassSummarySerializer(GameContentSerializer):
-    key = serializers.ReadOnlyField()
-    class Meta:
-        model = models.CharacterClass
-        fields = ['name', 'key']

--- a/api_v2/serializers/characterclass.py
+++ b/api_v2/serializers/characterclass.py
@@ -53,7 +53,7 @@ class ClassFeatureSerializer(GameContentSerializer):
 
         # serialize data and add it to representation
         representation['gained_at'] = [ClassFeatureItemSerializer(item).data for item in non_table_data]
-        representation['table_data'] = [ClassFeatureColumnItemSerializer(item).data for item in table_data]
+        representation['data_for_class_table'] = [ClassFeatureColumnItemSerializer(item).data for item in table_data]
 
         # remove feature_items field to avoid data duplication
         del representation['feature_items']

--- a/api_v2/tests/responses/TestObjects.test_class_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_class_example.approved.json
@@ -15,6 +15,7 @@
     },
     "features": [
         {
+            "data_for_class_table": [],
             "desc": "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can\u2019t increase an ability score above 20 using this feature.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -40,10 +41,10 @@
                 }
             ],
             "key": "srd_barbarian_ability-score-improvement",
-            "name": "Ability Score Improvement",
-            "table_data": []
+            "name": "Ability Score Improvement"
         },
         {
+            "data_for_class_table": [],
             "desc": "Beginning at 9th level, you can roll one additional weapon damage die when determining the extra damage for a critical hit with a melee attack.\r\n\r\nThis increases to two additional dice at 13th level and three additional dice at 17th level.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -61,10 +62,10 @@
                 }
             ],
             "key": "srd_barbarian_brutal-critical",
-            "name": "Brutal Critical",
-            "table_data": []
+            "name": "Brutal Critical"
         },
         {
+            "data_for_class_table": [],
             "desc": "At 2nd level, you gain an uncanny sense of when things nearby aren\u2019t as they should be, giving you an edge when you dodge away from danger.\r\n\r\nYou have advantage on Dexterity saving throws against effects that you can see, such as traps and spells. To gain this benefit, you can\u2019t be blinded, deafened, or incapacitated.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -74,18 +75,18 @@
                 }
             ],
             "key": "srd_barbarian_danger-sense",
-            "name": "Danger Sense",
-            "table_data": []
+            "name": "Danger Sense"
         },
         {
+            "data_for_class_table": [],
             "desc": "You start with the following equipment, in addition to the equipment granted by your background:\r\n* (*a*) a greataxe or (*b*) any martial melee weapon\r\n* (*a*) two handaxes or (*b*) any simple weapon\r\n* An explorer\u2019s pack and four javelins",
             "feature_type": "STARTING_EQUIPMENT",
             "gained_at": [],
             "key": "srd_barbarian_equipment",
-            "name": "Equipment",
-            "table_data": []
+            "name": "Equipment"
         },
         {
+            "data_for_class_table": [],
             "desc": "Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -95,10 +96,10 @@
                 }
             ],
             "key": "srd_barbarian_extra-attack",
-            "name": "Extra Attack",
-            "table_data": []
+            "name": "Extra Attack"
         },
         {
+            "data_for_class_table": [],
             "desc": "Starting at 5th level, your speed increases by 10 feet while you aren\u2019t wearing heavy armor.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -108,10 +109,10 @@
                 }
             ],
             "key": "srd_barbarian_fast-movement",
-            "name": "Fast Movement",
-            "table_data": []
+            "name": "Fast Movement"
         },
         {
+            "data_for_class_table": [],
             "desc": "By 7th level, your instincts are so honed that you have advantage on initiative rolls.\r\n\r\nAdditionally, if you are surprised at the beginning of combat and aren\u2019t incapacitated, you can act normally on your first turn, but only if you enter your rage before doing anything else on that turn.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -121,10 +122,10 @@
                 }
             ],
             "key": "srd_barbarian_feral-instinct",
-            "name": "Feral Instinct",
-            "table_data": []
+            "name": "Feral Instinct"
         },
         {
+            "data_for_class_table": [],
             "desc": "Beginning at 18th level, if your total for a Strength check is less than your Strength score, you can use that score in place of the total.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -134,10 +135,10 @@
                 }
             ],
             "key": "srd_barbarian_indomitable-might",
-            "name": "Indomitable Might",
-            "table_data": []
+            "name": "Indomitable Might"
         },
         {
+            "data_for_class_table": [],
             "desc": "Beginning at 15th level, your rage is so fierce that it ends early only if you fall unconscious or if you choose to end it.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -147,10 +148,10 @@
                 }
             ],
             "key": "srd_barbarian_persistent-rage",
-            "name": "Persistent Rage",
-            "table_data": []
+            "name": "Persistent Rage"
         },
         {
+            "data_for_class_table": [],
             "desc": "At 20th level, you embody the power of the wilds. Your Strength and Constitution scores increase by 4. Your maximum for those scores is now 24.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -160,10 +161,10 @@
                 }
             ],
             "key": "srd_barbarian_primal-champion",
-            "name": "Primal Champion",
-            "table_data": []
+            "name": "Primal Champion"
         },
         {
+            "data_for_class_table": [],
             "desc": "At 3rd level, you choose a path that shapes the nature of your rage. Choose the Path of the Berserker or the Path of the Totem Warrior, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -173,24 +174,18 @@
                 }
             ],
             "key": "srd_barbarian_primal-path",
-            "name": "Primal Path",
-            "table_data": []
+            "name": "Primal Path"
         },
         {
+            "data_for_class_table": [],
             "desc": "**Armor:** Light armor, medium armor, shields\r\n**Weapons:** Simple weapons, martial weapons\r\n**Tools:** None\r\n**Saving Throws:** Strength, Constitution\r\n**Skills:** Choose two from Animal Handling, Athletics, Intimidation, Nature, Perception, and Survival",
             "feature_type": "PROFICIENCIES",
             "gained_at": [],
             "key": "srd_barbarian_proficiencies",
-            "name": "Proficiencies",
-            "table_data": []
+            "name": "Proficiencies"
         },
         {
-            "desc": "[Column data]",
-            "feature_type": "PROFICIENCY_BONUS",
-            "gained_at": [],
-            "key": "srd_barbarian_proficiency-bonus",
-            "name": "Proficiency Bonus",
-            "table_data": [
+            "data_for_class_table": [
                 {
                     "column_value": "+2",
                     "level": 1
@@ -271,9 +266,15 @@
                     "column_value": "+4",
                     "level": 9
                 }
-            ]
+            ],
+            "desc": "[Column data]",
+            "feature_type": "PROFICIENCY_BONUS",
+            "gained_at": [],
+            "key": "srd_barbarian_proficiency-bonus",
+            "name": "Proficiency Bonus"
         },
         {
+            "data_for_class_table": [],
             "desc": "In battle, you fight with primal ferocity. On your turn, you can enter a rage as a bonus action.\r\n\r\nWhile raging, you gain the following benefits if you aren't wearing heavy armor:\r\n\r\n* You have advantage on Strength checks and Strength saving throws.\r\n* When you make a melee weapon attack using Strength, you gain a bonus to the damage roll that increases as you gain levels as a barbarian, as shown in the Rage Damage column of the Barbarian table.\r\n* You have resistance to bludgeoning, piercing, and slashing damage. \r\n\r\nIf you are able to cast spells, you can't cast them or concentrate on them while raging.\r\n\r\nYour rage lasts for 1 minute. It ends early if you are knocked unconscious or if your turn ends and you haven't attacked a hostile creature since your last turn or taken damage since then. You can also end your rage on your turn as a bonus action.\r\n\r\nOnce you have raged the number of times shown for your barbarian level in the Rages column of the Barbarian table, you must finish a long rest before you can rage again.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -283,16 +284,10 @@
                 }
             ],
             "key": "srd_barbarian_rage",
-            "name": "Rage",
-            "table_data": []
+            "name": "Rage"
         },
         {
-            "desc": "[Column data]",
-            "feature_type": "CLASS_FEATURE",
-            "gained_at": [],
-            "key": "srd_barbarian_rage-damage",
-            "name": "Rage Damage",
-            "table_data": [
+            "data_for_class_table": [
                 {
                     "column_value": "+2",
                     "level": 1
@@ -373,15 +368,15 @@
                     "column_value": "+3",
                     "level": 9
                 }
-            ]
-        },
-        {
+            ],
             "desc": "[Column data]",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [],
-            "key": "srd_barbarian_rages",
-            "name": "Rages",
-            "table_data": [
+            "key": "srd_barbarian_rage-damage",
+            "name": "Rage Damage"
+        },
+        {
+            "data_for_class_table": [
                 {
                     "column_value": "2",
                     "level": 1
@@ -462,9 +457,15 @@
                     "column_value": "4",
                     "level": 9
                 }
-            ]
+            ],
+            "desc": "[Column data]",
+            "feature_type": "CLASS_FEATURE",
+            "gained_at": [],
+            "key": "srd_barbarian_rages",
+            "name": "Rages"
         },
         {
+            "data_for_class_table": [],
             "desc": "Starting at 2nd level, you can throw aside all concern for defense to attack with fierce desperation. When you make your first attack on your turn, you can decide to attack recklessly. Doing so gives you advantage on melee weapon attack rolls using Strength during this turn, but attack rolls against you have advantage until your next turn.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -474,10 +475,10 @@
                 }
             ],
             "key": "srd_barbarian_reckless-attack",
-            "name": "Reckless Attack",
-            "table_data": []
+            "name": "Reckless Attack"
         },
         {
+            "data_for_class_table": [],
             "desc": "Starting at 11th level, your rage can keep you fighting despite grievous wounds. If you drop to 0 hit points while you\u2019re raging and don\u2019t die outright, you can make a DC 10 Constitution saving throw. If you succeed, you drop to 1 hit point instead.\r\n\r\nEach time you use this feature after the first, the DC increases by 5. When you finish a short or long rest, the DC resets to 10.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -487,10 +488,10 @@
                 }
             ],
             "key": "srd_barbarian_relentless-rage",
-            "name": "Relentless Rage",
-            "table_data": []
+            "name": "Relentless Rage"
         },
         {
+            "data_for_class_table": [],
             "desc": "While you are not wearing any armor, your Armor Class equals 10 + your Dexterity modifier + your Constitution modifier. You can use a shield and still gain this benefit.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -500,8 +501,7 @@
                 }
             ],
             "key": "srd_barbarian_unarmored-defense",
-            "name": "Unarmored Defense",
-            "table_data": []
+            "name": "Unarmored Defense"
         }
     ],
     "hit_dice": "D12",
@@ -514,8 +514,14 @@
     "key": "srd_barbarian",
     "name": "Barbarian",
     "saving_throws": [
-        "http://localhost:8000/v2/abilities/con/",
-        "http://localhost:8000/v2/abilities/str/"
+        {
+            "name": "Constitution",
+            "url": "http://localhost:8000/v2/abilities/con/"
+        },
+        {
+            "name": "Strength",
+            "url": "http://localhost:8000/v2/abilities/str/"
+        }
     ],
     "subclass_of": null,
     "url": "http://localhost:8000/v2/classes/srd_barbarian/"

--- a/api_v2/tests/responses/TestObjects.test_spell_cantrip_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_spell_cantrip_example.approved.json
@@ -15,19 +15,23 @@
     "classes": [
         {
             "key": "srd_bard",
-            "name": "Bard"
+            "name": "Bard",
+            "url": "http://localhost:8000/v2/classes/srd_bard/"
         },
         {
             "key": "srd_sorcerer",
-            "name": "Sorcerer"
+            "name": "Sorcerer",
+            "url": "http://localhost:8000/v2/classes/srd_sorcerer/"
         },
         {
             "key": "srd_warlock",
-            "name": "Warlock"
+            "name": "Warlock",
+            "url": "http://localhost:8000/v2/classes/srd_warlock/"
         },
         {
             "key": "srd_wizard",
-            "name": "Wizard"
+            "name": "Wizard",
+            "url": "http://localhost:8000/v2/classes/srd_wizard/"
         }
     ],
     "concentration": false,

--- a/api_v2/tests/responses/TestObjects.test_spell_fireball.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_spell_fireball.approved.json
@@ -69,11 +69,13 @@
     "classes": [
         {
             "key": "srd_sorcerer",
-            "name": "Sorcerer"
+            "name": "Sorcerer",
+            "url": "http://localhost:8000/v2/classes/srd_sorcerer/"
         },
         {
             "key": "srd_wizard",
-            "name": "Wizard"
+            "name": "Wizard",
+            "url": "http://localhost:8000/v2/classes/srd_wizard/"
         }
     ],
     "concentration": false,

--- a/api_v2/tests/responses/TestObjects.test_spell_wish.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_spell_wish.approved.json
@@ -15,11 +15,13 @@
     "classes": [
         {
             "key": "srd_sorcerer",
-            "name": "Sorcerer"
+            "name": "Sorcerer",
+            "url": "http://localhost:8000/v2/classes/srd_sorcerer/"
         },
         {
             "key": "srd_wizard",
-            "name": "Wizard"
+            "name": "Wizard",
+            "url": "http://localhost:8000/v2/classes/srd_wizard/"
         }
     ],
     "concentration": false,

--- a/api_v2/tests/responses/TestObjects.test_subclass_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_subclass_example.approved.json
@@ -86,7 +86,8 @@
     "saving_throws": [],
     "subclass_of": {
         "key": "srd_rogue",
-        "name": "Rogue"
+        "name": "Rogue",
+        "url": "http://localhost:8000/v2/classes/srd_rogue/"
     },
     "url": "http://localhost:8000/v2/classes/srd_thief/"
 }

--- a/api_v2/tests/responses/TestObjects.test_subclass_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_subclass_example.approved.json
@@ -15,6 +15,7 @@
     },
     "features": [
         {
+            "data_for_class_table": [],
             "desc": "Starting at 3rd level, you can use the bonus action granted by your Cunning Action to make a Dexterity (Sleight of Hand) check, use your thieves' tools to disarm a trap or open a lock, or take the Use an Object action.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -24,10 +25,10 @@
                 }
             ],
             "key": "srd_thief_fast-hands",
-            "name": "Fast Hands",
-            "table_data": []
+            "name": "Fast Hands"
         },
         {
+            "data_for_class_table": [],
             "desc": "When you choose this archetype at 3rd level, you gain the ability to climb faster than normal; climbing no longer costs you extra movement.\r\n\r\nIn addition, when you make a running jump, the distance you cover increases by a number of feet equal to your Dexterity modifier.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -37,10 +38,10 @@
                 }
             ],
             "key": "srd_thief_second-story-work",
-            "name": "Second-Story Work",
-            "table_data": []
+            "name": "Second-Story Work"
         },
         {
+            "data_for_class_table": [],
             "desc": "Starting at 9th level, you have advantage on a Dexterity (Stealth) check if you move no more than half your speed on the same turn.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -50,10 +51,10 @@
                 }
             ],
             "key": "srd_thief_supreme-sneak",
-            "name": "Supreme Sneak",
-            "table_data": []
+            "name": "Supreme Sneak"
         },
         {
+            "data_for_class_table": [],
             "desc": "When you reach 17th level, you have become adept at laying ambushes and quickly escaping danger. You can take two turns during the first round of any combat. You take your first turn at your normal initiative and your second turn at your initiative minus 10. You can't use this feature when you are surprised.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -63,10 +64,10 @@
                 }
             ],
             "key": "srd_thief_thiefs-reflexes",
-            "name": "Thief's Reflexes",
-            "table_data": []
+            "name": "Thief's Reflexes"
         },
         {
+            "data_for_class_table": [],
             "desc": "By 13th level, you have learned enough about the workings of magic that you can improvise the use of items even when they are not intended for you. You ignore all class, race, and level requirements on the use of magic items.",
             "feature_type": "CLASS_FEATURE",
             "gained_at": [
@@ -76,14 +77,16 @@
                 }
             ],
             "key": "srd_thief_use-magic-device",
-            "name": "Use Magic Device",
-            "table_data": []
+            "name": "Use Magic Device"
         }
     ],
     "hit_dice": null,
     "key": "srd_thief",
     "name": "Thief",
     "saving_throws": [],
-    "subclass_of": "http://localhost:8000/v2/classes/srd_rogue/",
+    "subclass_of": {
+        "key": "srd_rogue",
+        "name": "Rogue"
+    },
     "url": "http://localhost:8000/v2/classes/srd_thief/"
 }


### PR DESCRIPTION
## Description

This PR fixes a number of issues with on the V2 classes endpoint as outline in our recent API audit.

1. The `"saving_throws"` field now returns an array of objects instead of URLs.

```
"saving_throws": [
  {
    "name": "Constitution",
    "url": "http://localhost:8000/v2/abilities/con/"
  },
  {
    "name": "Strength",
    "url": "http://localhost:8000/v2/abilities/str/"
  }
],
```

2. The `"table_data" field sub-field of the `"features"` array has had its name changed to `"data_for_class_table"` to makes it intended function more obvious.

3. The `"subclass_of"` field now returns a object containing the base classes name, key and url

## Related Issue

Closes #700 

