### PR TITLE
[V2] Added WotC SRD 5.2 to Document list

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2024/Document.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/Document.json
@@ -1,0 +1,20 @@
+[
+  {
+    "model": "api_v2.document",
+    "pk": "srd-2024",
+    "fields": {
+      "name": "System Reference Document 5.2",
+      "desc": "The System Reference Document (SRD) contains guidelines for publishing content under Creative Commons.",
+      "publisher": "wizards-of-the-coast",
+      "gamesystem": "o5e",
+      "author": "Wizards of the Coast",
+      "publication_date": "2024-01-01T00:00:00",
+      "permalink": "https://dnd.wizards.com/resources/systems-reference-document",
+      "distance_unit": "feet",
+      "weight_unit": "lb",
+      "licenses": [
+        "cc-by-40"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Description

This PR had the WotC SRD 5.2 document to the list of source documents available via the Open5e API (ie. articles that can be viewed at the `/v2/documents` endpoint).

This entry is a prerequisite to adding any other 5.2 data, as each item requires a source document to be defined.

## Related Issue

A step toward getting #711 resolved