### PR TITLE
766 bug weapon properties is unordered

### DIFF
--- a/api_v2/serializers/item.py
+++ b/api_v2/serializers/item.py
@@ -63,7 +63,7 @@ class WeaponPropertyAssignmentSerializer(GameContentSerializer):
 class WeaponSerializer(GameContentSerializer):
     key = serializers.ReadOnlyField()
     document = DocumentSummarySerializer()
-    properties = WeaponPropertyAssignmentSerializer(many=True)
+    properties = serializers.SerializerMethodField()
     damage_type = DamageTypeSummarySerializer()
     ranged_attack_possible = serializers.ReadOnlyField()
     range_melee = serializers.ReadOnlyField()
@@ -77,6 +77,10 @@ class WeaponSerializer(GameContentSerializer):
     @extend_schema_field(OpenApiTypes.STR)
     def get_distance_unit(self, Weapon):
         return Weapon.get_distance_unit
+
+    def get_properties(self, instance):
+        properties = instance.properties.all().order_by('-property_id')
+        return WeaponPropertyAssignmentSerializer(properties, context={'request': None}, many=True).data
 
 class WeaponSummarySerializer(GameContentSerializer):
     '''

--- a/api_v2/tests/responses/TestObjects.test_item_ranged_weapon_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_ranged_weapon_example.approved.json
@@ -69,19 +69,19 @@
         "name": "Longbow",
         "properties": [
             {
-                "detail": "range 150/600",
-                "property": {
-                    "name": "Ammunition",
-                    "type": null,
-                    "url": "http://localhost:8000/v2/weaponproperties/srd-2014_ammunition-wp/"
-                }
-            },
-            {
                 "detail": null,
                 "property": {
                     "name": "Two-Handed",
                     "type": null,
                     "url": "http://localhost:8000/v2/weaponproperties/srd-2014_two-handed-wp/"
+                }
+            },
+            {
+                "detail": "range 150/600",
+                "property": {
+                    "name": "Ammunition",
+                    "type": null,
+                    "url": "http://localhost:8000/v2/weaponproperties/srd-2014_ammunition-wp/"
                 }
             }
         ],

--- a/api_v2/tests/responses/TestObjects.test_weapon_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_weapon_example.approved.json
@@ -31,17 +31,17 @@
         {
             "detail": null,
             "property": {
-                "name": "Finesse",
+                "name": "Light",
                 "type": null,
-                "url": "http://localhost:8000/v2/weaponproperties/srd-2014_finesse-wp/"
+                "url": "/v2/weaponproperties/srd-2014_light-wp/"
             }
         },
         {
             "detail": null,
             "property": {
-                "name": "Light",
+                "name": "Finesse",
                 "type": null,
-                "url": "http://localhost:8000/v2/weaponproperties/srd-2014_light-wp/"
+                "url": "/v2/weaponproperties/srd-2014_finesse-wp/"
             }
         }
     ],

--- a/api_v2/tests/responses/TestObjects.test_weapon_with_mastery_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_weapon_with_mastery_example.approved.json
@@ -29,19 +29,19 @@
     "name": "Longsword",
     "properties": [
         {
-            "detail": null,
-            "property": {
-                "name": "Sap",
-                "type": "Mastery",
-                "url": "http://localhost:8000/v2/weaponproperties/srd-2024_sap-mastery/"
-            }
-        },
-        {
             "detail": "1d10",
             "property": {
                 "name": "Versatile",
                 "type": null,
-                "url": "http://localhost:8000/v2/weaponproperties/srd-2024_versatile-wp/"
+                "url": "/v2/weaponproperties/srd-2024_versatile-wp/"
+            }
+        },
+        {
+            "detail": null,
+            "property": {
+                "name": "Sap",
+                "type": "Mastery",
+                "url": "/v2/weaponproperties/srd-2024_sap-mastery/"
             }
         }
     ],


### PR DESCRIPTION
The properties field on a weapon would sometimes come back in a different order. This results in tests occasionally failing with no code changes depending on host-based interactions. I have ordered this field, it will now always return based on the descending property id.

Tests have been adjusted to use this order.