### PR TITLE
[V2 DATA] Fixed erroneous `"False"` strings as null values in TOB-2023 dataset

### DIFF
--- a/data/v2/kobold-press/tob-2023/Creature.json
+++ b/data/v2/kobold-press/tob-2023/Creature.json
@@ -77,10 +77,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -167,7 +167,7 @@
     "environments": [],
     "damage_resistances_display": "necrotic; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, poisoned"
   }
 },
@@ -250,9 +250,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, poisoned"
   }
 },
@@ -332,10 +332,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -413,9 +413,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "slashing",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed"
   }
 },
@@ -496,10 +496,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -582,9 +582,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -669,8 +669,8 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "lightning",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -764,7 +764,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, fire; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "cold, lightning, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -844,10 +844,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "lightning, thunder",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -930,9 +930,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "lightning, poison, thunder",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -1014,9 +1014,9 @@
     ],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -1097,9 +1097,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -1194,7 +1194,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold, lightning",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -1273,10 +1273,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "leather armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -1350,10 +1350,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -1435,9 +1435,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, poisoned"
   }
 },
@@ -1517,10 +1517,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -1598,9 +1598,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "slashing",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed"
   }
 },
@@ -1681,10 +1681,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -1767,9 +1767,9 @@
     "environments": [],
     "armor_detail": "breastplate",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -1852,9 +1852,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -1939,8 +1939,8 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "lightning",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -2028,7 +2028,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "necrotic; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, poisoned"
   }
 },
@@ -2111,9 +2111,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, deafened, poisoned, prone"
   }
 },
@@ -2199,7 +2199,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "lightning",
     "damage_immunities_display": "poison; bludgeoning from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -2292,7 +2292,7 @@
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious"
   }
 },
@@ -2459,10 +2459,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -2539,10 +2539,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -2625,9 +2625,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning, poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -2703,10 +2703,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -2785,10 +2785,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -2865,9 +2865,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -2957,7 +2957,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -3037,10 +3037,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "lightning, thunder",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -3131,7 +3131,7 @@
     "armor_detail": "plate, shield",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "lightning, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, paralyzed, poisoned"
   }
 },
@@ -3208,10 +3208,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -3285,10 +3285,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "breastplate",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -3364,10 +3364,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -3457,7 +3457,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "poison; bludgeoning, slashing, and piercing from nonmagical attacks not made with cold iron weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -3535,10 +3535,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "hide armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -3619,9 +3619,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, poisoned"
   }
 },
@@ -3719,7 +3719,7 @@
     "armor_detail": "Angry Defiance",
     "damage_resistances_display": "acid, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "cold, necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained"
   }
 },
@@ -3802,9 +3802,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -3886,10 +3886,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
     "damage_vulnerabilities_display": "fire",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -3968,10 +3968,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "bludgeoning",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -4063,7 +4063,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "lightning, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -4138,10 +4138,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "plate",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -4217,10 +4217,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -4301,9 +4301,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, poisoned"
   }
 },
@@ -4381,10 +4381,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -4479,7 +4479,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, slashing",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone, restrained, stunned"
   }
 },
@@ -4557,9 +4557,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -4753,7 +4753,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, poisoned"
   }
 },
@@ -4847,7 +4847,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, lightning; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, poisoned"
   }
 },
@@ -4938,7 +4938,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -5015,10 +5015,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -5096,10 +5096,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "thunder",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -5187,8 +5187,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "radiant; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened"
   }
 },
@@ -5264,10 +5264,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -5350,7 +5350,7 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "fire",
     "condition_immunities_display": "blinded, deafened"
   }
@@ -5538,9 +5538,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, poisoned, prone"
   }
 },
@@ -5617,9 +5617,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "paralyzed"
   }
 },
@@ -5696,10 +5696,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "acid",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -5780,9 +5780,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, poisoned"
   }
 },
@@ -5873,8 +5873,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold, fire; slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, deafened, frightened, paralyzed, prone, stunned, unconscious"
   }
 },
@@ -5963,7 +5963,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "piercing",
     "damage_immunities_display": "fire, radiant",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion"
   }
 },
@@ -6043,9 +6043,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, poisoned"
   }
 },
@@ -6128,9 +6128,9 @@
     "condition_immunities": [],
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -6210,9 +6210,9 @@
     ],
     "environments": [],
     "armor_detail": "studded leather, shield",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -6291,10 +6291,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "fire",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -6384,7 +6384,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "cold, fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -6475,9 +6475,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, grappled, paralyzed, petrified, poisoned, restrained, unconscious"
   }
 },
@@ -6556,9 +6556,9 @@
     "condition_immunities": [],
     "environments": [],
     "damage_resistances_display": "acid, fire, poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -6636,10 +6636,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "acid",
     "damage_vulnerabilities_display": "bludgeoning",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -6715,10 +6715,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "chain shirt",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -6813,7 +6813,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -6898,9 +6898,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -6995,7 +6995,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, slashing",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned"
   }
 },
@@ -7079,9 +7079,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -7166,9 +7166,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -7253,9 +7253,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -7342,9 +7342,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -7431,9 +7431,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -7515,9 +7515,9 @@
     ],
     "environments": [],
     "armor_detail": "Clurichaun's Luck",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "frightened, poisoned"
   }
 },
@@ -7606,8 +7606,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, slashing",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned"
   }
 },
@@ -7692,7 +7692,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -7778,7 +7778,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "necrotic",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, poisoned"
   }
 },
@@ -7856,10 +7856,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -8038,7 +8038,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, slashing",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, deafened, exhaustion, frightened, prone poisoned"
   }
 },
@@ -8118,10 +8118,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -8212,7 +8212,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -8299,7 +8299,7 @@
     "armor_detail": "scale mail, shield",
     "damage_resistances_display": "necrotic",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, poisoned"
   }
 },
@@ -8377,10 +8377,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -8472,7 +8472,7 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, slashing",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "cold, fire",
     "condition_immunities_display": "charmed, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned"
   }
@@ -8548,10 +8548,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -8647,7 +8647,7 @@
     "environments": [],
     "damage_resistances_display": "acid, cold, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained"
   }
 },
@@ -8730,9 +8730,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "necrotic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "paralyzed"
   }
 },
@@ -8815,9 +8815,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "fire",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -8900,9 +8900,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, thunder",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "fire",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -8984,9 +8984,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "fire",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -9062,10 +9062,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "armor scraps",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -9144,10 +9144,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -9235,8 +9235,8 @@
     "environments": [],
     "armor_detail": "Infernal Blessing",
     "damage_resistances_display": "cold, fire, poison; bludgeoning, piercing, and slashing damage from nonmagical attacks not made with silvered weapons",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -9321,8 +9321,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, deafened, exhaustion, frightened, prone"
   }
 },
@@ -9410,7 +9410,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, poisoned"
   }
 },
@@ -9485,10 +9485,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -9562,10 +9562,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -9646,10 +9646,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "acid, lightning",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -9722,10 +9722,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -9806,9 +9806,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold, lightning",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -9891,9 +9891,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "lightning",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "paralyzed, prone"
   }
 },
@@ -9971,9 +9971,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, deafened"
   }
 },
@@ -10053,8 +10053,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "paralyzed"
   }
 },
@@ -10147,7 +10147,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -10239,7 +10239,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, poisoned"
   }
 },
@@ -10317,10 +10317,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -10410,7 +10410,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing damage from nonmagical attacks",
     "damage_immunities_display": "necrotic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened"
   }
 },
@@ -10490,9 +10490,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "acid, fire",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "prone"
   }
 },
@@ -10571,10 +10571,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -10654,9 +10654,9 @@
     ],
     "environments": [],
     "armor_detail": "leather armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -10737,9 +10737,9 @@
     "environments": [],
     "armor_detail": "breastplate",
     "damage_resistances_display": "poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -10815,10 +10815,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -10909,7 +10909,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "lightning, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, poisoned"
   }
 },
@@ -11009,7 +11009,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, grappled, frightened, paralyzed, petrified, poisoned, prone, restrained, unconscious"
   }
 },
@@ -11084,10 +11084,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -11169,9 +11169,9 @@
     "environments": [],
     "armor_detail": "chain mail, shield",
     "damage_resistances_display": "piercing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -11252,10 +11252,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
     "damage_vulnerabilities_display": "radiant",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -11355,7 +11355,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, slashing",
     "damage_immunities_display": "acid, cold, fire, lightning, poison, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, unconscious"
   }
 },
@@ -11433,10 +11433,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -11533,7 +11533,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, piercing",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, deafened, charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone, unconscious"
   }
 },
@@ -11608,10 +11608,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "Divine Blessing",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -11779,10 +11779,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "breastplate",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -11860,10 +11860,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "leather armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -11942,9 +11942,9 @@
     "environments": [],
     "armor_detail": "leather armor",
     "damage_resistances_display": "poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -12023,9 +12023,9 @@
     "environments": [],
     "armor_detail": "chain shirt",
     "damage_resistances_display": "poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -12113,9 +12113,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic, radiant; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -12194,10 +12194,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "hide armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -12274,9 +12274,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -12362,8 +12362,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from attacks not made with cold iron weapons",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -12456,7 +12456,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold, fire, lightning",
     "damage_immunities_display": "necrotic, poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -12537,9 +12537,9 @@
       "frightened"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -12628,7 +12628,7 @@
     "armor_detail": "Patron's Blessing",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, poisoned"
   }
 },
@@ -12720,7 +12720,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
     "damage_immunities_display": "lightning, poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -12816,7 +12816,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "fire, lightning, poison; bludgeoning, piercing, and slashing damage from nonmagical attacks",
     "damage_immunities_display": "acid, cold",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, petrified, poisoned"
   }
 },
@@ -12908,7 +12908,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, poisoned"
   }
 },
@@ -12994,9 +12994,9 @@
       "unconscious"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious"
   }
 },
@@ -13079,9 +13079,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -13161,10 +13161,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -13343,7 +13343,7 @@
     "armor_detail": "studded leather",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "necrotic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "frightened"
   }
 },
@@ -13421,10 +13421,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "chain shirt",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -13502,10 +13502,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -13583,10 +13583,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "leather armor, shield",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -13751,10 +13751,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -13828,10 +13828,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -13923,7 +13923,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -13998,10 +13998,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -14087,7 +14087,7 @@
     "armor_detail": "half plate",
     "damage_resistances_display": "necrotic",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, poisoned"
   }
 },
@@ -14165,9 +14165,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -14242,10 +14242,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -14319,10 +14319,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -14413,7 +14413,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold; bludgeoning, piercing, and slashing damage from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -14488,10 +14488,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -14581,7 +14581,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -14656,10 +14656,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "chain shirt",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -14738,9 +14738,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -14826,7 +14826,7 @@
     "environments": [],
     "damage_resistances_display": "necrotic",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, poisoned"
   }
 },
@@ -14919,7 +14919,7 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, slashing",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "cold, fire",
     "condition_immunities_display": "charmed, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned"
   }
@@ -14996,10 +14996,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -15094,7 +15094,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "necrotic, poison; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, poisoned"
   }
 },
@@ -15175,9 +15175,9 @@
     ],
     "environments": [],
     "armor_detail": "chain shirt",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -15262,9 +15262,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, paralyzed, poisoned"
   }
 },
@@ -15354,7 +15354,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "necrotic; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "psychic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -15451,7 +15451,7 @@
     "environments": [],
     "damage_resistances_display": "acid, cold, fire, lightning, necrotic, thunder",
     "damage_immunities_display": "poison; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, restrained"
   }
 },
@@ -15546,7 +15546,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -15642,7 +15642,7 @@
     "armor_detail": "chain shirt",
     "damage_resistances_display": "bludgeoning, cold, lightning",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -15730,9 +15730,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -15807,10 +15807,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -15888,10 +15888,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
     "damage_vulnerabilities_display": "fire",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -15979,7 +15979,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "lightning, thunder",
     "damage_immunities_display": "cold; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion"
   }
 },
@@ -16059,9 +16059,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -16156,7 +16156,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "lightning, radiant, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "acid, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, deafened, exhaustion, frightened, prone, stunned, unconscious"
   }
 },
@@ -16252,7 +16252,7 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "bludgeoning, fire, piercing, poison, slashing",
     "damage_vulnerabilities_display": "cold",
     "condition_immunities_display": "charmed, frightened, paralyzed, petrified, poisoned, prone, restrained, stunned"
@@ -16344,7 +16344,7 @@
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "cold",
     "damage_vulnerabilities_display": "fire",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -16439,7 +16439,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone"
   }
 },
@@ -16523,9 +16523,9 @@
     ],
     "environments": [],
     "armor_detail": "breastplate",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, poisoned"
   }
 },
@@ -16616,7 +16616,7 @@
     "environments": [],
     "damage_resistances_display": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -16700,9 +16700,9 @@
     ],
     "environments": [],
     "armor_detail": "breastplate",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, poisoned"
   }
 },
@@ -16779,10 +16779,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -16863,9 +16863,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, lightning",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -16939,10 +16939,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17024,10 +17024,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17108,9 +17108,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17192,9 +17192,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17286,7 +17286,7 @@
     "armor_detail": "natural armor, shield",
     "damage_resistances_display": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -17361,10 +17361,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17452,7 +17452,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold; bludgeoning, piercing, and slashing damage from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -17530,10 +17530,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17619,9 +17619,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold, poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, poisoned"
   }
 },
@@ -17699,10 +17699,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17780,10 +17780,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17858,10 +17858,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -17943,9 +17943,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -18032,9 +18032,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -18119,7 +18119,7 @@
     "environments": [],
     "damage_resistances_display": "piercing and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, poisoned"
   }
 },
@@ -18198,10 +18198,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -18283,7 +18283,7 @@
       "unconscious"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
     "damage_vulnerabilities_display": "fire",
     "condition_immunities_display": "paralyzed, unconscious"
@@ -18385,7 +18385,7 @@
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison, psychic, radiant",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious"
   }
 },
@@ -18474,7 +18474,7 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic",
     "damage_vulnerabilities_display": "fire",
     "condition_immunities_display": "blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned"
@@ -18570,7 +18570,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with cold iron weapons",
     "damage_immunities_display": "cold, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, charmed, frightened, poisoned"
   }
 },
@@ -18647,10 +18647,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -18724,10 +18724,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -18819,7 +18819,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold; bludgeoning, piercing, and slashing damage from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -18894,10 +18894,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -18988,7 +18988,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "fire, radiant, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, poisoned"
   }
 },
@@ -19080,7 +19080,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, poisoned"
   }
 },
@@ -19158,10 +19158,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -19245,9 +19245,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -19325,9 +19325,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "acid",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "prone"
   }
 },
@@ -19521,7 +19521,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "fire; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -19600,9 +19600,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -19698,7 +19698,7 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "acid, fire, lightning, poison; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_vulnerabilities_display": "cold",
     "condition_immunities_display": "charmed, frightened, poisoned, stunned"
@@ -19782,9 +19782,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, radiant",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -19866,8 +19866,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "poison, slashing",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "prone"
   }
 },
@@ -19949,9 +19949,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "acid, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, poisoned"
   }
 },
@@ -20028,10 +20028,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -20106,10 +20106,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -20192,8 +20192,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "thunder",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -20272,9 +20272,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "slashing",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed"
   }
 },
@@ -20352,10 +20352,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "Ethereal Coat",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -20444,9 +20444,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -20539,7 +20539,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -20635,7 +20635,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid; bludgeoning, piercing, and slashing from attacks not made with cold iron weapons",
     "damage_immunities_display": "cold, fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, poisoned"
   }
 },
@@ -20723,7 +20723,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning from nonmagical attacks",
     "damage_immunities_display": "acid",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "prone"
   }
 },
@@ -20799,10 +20799,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -20883,9 +20883,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -20975,7 +20975,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, poisoned, stunned, unconscious"
   }
 },
@@ -21066,7 +21066,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "paralyzed, poisoned, unconscious"
   }
 },
@@ -21150,7 +21150,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "necrotic",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, poisoned"
   }
 },
@@ -21225,10 +21225,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -21396,10 +21396,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -21483,9 +21483,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "lightning, thunder",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "radiant; bludgeoning, piercing, and slashing from nonmagical attacks made with silvered weapons",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -21580,7 +21580,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing and slashing from nonmagical attacks",
     "damage_immunities_display": "cold, necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, restrained"
   }
 },
@@ -21661,9 +21661,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold, necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -21743,9 +21743,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold, necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -21820,10 +21820,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather in Humanoid form",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -21897,10 +21897,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather in Humanoid form",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -21978,9 +21978,9 @@
     ],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "frightened"
   }
 },
@@ -22068,8 +22068,8 @@
     ],
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, slashing",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned"
   }
 },
@@ -22252,7 +22252,7 @@
     "armor_detail": "natural armor, shield",
     "damage_resistances_display": "acid, cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -22430,10 +22430,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "thunder",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -22518,7 +22518,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "necrotic; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -22595,10 +22595,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -22685,7 +22685,7 @@
     "armor_detail": "plate",
     "damage_resistances_display": "radiant; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, poisoned"
   }
 },
@@ -22762,10 +22762,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -22852,9 +22852,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -22942,7 +22942,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -23029,7 +23029,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning and piercing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, poisoned"
   }
 },
@@ -23121,7 +23121,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning",
     "damage_immunities_display": "poison; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, exhaustion, frightened, poisoned"
   }
 },
@@ -23214,7 +23214,7 @@
     "armor_detail": "Regal Bearing",
     "damage_resistances_display": "fire, lightning",
     "damage_immunities_display": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with cold iron weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -23309,7 +23309,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks not made with cold iron weapons",
     "damage_immunities_display": "radiant",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, frightened"
   }
 },
@@ -23494,9 +23494,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, fire; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -23572,10 +23572,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "leather armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -23668,7 +23668,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, paralyzed, petrified, poisoned, prone, stunned"
   }
 },
@@ -23750,9 +23750,9 @@
     "condition_immunities": [],
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -23828,10 +23828,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -23908,10 +23908,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -24000,7 +24000,7 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "cold, fire",
     "condition_immunities_display": "blinded, deafened"
   }
@@ -24078,10 +24078,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -24157,10 +24157,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -24236,10 +24236,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -24317,9 +24317,9 @@
       "frightened"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -24403,9 +24403,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, poisoned"
   }
 },
@@ -24492,8 +24492,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -24572,9 +24572,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "force, poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -24650,10 +24650,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -24730,9 +24730,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -24806,10 +24806,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "studded leather",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -24904,7 +24904,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks not made with cold iron weapons",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened"
   }
 },
@@ -24983,9 +24983,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -25064,9 +25064,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -25154,9 +25154,9 @@
       "unconscious"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, grappled, frightened, paralyzed, petrified, poisoned, prone, restrained, unconscious"
   }
 },
@@ -25249,7 +25249,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "lightning, thunder, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned, stunned"
   }
 },
@@ -25328,9 +25328,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -25414,7 +25414,7 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
     "damage_vulnerabilities_display": "acid",
     "condition_immunities_display": "poisoned"
@@ -25507,7 +25507,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -25596,9 +25596,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire, poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -25678,10 +25678,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -25768,7 +25768,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, frightened, poisoned"
   }
 },
@@ -25843,10 +25843,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -25940,7 +25940,7 @@
     "environments": [],
     "damage_resistances_display": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, poisoned, unconscious"
   }
 },
@@ -26015,10 +26015,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -26105,7 +26105,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning",
     "damage_immunities_display": "acid",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, deafened, exhaustion, frightened, prone"
   }
 },
@@ -26194,7 +26194,7 @@
     "environments": [],
     "damage_resistances_display": "acid, necrotic",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, deafened, exhaustion, frightened, poisoned, prone"
   }
 },
@@ -26283,7 +26283,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "acid, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, paralyzed, petrified, poisoned"
   }
 },
@@ -26366,8 +26366,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -26448,9 +26448,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "unconscious"
   }
 },
@@ -26529,9 +26529,9 @@
     "condition_immunities": [],
     "environments": [],
     "damage_resistances_display": "poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -26611,10 +26611,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -26702,8 +26702,8 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "acid, lightning",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -26782,8 +26782,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "poison",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -26858,10 +26858,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -26937,10 +26937,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "breastplate, shield",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -27034,8 +27034,8 @@
     ],
     "environments": [],
     "damage_resistances_display": "acid, cold, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, grappled, paralyzed, petrified, poisoned, restrained"
   }
 },
@@ -27113,10 +27113,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "chain shirt",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -27198,7 +27198,7 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold, poison",
     "damage_vulnerabilities_display": "bludgeoning",
     "condition_immunities_display": "exhaustion, poisoned"
@@ -27282,9 +27282,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, poisoned, unconscious"
   }
 },
@@ -27377,7 +27377,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, fire, piercing",
     "damage_immunities_display": "cold, slashing, thunder",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, deafened, prone, stunned, unconscious"
   }
 },
@@ -27563,8 +27563,8 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "radiant",
     "damage_immunities_display": "fire, lightning, psychic",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -27642,9 +27642,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -27728,9 +27728,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "acid",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, deafened, exhaustion, frightened, prone"
   }
 },
@@ -27827,7 +27827,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "lightning",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious"
   }
 },
@@ -27915,9 +27915,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -28009,7 +28009,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with cold iron weapons",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened"
   }
 },
@@ -28106,7 +28106,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "necrotic, radiant; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "cold, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -28200,7 +28200,7 @@
     "environments": [],
     "damage_resistances_display": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "paralyzed, poisoned, prone, stunned, unconscious"
   }
 },
@@ -28295,7 +28295,7 @@
     "environments": [],
     "damage_resistances_display": "thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "lightning",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained, unconscious"
   }
 },
@@ -28382,7 +28382,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -28471,7 +28471,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -28569,7 +28569,7 @@
     "environments": [],
     "damage_resistances_display": "acid, fire, lightning, thunder; bludgeoning, piercing, and slashing damage from nonmagical attacks",
     "damage_immunities_display": "cold, necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained"
   }
 },
@@ -28653,9 +28653,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, poisoned, unconscious"
   }
 },
@@ -28744,7 +28744,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "fire",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -28819,10 +28819,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -28908,8 +28908,8 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "piercing from nonmagical attacks",
     "damage_immunities_display": "lightning, thunder",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -29001,9 +29001,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, frightened, paralyzed"
   }
 },
@@ -29100,7 +29100,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, slashing",
     "damage_immunities_display": "cold, fire, lightning, poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -29189,9 +29189,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire, poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine weapons",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -29268,10 +29268,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -29347,10 +29347,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -29442,7 +29442,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, fire, lightning; bludgeoning and piercing from nonmagical attacks",
     "damage_immunities_display": "cold, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -29517,10 +29517,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -29596,10 +29596,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -29672,10 +29672,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -29748,10 +29748,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -29845,7 +29845,7 @@
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, slashing",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned, unconscious"
   }
 },
@@ -29934,8 +29934,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, slashing",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned"
   }
 },
@@ -30023,8 +30023,8 @@
     ],
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, slashing",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned"
   }
 },
@@ -30207,8 +30207,8 @@
     ],
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, slashing",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, grappled, paralyzed, petrified, prone, restrained, stunned"
   }
 },
@@ -30308,7 +30308,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "acid, fire, lightning, thunder; bludgeoning, necrotic, piercing, slashing",
     "damage_immunities_display": "cold, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, grappled, paralyzed, petrified, poisoned, prone, restrained, stunned"
   }
 },
@@ -30394,7 +30394,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "radiant; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -30474,8 +30474,8 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "fire",
     "condition_immunities_display": "blinded, deafened"
   }
@@ -30654,10 +30654,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "chain shirt",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -30731,10 +30731,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -30823,7 +30823,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "fire, poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -30897,10 +30897,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -30976,10 +30976,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -31061,9 +31061,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, poisoned"
   }
 },
@@ -31137,10 +31137,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -31217,10 +31217,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "leather armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -31293,10 +31293,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -31372,10 +31372,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "hide armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -31451,10 +31451,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "lightning",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -31552,7 +31552,7 @@
     "environments": [],
     "damage_resistances_display": "acid, fire, lightning, thunder; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "cold, necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion, grappled, paralyzed, petrified, poisoned, prone, restrained"
   }
 },
@@ -31639,7 +31639,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "radiant; bludgeoning, piercing, and slashing damage from nonmagical attacks",
     "damage_immunities_display": "fire, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -31726,7 +31726,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, lightning; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons",
     "damage_immunities_display": "thunder",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "frightened"
   }
 },
@@ -31817,7 +31817,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -31905,9 +31905,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -31998,7 +31998,7 @@
     "armor_detail": "chain mail, shield",
     "damage_resistances_display": "acid, cold, fire, lightning, thunder",
     "damage_immunities_display": "poison; bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "frightened, poisoned"
   }
 },
@@ -32079,9 +32079,9 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -32259,8 +32259,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "fire, bludgeoning, piercing",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, blinded, deafened, frightened, prone"
   }
 },
@@ -32342,9 +32342,9 @@
     "condition_immunities": [],
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -32428,8 +32428,8 @@
     ],
     "environments": [],
     "damage_resistances_display": "bludgeoning, piercing, and slashing from nonmagical attacks not made with cold iron weapons",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "frightened"
   }
 },
@@ -32512,8 +32512,8 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "fire",
     "condition_immunities_display": "blinded, deafened"
   }
@@ -32601,7 +32601,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing, and slashing damage from nonmagical attacks",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "deafened, exhaustion, poisoned"
   }
 },
@@ -32685,9 +32685,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -32771,7 +32771,7 @@
       "prone"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "necrotic",
     "damage_vulnerabilities_display": "radiant",
     "condition_immunities_display": "exhaustion, petrified, prone"
@@ -32865,7 +32865,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks",
     "damage_immunities_display": "acid, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "poisoned"
   }
 },
@@ -32947,9 +32947,9 @@
     ],
     "environments": [],
     "armor_detail": "chain shirt",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "necrotic, poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened, poisoned"
   }
 },
@@ -33025,10 +33025,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -33101,10 +33101,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -33178,10 +33178,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -33266,9 +33266,9 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning, piercing",
-    "damage_immunities_display": "False",
+    "damage_immunities_display": "",
     "damage_vulnerabilities_display": "fire",
-    "condition_immunities_display": "False"
+    "condition_immunities_display": ""
   }
 },
 {
@@ -33341,10 +33341,10 @@
     "damage_resistances": [],
     "condition_immunities": [],
     "environments": [],
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -33420,10 +33420,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -33506,8 +33506,8 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "lightning",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -33593,9 +33593,9 @@
       "prone"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison, psychic, radiant",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, charmed, exhaustion, frightened, paralyzed, petrified, poisoned, prone"
   }
 },
@@ -33673,10 +33673,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "chain shirt, shield",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -33756,7 +33756,7 @@
       "poisoned"
     ],
     "environments": [],
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "necrotic, poison",
     "damage_vulnerabilities_display": "radiant",
     "condition_immunities_display": "poisoned"
@@ -33847,7 +33847,7 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "force",
     "damage_immunities_display": "poison, psychic",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, exhaustion, frightened, paralyzed, petrified, poisoned"
   }
 },
@@ -33926,10 +33926,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -34008,8 +34008,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "bludgeoning",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "exhaustion"
   }
 },
@@ -34092,9 +34092,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "poison",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "blinded, poisoned"
   }
 },
@@ -34174,10 +34174,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "fire",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -34255,9 +34255,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "slashing",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed"
   }
 },
@@ -34338,10 +34338,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -34415,10 +34415,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -34501,9 +34501,9 @@
     ],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
+    "damage_resistances_display": "",
     "damage_immunities_display": "cold",
-    "damage_vulnerabilities_display": "False",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "charmed, frightened"
   }
 },
@@ -34588,8 +34588,8 @@
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold",
     "damage_immunities_display": "lightning",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -34663,10 +34663,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -34742,10 +34742,10 @@
     "condition_immunities": [],
     "environments": [],
     "armor_detail": "natural armor",
-    "damage_resistances_display": "False",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
-    "condition_immunities_display": "False"
+    "damage_resistances_display": "",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
+    "condition_immunities_display": ""
   }
 },
 {
@@ -34831,8 +34831,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "paralyzed, unconscious"
   }
 },
@@ -34918,8 +34918,8 @@
     "environments": [],
     "armor_detail": "natural armor",
     "damage_resistances_display": "cold, fire",
-    "damage_immunities_display": "False",
-    "damage_vulnerabilities_display": "False",
+    "damage_immunities_display": "",
+    "damage_vulnerabilities_display": "",
     "condition_immunities_display": "paralyzed, unconscious"
   }
 }

--- a/data/v2/kobold-press/tob3/CreatureTrait.json
+++ b/data/v2/kobold-press/tob3/CreatureTrait.json
@@ -291,10 +291,10 @@
 },
 {
   "model": "api_v2.creaturetrait",
-  "pk": "tob3_alpine-creeper_false",
+  "pk": "tob3_alpine-creeper_false-appearance",
   "fields": {
-    "name": "False",
-    "desc": "[+]Appearance[/+] Motionless: indistinguishable from patch of lichen.",
+    "name": "False Appearance",
+    "desc": "Motionless: indistinguishable from patch of lichen.",
     "type": null,
     "parent": "tob3_alpine-creeper"
   }
@@ -831,10 +831,10 @@
 },
 {
   "model": "api_v2.creaturetrait",
-  "pk": "tob3_animated-instrument-symphony_false",
+  "pk": "tob3_animated-instrument-symphony_false-appearance",
   "fields": {
-    "name": "False",
-    "desc": "[+]Appearance[/+] Motionless and not flying: indistinguishable from large musical instrument collection and performance paraphernalia.",
+    "name": "False Appearance",
+    "desc": "Motionless and not flying: indistinguishable from large musical instrument collection and performance paraphernalia.",
     "type": null,
     "parent": "tob3_animated-instrument-symphony"
   }
@@ -911,10 +911,10 @@
 },
 {
   "model": "api_v2.creaturetrait",
-  "pk": "tob3_animated-instrument_false",
+  "pk": "tob3_animated-instrument_false-appearance",
   "fields": {
-    "name": "False",
-    "desc": "[+]Appearance[/+] While motionless and isn't flying indistinguishable from normal musical instrument.",
+    "name": "False Appearance",
+    "desc": "While motionless and not flying indistinguishable from normal musical instrument.",
     "type": null,
     "parent": "tob3_animated-instrument"
   }
@@ -8151,10 +8151,10 @@
 },
 {
   "model": "api_v2.creaturetrait",
-  "pk": "tob3_moppet_false",
+  "pk": "tob3_moppet_false-appearance",
   "fields": {
-    "name": "False",
-    "desc": "[+]Appearance[/+] Motionless: indistinguishable from normal doll.",
+    "name": "False Appearance",
+    "desc": "Motionless: indistinguishable from normal doll.",
     "type": null,
     "parent": "tob3_moppet"
   }
@@ -8451,10 +8451,10 @@
 },
 {
   "model": "api_v2.creaturetrait",
-  "pk": "tob3_nariphon_false",
+  "pk": "tob3_nariphon_false-appearance",
   "fields": {
-    "name": "False",
-    "desc": "[+]Appearance[/+] Motionless: indistinguishable from ordinary tree.",
+    "name": "False Appearance",
+    "desc": "Motionless: indistinguishable from an ordinary tree.",
     "type": null,
     "parent": "tob3_nariphon"
   }
@@ -9291,10 +9291,10 @@
 },
 {
   "model": "api_v2.creaturetrait",
-  "pk": "tob3_ooze-shoal_false",
+  "pk": "tob3_ooze-shoal_false-appearance",
   "fields": {
-    "name": "False",
-    "desc": "[+]Appearance[/+] Until it attacks indistinguishable from a large school of fish.",
+    "name": "False Appearance",
+    "desc": "Until it attacks indistinguishable from a large school of fish.",
     "type": null,
     "parent": "tob3_ooze-shoal"
   }


### PR DESCRIPTION
## Description

This PR fixes a minor bug in the V2 data where certain fields in the Tome of Beasts 2023 Creatures data had certain null values set to the string `"False"` instead of anactually null/nullish value. If the same problematic fields in different document sources, the null value is listed as an empty string, `""`. I have updated the TOB-2023 data to follow this convention.

While investigating, I encounted another bug in certain CreatureTraits from the TOB3 dataset. Traits that included the word "False" in their name, ie. "False Appearance" that their titles spread across their descriptions. This was persumably a parsing error from the V1->V2 conversion and has now been fixed.

## Related Issue

Closes  #727