### PR TITLE
Summary Serializers

### DIFF
--- a/api_v2/serializers/ability.py
+++ b/api_v2/serializers/ability.py
@@ -23,6 +23,11 @@ class AbilitySerializer(GameContentSerializer):
         fields = '__all__'
 
 class AbilitySummarySerializer(GameContentSerializer):
+    '''
+    A slimmer AbilitySerializer, designed to serialize Ability FKs on other 
+    serializers. ie. The `saving_throws` field on CharacterClassSerializer. Not
+    intended to be used directly with in a ModelViewset.
+    '''
     class Meta:
         model = models.Ability
         fields = ['name', 'url']

--- a/api_v2/serializers/characterclass.py
+++ b/api_v2/serializers/characterclass.py
@@ -70,6 +70,12 @@ class ClassFeatureSerializer(GameContentSerializer):
         ]
 
 class CharacterClassSummarySerializer(serializers.ModelSerializer):
+    '''
+    A slimmer CharacterClassSerializer, designed to serialize Class FKs on
+    other serializers. ie. The `subclass_of` field on the 
+    CharacterClassSerializer serializer. Not intended to be used directly in a
+    ModelViewset.
+    '''
     class Meta:
         model = models.CharacterClass
         fields = ['name', 'key', 'url']

--- a/api_v2/serializers/condition.py
+++ b/api_v2/serializers/condition.py
@@ -16,3 +16,8 @@ class ConditionSerializer(GameContentSerializer):
     class Meta:
         model = models.Condition
         fields = '__all__'
+
+class ConditionSummarySerializer(GameContentSerializer):
+    class Meta:
+        model = models.Condition
+        fields = ['name', 'key', 'url']

--- a/api_v2/serializers/condition.py
+++ b/api_v2/serializers/condition.py
@@ -18,6 +18,11 @@ class ConditionSerializer(GameContentSerializer):
         fields = '__all__'
 
 class ConditionSummarySerializer(GameContentSerializer):
+    '''
+    A slimmer ConditionSerializer, designed to serialize Condition FKs on
+    other serializers. ie. The `condition_immunities` field on the Creature
+    serializer. Not intended to be used directly with in a ModelViewset.
+    '''
     class Meta:
         model = models.Condition
         fields = ['name', 'key', 'url']

--- a/api_v2/serializers/creature.py
+++ b/api_v2/serializers/creature.py
@@ -7,12 +7,12 @@ from rest_framework import serializers
 from api_v2 import models
 
 from .abstracts import GameContentSerializer
-from .damagetype import DamageTypeSerializer
-from .condition import ConditionSerializer
+from .damagetype import DamageTypeSummarySerializer
+from .condition import ConditionSummarySerializer
 from .document import DocumentSummarySerializer
 from .language import LanguageSummarySerializer
-from .environment import EnvironmentSerializer
-from .size import SizeSerializer
+from .environment import EnvironmentSummarySerializer
+from .size import SizeSummarySerializer
 from drf_spectacular.utils import extend_schema_field, inline_serializer
 from drf_spectacular.types import OpenApiTypes
 
@@ -45,7 +45,12 @@ class CreatureTypeSerializer(GameContentSerializer):
     class Meta:
         '''Meta options for serializer.'''
         model = models.CreatureType
-        fields = '__all__'
+        fields = ['__all__']
+
+class CreatureTypeSummarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.CreatureType
+        fields = ['name', 'key', 'url']
 
 
 class CreatureTraitSerializer(GameContentSerializer):
@@ -74,10 +79,10 @@ class CreatureSerializer(GameContentSerializer):
     saving_throws_all = serializers.SerializerMethodField()
     skill_bonuses = serializers.SerializerMethodField()
     skill_bonuses_all = serializers.SerializerMethodField()
-    damage_immunities = DamageTypeSerializer(many=True)
-    damage_resistances = DamageTypeSerializer(many=True)
-    damage_vulnerabilities = DamageTypeSerializer(many=True)
-    condition_immunities = ConditionSerializer(many=True)
+    damage_immunities = DamageTypeSummarySerializer(many=True)
+    damage_resistances = DamageTypeSummarySerializer(many=True)
+    damage_vulnerabilities = DamageTypeSummarySerializer(many=True)
+    condition_immunities = ConditionSummarySerializer(many=True)
     actions = CreatureActionSerializer(many=True)
     traits = CreatureTraitSerializer(many=True, read_only=True)
     speed = serializers.SerializerMethodField()
@@ -85,10 +90,10 @@ class CreatureSerializer(GameContentSerializer):
     challenge_rating_text = serializers.SerializerMethodField()
     experience_points = serializers.SerializerMethodField()
     document = DocumentSummarySerializer()
-    type = CreatureTypeSerializer()
-    size = SizeSerializer()
+    type = CreatureTypeSummarySerializer()
+    size = SizeSummarySerializer()
     languages = CreatureLanguageSerializer(source='*')
-    environments = EnvironmentSerializer(many=True)
+    environments = EnvironmentSummarySerializer(many=True)
     initiative_bonus = serializers.SerializerMethodField()
 
     class Meta:
@@ -96,23 +101,23 @@ class CreatureSerializer(GameContentSerializer):
         model = models.Creature
         fields = [
             'url',
-            'document',
             'key',
             'name',
+            'document',
+            'type',
             'size',
+            'challenge_rating_decimal',
+            'challenge_rating_text',
             'speed',
             'speed_all',
             'category',
             'subcategory',
-            'type',
             'alignment',
             'languages',
             'armor_class',
             'armor_detail',
             'hit_points',
             'hit_dice',
-            'challenge_rating_decimal',
-            'challenge_rating_text',
             'experience_points',
             'ability_scores',
             'modifiers',

--- a/api_v2/serializers/creature.py
+++ b/api_v2/serializers/creature.py
@@ -45,7 +45,7 @@ class CreatureTypeSerializer(GameContentSerializer):
     class Meta:
         '''Meta options for serializer.'''
         model = models.CreatureType
-        fields = ['__all__']
+        fields = '__all__'
 
 class CreatureTypeSummarySerializer(serializers.ModelSerializer):
     class Meta:

--- a/api_v2/serializers/creature.py
+++ b/api_v2/serializers/creature.py
@@ -48,6 +48,10 @@ class CreatureTypeSerializer(GameContentSerializer):
         fields = '__all__'
 
 class CreatureTypeSummarySerializer(serializers.ModelSerializer):
+    '''
+    A slimmer CreatureTypeSerializer, designed to serialize CreatureType FKs on
+    other serializers . Not intended to be used directly with in a ModelViewset.
+    '''
     class Meta:
         model = models.CreatureType
         fields = ['name', 'key', 'url']

--- a/api_v2/serializers/damagetype.py
+++ b/api_v2/serializers/damagetype.py
@@ -13,7 +13,7 @@ class DamageTypeSerializer(GameContentSerializer):
         model = models.DamageType
         fields = '__all__'
 
-class DamageTypeSummarySerializer(GameContentSerializer):
+class DamageTypeSummarySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.DamageType
         fields = ['name', 'key', 'url']

--- a/api_v2/serializers/damagetype.py
+++ b/api_v2/serializers/damagetype.py
@@ -14,6 +14,10 @@ class DamageTypeSerializer(GameContentSerializer):
         fields = '__all__'
 
 class DamageTypeSummarySerializer(serializers.ModelSerializer):
+    '''
+    A slimmer DamageTypeSerializer, designed to serialize DamageType FKs on
+    other serializers. Not intended to be used directly with in a ModelViewset.
+    '''
     class Meta:
         model = models.DamageType
         fields = ['name', 'key', 'url']

--- a/api_v2/serializers/damagetype.py
+++ b/api_v2/serializers/damagetype.py
@@ -12,3 +12,8 @@ class DamageTypeSerializer(GameContentSerializer):
     class Meta:
         model = models.DamageType
         fields = '__all__'
+
+class DamageTypeSummarySerializer(GameContentSerializer):
+    class Meta:
+        model = models.DamageType
+        fields = ['name', 'key', 'url']

--- a/api_v2/serializers/document.py
+++ b/api_v2/serializers/document.py
@@ -12,6 +12,10 @@ class GameSystemSerializer(GameContentSerializer):
         fields = '__all__'
 
 class GameSystemSummarySerializer(serializers.ModelSerializer):
+    '''
+    A slimmer GameSystemSerializer, designed to serialize GameSystem FKs on 
+    other serializers. Not intended to be used directly with in a ModelViewset.
+    '''
     class Meta:
         model = models.GameSystem
         fields = ['name', 'key', 'url']
@@ -25,7 +29,10 @@ class LicenseSerializer(GameContentSerializer):
         fields = '__all__'
 
 class LicenseSummarySerializer(GameContentSerializer):
-    key = serializers.ReadOnlyField()
+    '''
+    A slimmer LicenseSerializer, designed to serialize License FKs on other 
+    serializers. Not intended to be used directly with in a ModelViewset.
+    '''
     class Meta:
         model = models.License
         fields = ['name', 'key', 'url']
@@ -38,7 +45,10 @@ class PublisherSerializer(GameContentSerializer):
         fields = '__all__'
 
 class PublisherSummarySerializer(serializers.ModelSerializer):
-    key = serializers.ReadOnlyField()
+    '''
+    A slimmer PublisherSerializer, designed to serialize Publisher FKs on other
+    serializers. Not intended to be used directly with in a ModelViewset.
+    '''
     class Meta:
         model = models.Publisher
         fields = ['name', 'key', 'url']
@@ -54,9 +64,13 @@ class DocumentSerializer(GameContentSerializer):
         fields = '__all__'
 
 class DocumentSummarySerializer(GameContentSerializer):
-    key = serializers.ReadOnlyField()
+    '''
+    A slimmer DocumentSerializer, designed to serialize Documents FKs on other
+    serializers. Not intended to be used directly with in a ModelViewset.
+    '''
     publisher = PublisherSummarySerializer()
     gamesystem = GameSystemSummarySerializer()
+
     class Meta:
         model = models.Document
         fields = ['name', 'key', 'publisher', 'gamesystem', 'permalink']

--- a/api_v2/serializers/document.py
+++ b/api_v2/serializers/document.py
@@ -56,7 +56,7 @@ class DocumentSerializer(GameContentSerializer):
 class DocumentSummarySerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
     publisher = PublisherSummarySerializer()
-    gamesystem = GameSystemSummarySerializer() 
+    gamesystem = GameSystemSummarySerializer()
     class Meta:
         model = models.Document
         fields = ['name', 'key', 'publisher', 'gamesystem', 'permalink']

--- a/api_v2/serializers/environment.py
+++ b/api_v2/serializers/environment.py
@@ -14,6 +14,11 @@ class EnvironmentSerializer(GameContentSerializer):
         fields = '__all__'
 
 class EnvironmentSummarySerializer(GameContentSerializer):
+    '''
+    A slimmer EnvironmentSerializer, designed to serialize Enviroment FKs on
+    other serializers. ie. The `environments` field on the CreatureSerializer.
+    Not intended to be used directly in a ModelViewset.
+    '''
     class Meta:
         model = models.Environment
         fields = ['name', 'key', 'url']

--- a/api_v2/serializers/environment.py
+++ b/api_v2/serializers/environment.py
@@ -12,3 +12,8 @@ class EnvironmentSerializer(GameContentSerializer):
     class Meta:
         model = models.Environment
         fields = '__all__'
+
+class EnvironmentSummarySerializer(GameContentSerializer):
+    class Meta:
+        model = models.Environment
+        fields = ['name', 'key', 'url']

--- a/api_v2/serializers/item.py
+++ b/api_v2/serializers/item.py
@@ -5,13 +5,14 @@ from rest_framework import serializers
 from api_v2 import models
 
 from .abstracts import GameContentSerializer
-from .size import SizeSerializer
+from .damagetype import DamageTypeSummarySerializer
 from .document import DocumentSummarySerializer
+from .size import SizeSummarySerializer
 from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
 
 
-class ArmorSerializer(GameContentSerializer):
+class ArmorSerializer(serializers.ModelSerializer):
     key = serializers.ReadOnlyField()
     ac_display = serializers.ReadOnlyField()
     category = serializers.ReadOnlyField()
@@ -22,6 +23,7 @@ class ArmorSerializer(GameContentSerializer):
 
 class WeaponSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
+    damage_type = DamageTypeSummarySerializer()
     is_versatile = serializers.ReadOnlyField()
     is_martial = serializers.ReadOnlyField()
     is_melee = serializers.ReadOnlyField()
@@ -41,14 +43,12 @@ class WeaponSerializer(GameContentSerializer):
         return Weapon.get_distance_unit
 
 
-class ItemRaritySerializer(GameContentSerializer):
-    key=serializers.ReadOnlyField()
-
+class ItemRaritySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.ItemRarity
-        fields = '__all__'
+        fields = ['name', 'url', 'key', 'rank']
 
-class ItemCategorySerializer(GameContentSerializer):
+class ItemCategorySerializer(serializers.ModelSerializer):
     key = serializers.ReadOnlyField()
 
     class Meta:
@@ -58,20 +58,22 @@ class ItemCategorySerializer(GameContentSerializer):
 class ItemSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
     is_magic_item = serializers.ReadOnlyField()
-    weapon = WeaponSerializer(read_only=True, context={'request':{}})
-    armor = ArmorSerializer(read_only=True, context={'request':{}})
+    weapon = WeaponSerializer()
+    armor = ArmorSerializer()
     document = DocumentSummarySerializer()
     category = ItemCategorySerializer()
     rarity = ItemRaritySerializer()
+    damage_immunities = DamageTypeSummarySerializer(many=True)
+    size = SizeSummarySerializer()
     
-    def to_representation(self, instance):
-        """Ensures weapon/armor remain null instead of empty objects at depth>0."""
-        data = super().to_representation(instance)
+    # def to_representation(self, instance):
+    #     """Ensures weapon/armor remain null instead of empty objects at depth>0."""
+    #     data = super().to_representation(instance)
 
-        for field in ["weapon", "armor"]:
-            if getattr(instance, field, None) is None:
-                data[field] = None
-        return data
+    #     for field in ["weapon", "armor"]:
+    #         if getattr(instance, field, None) is None:
+    #             data[field] = None
+    #     return data
     
     class Meta:
         model = models.Item

--- a/api_v2/serializers/item.py
+++ b/api_v2/serializers/item.py
@@ -33,7 +33,8 @@ class ArmorSummarySerializer(serializers.ModelSerializer):
             'ac_display',
             'ac_add_dexmod',
             'ac_cap_dexmod',
-            'grants_stealth_disadvantage'
+            'grants_stealth_disadvantage',
+            'strength_score_required',
         ]
 
 class WeaponSerializer(GameContentSerializer):

--- a/api_v2/serializers/item.py
+++ b/api_v2/serializers/item.py
@@ -12,7 +12,7 @@ from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
 
 
-class ArmorSerializer(serializers.ModelSerializer):
+class ArmorSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
     ac_display = serializers.ReadOnlyField()
     category = serializers.ReadOnlyField()
@@ -20,6 +20,21 @@ class ArmorSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Armor
         fields = '__all__'
+
+class ArmorSummarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Armor
+        fields = [
+            'name',
+            'key',
+            'url',
+            'category',
+            'ac_base',
+            'ac_display',
+            'ac_add_dexmod',
+            'ac_cap_dexmod',
+            'grants_stealth_disadvantage'
+        ]
 
 class WeaponSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
@@ -59,22 +74,13 @@ class ItemSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
     is_magic_item = serializers.ReadOnlyField()
     weapon = WeaponSerializer()
-    armor = ArmorSerializer()
+    armor = ArmorSummarySerializer()
     document = DocumentSummarySerializer()
     category = ItemCategorySerializer()
     rarity = ItemRaritySerializer()
     damage_immunities = DamageTypeSummarySerializer(many=True)
     size = SizeSummarySerializer()
-    
-    # def to_representation(self, instance):
-    #     """Ensures weapon/armor remain null instead of empty objects at depth>0."""
-    #     data = super().to_representation(instance)
-
-    #     for field in ["weapon", "armor"]:
-    #         if getattr(instance, field, None) is None:
-    #             data[field] = None
-    #     return data
-    
+        
     class Meta:
         model = models.Item
         fields = '__all__'

--- a/api_v2/serializers/item.py
+++ b/api_v2/serializers/item.py
@@ -22,6 +22,11 @@ class ArmorSerializer(GameContentSerializer):
         fields = '__all__'
 
 class ArmorSummarySerializer(serializers.ModelSerializer):
+    '''
+    A slightly slimmer ArmorSerializer, designed to serialize Armor FKs on
+    other serializers. ie. The `armor` field on the ItemSerializer. Not 
+    intended to be used directly in a ModelViewset.
+    '''
     class Meta:
         model = models.Armor
         fields = [

--- a/api_v2/serializers/size.py
+++ b/api_v2/serializers/size.py
@@ -25,6 +25,11 @@ class SizeSerializer(GameContentSerializer):
         return Size.get_distance_unit
 
 class SizeSummarySerializer(serializers.ModelSerializer):
+    '''
+    A slimmer SizeSerializer, designed to serialize Size FKs on other
+    serializers. ie. The `size` field on the CreatureSerializer. Not intended
+    to be used directly in a ModelViewset.
+    '''
     class Meta:
         model = models.Size
         fields = ['name', 'key', 'url']

--- a/api_v2/serializers/size.py
+++ b/api_v2/serializers/size.py
@@ -23,3 +23,8 @@ class SizeSerializer(GameContentSerializer):
     @extend_schema_field(OpenApiTypes.STR)
     def get_distance_unit(self, Size):
         return Size.get_distance_unit
+
+class SizeSummarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Size
+        fields = ['name', 'key', 'url']

--- a/api_v2/serializers/spell.py
+++ b/api_v2/serializers/spell.py
@@ -16,6 +16,10 @@ class SpellSchoolSerializer(GameContentSerializer):
         model = models.SpellSchool
         fields='__all__'
 
+class SpellSchoolSummarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.SpellSchool
+        fields = ['name', 'key', 'url']
 
 class SpellCastingOptionSerializer(serializers.ModelSerializer):
     class Meta:
@@ -27,7 +31,7 @@ class SpellSerializer(GameContentSerializer):
     document = DocumentSummarySerializer()
     key = serializers.ReadOnlyField()
     casting_options = SpellCastingOptionSerializer(many=True)
-    school = SpellSchoolSerializer()
+    school = SpellSchoolSummarySerializer()
     classes = CharacterClassSummarySerializer(many=True)
     
     range_unit = serializers.SerializerMethodField()

--- a/api_v2/serializers/spell.py
+++ b/api_v2/serializers/spell.py
@@ -17,6 +17,11 @@ class SpellSchoolSerializer(GameContentSerializer):
         fields='__all__'
 
 class SpellSchoolSummarySerializer(serializers.ModelSerializer):
+    '''
+    A slimmer SpellSchoolSerializer, designed to serialize Spell School FKs on 
+    other serializers. ie. The `school` field on the SpellSerializer. Not
+    intended to be used directly in a ModelViewset.
+    '''
     class Meta:
         model = models.SpellSchool
         fields = ['name', 'key', 'url']

--- a/api_v2/tests/responses/TestObjects.test_creature_ancient_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creature_ancient_example.approved.json
@@ -200,8 +200,6 @@
     "creaturesets": [],
     "damage_immunities": [
         {
-            "desc": "Red dragons breathe fire, and many spells conjure flames to deal fire damage.",
-            "document": "http://localhost:8000/v2/documents/srd/",
             "key": "fire",
             "name": "Fire",
             "url": "http://localhost:8000/v2/damagetypes/fire/"
@@ -227,23 +225,13 @@
     },
     "environments": [
         {
-            "aquatic": false,
-            "desc": "[None Provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "hills",
             "name": "Hills",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/hills/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "mountain",
             "name": "Mountain",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/mountain/"
         }
     ],
@@ -296,7 +284,11 @@
         "strength": 10,
         "wisdom": 9
     },
-    "size": "http://localhost:8000/v2/sizes/gargantuan/",
+    "size": {
+        "key": "gargantuan",
+        "name": "Gargantuan",
+        "url": "http://localhost:8000/v2/sizes/gargantuan/"
+    },
     "skill_bonuses": {
         "perception": 16,
         "stealth": 7
@@ -350,6 +342,10 @@
     ],
     "tremorsense_range": null,
     "truesight_range": null,
-    "type": "http://localhost:8000/v2/creaturetypes/dragon/",
+    "type": {
+        "key": "dragon",
+        "name": "Dragon",
+        "url": "http://localhost:8000/v2/creaturetypes/dragon/"
+    },
     "url": "http://localhost:8000/v2/creatures/srd_ancient-red-dragon/"
 }

--- a/api_v2/tests/responses/TestObjects.test_creature_goblin_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creature_goblin_example.approved.json
@@ -107,133 +107,68 @@
     },
     "environments": [
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "arctic",
             "name": "Arctic or Tundra",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/arctic/"
         },
         {
-            "aquatic": false,
-            "desc": "Caves and caverns",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": true,
             "key": "caves",
             "name": "Caves",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/caves/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "desert",
             "name": "Desert",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/desert/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "forest",
             "name": "Forest or Jungle",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/forest/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "grassland",
             "name": "Grassland or Plains",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/grassland/"
         },
         {
-            "aquatic": false,
-            "desc": "[None Provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "hills",
             "name": "Hills",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/hills/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "mountain",
             "name": "Mountain",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/mountain/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": true,
             "key": "ruins",
             "name": "Ruins",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/ruins/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": true,
             "key": "sewer",
             "name": "Sewer",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/sewer/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "srd_feywild",
             "name": "Feywild",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/srd_feywild/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "swamp",
             "name": "Swamp or Marsh",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/swamp/"
         },
         {
-            "aquatic": false,
-            "desc": "[None Provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "underworld",
             "name": "Underworld",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/underworld/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "urban",
             "name": "Urban",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/urban/"
         }
     ],
@@ -281,7 +216,11 @@
         "strength": -1,
         "wisdom": -1
     },
-    "size": "http://localhost:8000/v2/sizes/small/",
+    "size": {
+        "key": "small",
+        "name": "Small",
+        "url": "http://localhost:8000/v2/sizes/small/"
+    },
     "skill_bonuses": {
         "stealth": 6
     },
@@ -332,6 +271,10 @@
     ],
     "tremorsense_range": null,
     "truesight_range": null,
-    "type": "http://localhost:8000/v2/creaturetypes/humanoid/",
+    "type": {
+        "key": "humanoid",
+        "name": "Humanoid",
+        "url": "http://localhost:8000/v2/creaturetypes/humanoid/"
+    },
     "url": "http://localhost:8000/v2/creatures/srd_goblin/"
 }

--- a/api_v2/tests/responses/TestObjects.test_creature_guard_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creature_guard_example.approved.json
@@ -93,73 +93,38 @@
     },
     "environments": [
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "coast",
             "name": "Coast",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/coast/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "desert",
             "name": "Desert",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/desert/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "forest",
             "name": "Forest or Jungle",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/forest/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "grassland",
             "name": "Grassland or Plains",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/grassland/"
         },
         {
-            "aquatic": false,
-            "desc": "[None Provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "hills",
             "name": "Hills",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/hills/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "mountain",
             "name": "Mountain",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/mountain/"
         },
         {
-            "aquatic": false,
-            "desc": "[None provided]",
-            "document": "http://localhost:8000/v2/documents/open5e-e/",
-            "interior": false,
             "key": "urban",
             "name": "Urban",
-            "planar": false,
             "url": "http://localhost:8000/v2/environments/urban/"
         }
     ],
@@ -201,7 +166,11 @@
         "strength": 1,
         "wisdom": 0
     },
-    "size": "http://localhost:8000/v2/sizes/medium/",
+    "size": {
+        "key": "medium",
+        "name": "Medium",
+        "url": "http://localhost:8000/v2/sizes/medium/"
+    },
     "skill_bonuses": {
         "perception": 2
     },
@@ -243,6 +212,10 @@
     "traits": [],
     "tremorsense_range": null,
     "truesight_range": null,
-    "type": "http://localhost:8000/v2/creaturetypes/humanoid/",
+    "type": {
+        "key": "humanoid",
+        "name": "Humanoid",
+        "url": "http://localhost:8000/v2/creaturetypes/humanoid/"
+    },
     "url": "http://localhost:8000/v2/creatures/srd_guard/"
 }

--- a/api_v2/tests/responses/TestObjects.test_creatureset_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creatureset_example.approved.json
@@ -77,23 +77,13 @@
             },
             "environments": [
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "desert",
                     "name": "Desert",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/desert/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "urban",
                     "name": "Urban",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/urban/"
                 }
             ],
@@ -135,7 +125,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/large/",
+            "size": {
+                "key": "large",
+                "name": "Large",
+                "url": "http://localhost:8000/v2/sizes/large/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -194,7 +188,11 @@
             "traits": [],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_camel/"
         },
         {
@@ -276,7 +274,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/medium/",
+            "size": {
+                "key": "medium",
+                "name": "Medium",
+                "url": "http://localhost:8000/v2/sizes/medium/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -335,7 +337,11 @@
             "traits": [],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_donkey/"
         },
         {
@@ -415,13 +421,8 @@
             },
             "environments": [
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "urban",
                     "name": "Urban",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/urban/"
                 }
             ],
@@ -463,7 +464,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/large/",
+            "size": {
+                "key": "large",
+                "name": "Large",
+                "url": "http://localhost:8000/v2/sizes/large/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -522,7 +527,11 @@
             "traits": [],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_draft-horse/"
         },
         {
@@ -636,33 +645,18 @@
             },
             "environments": [
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "desert",
                     "name": "Desert",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/desert/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "forest",
                     "name": "Forest or Jungle",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/forest/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "grassland",
                     "name": "Grassland or Plains",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/grassland/"
                 }
             ],
@@ -704,7 +698,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/huge/",
+            "size": {
+                "key": "huge",
+                "name": "Huge",
+                "url": "http://localhost:8000/v2/sizes/huge/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -772,7 +770,11 @@
             ],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_elephant/"
         },
         {
@@ -852,33 +854,18 @@
             },
             "environments": [
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "forest",
                     "name": "Forest or Jungle",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/forest/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None Provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "hills",
                     "name": "Hills",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/hills/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "urban",
                     "name": "Urban",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/urban/"
                 }
             ],
@@ -920,7 +907,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/medium/",
+            "size": {
+                "key": "medium",
+                "name": "Medium",
+                "url": "http://localhost:8000/v2/sizes/medium/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -988,7 +979,11 @@
             ],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_mastiff/"
         },
         {
@@ -1068,33 +1063,18 @@
             },
             "environments": [
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "grassland",
                     "name": "Grassland or Plains",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/grassland/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None Provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "hills",
                     "name": "Hills",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/hills/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "urban",
                     "name": "Urban",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/urban/"
                 }
             ],
@@ -1136,7 +1116,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/medium/",
+            "size": {
+                "key": "medium",
+                "name": "Medium",
+                "url": "http://localhost:8000/v2/sizes/medium/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -1212,7 +1196,11 @@
             ],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_mule/"
         },
         {
@@ -1292,23 +1280,13 @@
             },
             "environments": [
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "mountain",
                     "name": "Mountain",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/mountain/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "urban",
                     "name": "Urban",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/urban/"
                 }
             ],
@@ -1350,7 +1328,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/medium/",
+            "size": {
+                "key": "medium",
+                "name": "Medium",
+                "url": "http://localhost:8000/v2/sizes/medium/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -1409,7 +1391,11 @@
             "traits": [],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_pony/"
         },
         {
@@ -1489,23 +1475,13 @@
             },
             "environments": [
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "grassland",
                     "name": "Grassland or Plains",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/grassland/"
                 },
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "urban",
                     "name": "Urban",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/urban/"
                 }
             ],
@@ -1547,7 +1523,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/large/",
+            "size": {
+                "key": "large",
+                "name": "Large",
+                "url": "http://localhost:8000/v2/sizes/large/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -1606,7 +1586,11 @@
             "traits": [],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_riding-horse/"
         },
         {
@@ -1686,13 +1670,8 @@
             },
             "environments": [
                 {
-                    "aquatic": false,
-                    "desc": "[None provided]",
-                    "document": "http://localhost:8000/v2/documents/open5e-e/",
-                    "interior": false,
                     "key": "urban",
                     "name": "Urban",
-                    "planar": false,
                     "url": "http://localhost:8000/v2/environments/urban/"
                 }
             ],
@@ -1734,7 +1713,11 @@
                 "strength": 0,
                 "wisdom": 0
             },
-            "size": "http://localhost:8000/v2/sizes/large/",
+            "size": {
+                "key": "large",
+                "name": "Large",
+                "url": "http://localhost:8000/v2/sizes/large/"
+            },
             "skill_bonuses": {
                 "acrobatics": 0,
                 "animal_handling": 0,
@@ -1802,7 +1785,11 @@
             ],
             "tremorsense_range": null,
             "truesight_range": null,
-            "type": "http://localhost:8000/v2/creaturetypes/beast/",
+            "type": {
+                "key": "beast",
+                "name": "Beast",
+                "url": "http://localhost:8000/v2/creaturetypes/beast/"
+            },
             "url": "http://localhost:8000/v2/creatures/srd_warhorse/"
         }
     ],

--- a/api_v2/tests/responses/TestObjects.test_item_armor_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_armor_example.approved.json
@@ -1,12 +1,35 @@
 {
-    "armor": "http://localhost:8000/v2/armor/srd_splint/",
+    "armor": {
+        "ac_add_dexmod": false,
+        "ac_base": 17,
+        "ac_cap_dexmod": null,
+        "ac_display": "17",
+        "category": "heavy",
+        "grants_stealth_disadvantage": true,
+        "key": "srd_splint",
+        "name": "Splint",
+        "strength_score_required": 15,
+        "url": "http://localhost:8000/v2/armor/srd_splint/"
+    },
     "armor_class": 0,
     "armor_detail": "",
-    "category": "http://localhost:8000/v2/itemcategories/armor/",
+    "category": {
+        "document": "srd",
+        "key": "armor",
+        "name": "Armor"
+    },
     "cost": "200.00",
     "damage_immunities": [
-        "http://localhost:8000/v2/damagetypes/poison/",
-        "http://localhost:8000/v2/damagetypes/psychic/"
+        {
+            "key": "poison",
+            "name": "Poison",
+            "url": "http://localhost:8000/v2/damagetypes/poison/"
+        },
+        {
+            "key": "psychic",
+            "name": "Psychic",
+            "url": "http://localhost:8000/v2/damagetypes/psychic/"
+        }
     ],
     "damage_resistances": [],
     "damage_vulnerabilities": [],
@@ -35,7 +58,11 @@
     "nonmagical_attack_resistance": false,
     "rarity": null,
     "requires_attunement": false,
-    "size": "http://localhost:8000/v2/sizes/tiny/",
+    "size": {
+        "key": "tiny",
+        "name": "Tiny",
+        "url": "http://localhost:8000/v2/sizes/tiny/"
+    },
     "url": "http://localhost:8000/v2/items/srd_splint-armor/",
     "weapon": null,
     "weight": "60.000"

--- a/api_v2/tests/responses/TestObjects.test_item_category_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_category_example.approved.json
@@ -1,6 +1,5 @@
 {
-    "document": "http://localhost:8000/v2/documents/srd/",
+    "document": "srd",
     "key": "weapon",
-    "name": "Weapon",
-    "url": "http://localhost:8000/v2/itemcategories/weapon/"
+    "name": "Weapon"
 }

--- a/api_v2/tests/responses/TestObjects.test_item_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_example.approved.json
@@ -2,11 +2,23 @@
     "armor": null,
     "armor_class": 0,
     "armor_detail": "",
-    "category": "http://localhost:8000/v2/itemcategories/wondrous-item/",
+    "category": {
+        "document": "srd",
+        "key": "wondrous-item",
+        "name": "Wondrous Item"
+    },
     "cost": "0.00",
     "damage_immunities": [
-        "http://localhost:8000/v2/damagetypes/poison/",
-        "http://localhost:8000/v2/damagetypes/psychic/"
+        {
+            "key": "poison",
+            "name": "Poison",
+            "url": "http://localhost:8000/v2/damagetypes/poison/"
+        },
+        {
+            "key": "psychic",
+            "name": "Psychic",
+            "url": "http://localhost:8000/v2/damagetypes/psychic/"
+        }
     ],
     "damage_resistances": [],
     "damage_vulnerabilities": [],
@@ -33,9 +45,18 @@
     "name": "Apparatus of the Crab",
     "nonmagical_attack_immunity": false,
     "nonmagical_attack_resistance": false,
-    "rarity": "http://localhost:8000/v2/itemrarities/legendary/",
+    "rarity": {
+        "key": "legendary",
+        "name": "Legendary",
+        "rank": 5,
+        "url": "http://localhost:8000/v2/itemrarities/legendary/"
+    },
     "requires_attunement": false,
-    "size": "http://localhost:8000/v2/sizes/tiny/",
+    "size": {
+        "key": "tiny",
+        "name": "Tiny",
+        "url": "http://localhost:8000/v2/sizes/tiny/"
+    },
     "url": "http://localhost:8000/v2/items/srd_apparatus-of-the-crab/",
     "weapon": null,
     "weight": "0.000"

--- a/api_v2/tests/responses/TestObjects.test_item_melee_weapon_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_melee_weapon_example.approved.json
@@ -2,11 +2,23 @@
     "armor": null,
     "armor_class": 0,
     "armor_detail": "",
-    "category": "http://localhost:8000/v2/itemcategories/weapon/",
+    "category": {
+        "document": "srd",
+        "key": "weapon",
+        "name": "Weapon"
+    },
     "cost": "10.00",
     "damage_immunities": [
-        "http://localhost:8000/v2/damagetypes/poison/",
-        "http://localhost:8000/v2/damagetypes/psychic/"
+        {
+            "key": "poison",
+            "name": "Poison",
+            "url": "http://localhost:8000/v2/damagetypes/poison/"
+        },
+        {
+            "key": "psychic",
+            "name": "Psychic",
+            "url": "http://localhost:8000/v2/damagetypes/psychic/"
+        }
     ],
     "damage_resistances": [],
     "damage_vulnerabilities": [],
@@ -35,7 +47,11 @@
     "nonmagical_attack_resistance": false,
     "rarity": null,
     "requires_attunement": false,
-    "size": "http://localhost:8000/v2/sizes/tiny/",
+    "size": {
+        "key": "tiny",
+        "name": "Tiny",
+        "url": "http://localhost:8000/v2/sizes/tiny/"
+    },
     "url": "http://localhost:8000/v2/items/srd_shortsword/",
     "weapon": "http://localhost:8000/v2/weapons/srd_shortsword/",
     "weight": "2.000"

--- a/api_v2/tests/responses/TestObjects.test_item_ranged_weapon_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_ranged_weapon_example.approved.json
@@ -2,11 +2,23 @@
     "armor": null,
     "armor_class": 0,
     "armor_detail": "",
-    "category": "http://localhost:8000/v2/itemcategories/weapon/",
+    "category": {
+        "document": "srd",
+        "key": "weapon",
+        "name": "Weapon"
+    },
     "cost": "50.00",
     "damage_immunities": [
-        "http://localhost:8000/v2/damagetypes/poison/",
-        "http://localhost:8000/v2/damagetypes/psychic/"
+        {
+            "key": "poison",
+            "name": "Poison",
+            "url": "http://localhost:8000/v2/damagetypes/poison/"
+        },
+        {
+            "key": "psychic",
+            "name": "Psychic",
+            "url": "http://localhost:8000/v2/damagetypes/psychic/"
+        }
     ],
     "damage_resistances": [],
     "damage_vulnerabilities": [],
@@ -35,7 +47,11 @@
     "nonmagical_attack_resistance": false,
     "rarity": null,
     "requires_attunement": false,
-    "size": "http://localhost:8000/v2/sizes/tiny/",
+    "size": {
+        "key": "tiny",
+        "name": "Tiny",
+        "url": "http://localhost:8000/v2/sizes/tiny/"
+    },
     "url": "http://localhost:8000/v2/items/srd_longbow/",
     "weapon": "http://localhost:8000/v2/weapons/srd_longbow/",
     "weight": "2.000"

--- a/api_v2/tests/responses/TestObjects.test_item_set_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_set_example.approved.json
@@ -6,11 +6,23 @@
             "armor": null,
             "armor_class": 0,
             "armor_detail": "",
-            "category": "http://localhost:8000/v2/itemcategories/adventuring-gear/",
+            "category": {
+                "document": "srd",
+                "key": "adventuring-gear",
+                "name": "Adventuring Gear"
+            },
             "cost": "10.00",
             "damage_immunities": [
-                "http://localhost:8000/v2/damagetypes/poison/",
-                "http://localhost:8000/v2/damagetypes/psychic/"
+                {
+                    "key": "poison",
+                    "name": "Poison",
+                    "url": "http://localhost:8000/v2/damagetypes/poison/"
+                },
+                {
+                    "key": "psychic",
+                    "name": "Psychic",
+                    "url": "http://localhost:8000/v2/damagetypes/psychic/"
+                }
             ],
             "damage_resistances": [],
             "damage_vulnerabilities": [],
@@ -39,7 +51,11 @@
             "nonmagical_attack_resistance": false,
             "rarity": null,
             "requires_attunement": false,
-            "size": "http://localhost:8000/v2/sizes/tiny/",
+            "size": {
+                "key": "tiny",
+                "name": "Tiny",
+                "url": "http://localhost:8000/v2/sizes/tiny/"
+            },
             "url": "http://localhost:8000/v2/items/srd_crystal/",
             "weapon": null,
             "weight": "1.000"
@@ -48,11 +64,23 @@
             "armor": null,
             "armor_class": 0,
             "armor_detail": "",
-            "category": "http://localhost:8000/v2/itemcategories/adventuring-gear/",
+            "category": {
+                "document": "srd",
+                "key": "adventuring-gear",
+                "name": "Adventuring Gear"
+            },
             "cost": "20.00",
             "damage_immunities": [
-                "http://localhost:8000/v2/damagetypes/poison/",
-                "http://localhost:8000/v2/damagetypes/psychic/"
+                {
+                    "key": "poison",
+                    "name": "Poison",
+                    "url": "http://localhost:8000/v2/damagetypes/poison/"
+                },
+                {
+                    "key": "psychic",
+                    "name": "Psychic",
+                    "url": "http://localhost:8000/v2/damagetypes/psychic/"
+                }
             ],
             "damage_resistances": [],
             "damage_vulnerabilities": [],
@@ -81,7 +109,11 @@
             "nonmagical_attack_resistance": false,
             "rarity": null,
             "requires_attunement": false,
-            "size": "http://localhost:8000/v2/sizes/tiny/",
+            "size": {
+                "key": "tiny",
+                "name": "Tiny",
+                "url": "http://localhost:8000/v2/sizes/tiny/"
+            },
             "url": "http://localhost:8000/v2/items/srd_orb/",
             "weapon": null,
             "weight": "3.000"
@@ -90,11 +122,23 @@
             "armor": null,
             "armor_class": 0,
             "armor_detail": "",
-            "category": "http://localhost:8000/v2/itemcategories/rod/",
+            "category": {
+                "document": "srd",
+                "key": "rod",
+                "name": "Rod"
+            },
             "cost": "10.00",
             "damage_immunities": [
-                "http://localhost:8000/v2/damagetypes/poison/",
-                "http://localhost:8000/v2/damagetypes/psychic/"
+                {
+                    "key": "poison",
+                    "name": "Poison",
+                    "url": "http://localhost:8000/v2/damagetypes/poison/"
+                },
+                {
+                    "key": "psychic",
+                    "name": "Psychic",
+                    "url": "http://localhost:8000/v2/damagetypes/psychic/"
+                }
             ],
             "damage_resistances": [],
             "damage_vulnerabilities": [],
@@ -123,7 +167,11 @@
             "nonmagical_attack_resistance": false,
             "rarity": null,
             "requires_attunement": false,
-            "size": "http://localhost:8000/v2/sizes/tiny/",
+            "size": {
+                "key": "tiny",
+                "name": "Tiny",
+                "url": "http://localhost:8000/v2/sizes/tiny/"
+            },
             "url": "http://localhost:8000/v2/items/srd_rod/",
             "weapon": null,
             "weight": "0.000"
@@ -132,11 +180,23 @@
             "armor": null,
             "armor_class": 0,
             "armor_detail": "",
-            "category": "http://localhost:8000/v2/itemcategories/staff/",
+            "category": {
+                "document": "srd",
+                "key": "staff",
+                "name": "Staff"
+            },
             "cost": "5.00",
             "damage_immunities": [
-                "http://localhost:8000/v2/damagetypes/poison/",
-                "http://localhost:8000/v2/damagetypes/psychic/"
+                {
+                    "key": "poison",
+                    "name": "Poison",
+                    "url": "http://localhost:8000/v2/damagetypes/poison/"
+                },
+                {
+                    "key": "psychic",
+                    "name": "Psychic",
+                    "url": "http://localhost:8000/v2/damagetypes/psychic/"
+                }
             ],
             "damage_resistances": [],
             "damage_vulnerabilities": [],
@@ -165,7 +225,11 @@
             "nonmagical_attack_resistance": false,
             "rarity": null,
             "requires_attunement": false,
-            "size": "http://localhost:8000/v2/sizes/tiny/",
+            "size": {
+                "key": "tiny",
+                "name": "Tiny",
+                "url": "http://localhost:8000/v2/sizes/tiny/"
+            },
             "url": "http://localhost:8000/v2/items/srd_staff/",
             "weapon": "http://localhost:8000/v2/weapons/srd_quarterstaff/",
             "weight": "4.000"
@@ -174,11 +238,23 @@
             "armor": null,
             "armor_class": 0,
             "armor_detail": "",
-            "category": "http://localhost:8000/v2/itemcategories/wand/",
+            "category": {
+                "document": "srd",
+                "key": "wand",
+                "name": "Wand"
+            },
             "cost": "10.00",
             "damage_immunities": [
-                "http://localhost:8000/v2/damagetypes/poison/",
-                "http://localhost:8000/v2/damagetypes/psychic/"
+                {
+                    "key": "poison",
+                    "name": "Poison",
+                    "url": "http://localhost:8000/v2/damagetypes/poison/"
+                },
+                {
+                    "key": "psychic",
+                    "name": "Psychic",
+                    "url": "http://localhost:8000/v2/damagetypes/psychic/"
+                }
             ],
             "damage_resistances": [],
             "damage_vulnerabilities": [],
@@ -207,7 +283,11 @@
             "nonmagical_attack_resistance": false,
             "rarity": null,
             "requires_attunement": false,
-            "size": "http://localhost:8000/v2/sizes/tiny/",
+            "size": {
+                "key": "tiny",
+                "name": "Tiny",
+                "url": "http://localhost:8000/v2/sizes/tiny/"
+            },
             "url": "http://localhost:8000/v2/items/srd_wand/",
             "weapon": null,
             "weight": "1.000"

--- a/api_v2/tests/responses/TestObjects.test_itemrarity_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_itemrarity_example.approved.json
@@ -1,5 +1,4 @@
 {
-    "document": "http://localhost:8000/v2/documents/srd/",
     "key": "common",
     "name": "Common",
     "rank": 1,

--- a/api_v2/tests/responses/TestObjects.test_spell_cantrip_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_spell_cantrip_example.approved.json
@@ -68,7 +68,11 @@
     "reaction_condition": null,
     "ritual": false,
     "saving_throw_ability": "",
-    "school": "http://localhost:8000/v2/spellschools/transmutation/",
+    "school": {
+        "key": "transmutation",
+        "name": "Transmutation",
+        "url": "http://localhost:8000/v2/spellschools/transmutation/"
+    },
     "shape_size": null,
     "shape_size_unit": "feet",
     "shape_type": null,

--- a/api_v2/tests/responses/TestObjects.test_spell_fireball.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_spell_fireball.approved.json
@@ -114,7 +114,11 @@
     "reaction_condition": null,
     "ritual": false,
     "saving_throw_ability": "dexterity",
-    "school": "http://localhost:8000/v2/spellschools/evocation/",
+    "school": {
+        "key": "evocation",
+        "name": "Evocation",
+        "url": "http://localhost:8000/v2/spellschools/evocation/"
+    },
     "shape_size": 20.0,
     "shape_size_unit": "feet",
     "shape_type": "sphere",

--- a/api_v2/tests/responses/TestObjects.test_spell_wish.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_spell_wish.approved.json
@@ -58,7 +58,11 @@
     "reaction_condition": null,
     "ritual": false,
     "saving_throw_ability": "",
-    "school": "http://localhost:8000/v2/spellschools/conjuration/",
+    "school": {
+        "key": "conjuration",
+        "name": "Conjuration",
+        "url": "http://localhost:8000/v2/spellschools/conjuration/"
+    },
     "shape_size": null,
     "shape_size_unit": "feet",
     "shape_type": null,

--- a/api_v2/tests/responses/TestObjects.test_weapon_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_weapon_example.approved.json
@@ -1,6 +1,10 @@
 {
     "damage_dice": "1d6",
-    "damage_type": "http://localhost:8000/v2/damagetypes/slashing/",
+    "damage_type": {
+        "key": "slashing",
+        "name": "Slashing",
+        "url": "http://localhost:8000/v2/damagetypes/slashing/"
+    },
     "distance_unit": "feet",
     "document": "http://localhost:8000/v2/documents/srd/",
     "is_finesse": true,

--- a/api_v2/views/creature.py
+++ b/api_v2/views/creature.py
@@ -89,6 +89,14 @@ class CreatureViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
         'traits',
     ]
 
+    def get_serializer(self, *args, **kwargs):
+        # Ignore `depth` query parameter on this endpoint. It interacts badly
+        # with our custom serializers and is no longer necessary on this view
+        if 'depth' in self.request.query_params:
+            self.request.query_params._mutable = True
+            self.request.query_params.pop('depth', None)
+            self.request.query_params._mutable = False
+        return super().get_serializer(*args, **kwargs)
 
 class CreatureTypeFilterSet(FilterSet):
     class Meta:

--- a/api_v2/views/item.py
+++ b/api_v2/views/item.py
@@ -44,7 +44,9 @@ class ItemViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
         'damage_resistances',
         'damage_vulnerabilities',
         'document',
+        # 'document__gamesystem',
         'rarity',
+        'size',
     ]
 
 class ItemRarityViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
## Description

This PR introduces numerous new Summary Serializers into the V2 API. The purpose of these serializers is that they are used in other serializers to handle foreign keys better so that they return more finely grained information. Ultimately this will return repetition and redundancy in our endpoint JSON payloads, improving server response time and resource usage, while still retaining all existing functionality.

The following Serializers have been added:

- `ArmorSummarySerializer`, which is used for the `"armor"` FK on the `ItemSerializer`
- `ConditionSummarySerializer`, which is used for the `"conditions_immunities"` FK on the `CreatureSerializer`
- `CreatureTypeSummarySerializer`, which is used for the `"type"` FK on the `CreatureSerializer`
- `DamageTypeSummarySerializer` which is used on the `CreatureSerializer`, `WeaponSerializer`, and `ItemSerializer`s
- `EnvironmentSummarySerializer`, which is used for the `"environments"` FK on the `CreatureSerializer`
- `SizeSummarySerializer`, which is used across many endpoints
- `SpellSchoolSerializer`, which is used for the `"school"` FK on the `SpellSerializer`

Additionally, testing data needed to be updated to reflect the changes made to the shape of the API JSON response.

## Related Issue

Closes #703 