### PR TITLE
[V2 DATA] Removed duplicated copy from A5e/SRD-2014 Feats

### DIFF
--- a/api_v2/tests/responses/TestObjects.test_feats_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_feats_example.approved.json
@@ -7,7 +7,7 @@
             "desc": "You can use your action to try to pin a creature grappled by you. The creature makes a Strength or Dexterity saving throw against your maneuver DC. On a failure, you and the creature are both restrained until the grapple ends."
         }
     ],
-    "desc": "You've developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:\r\n* You have advantage on attack rolls against a creature you are grappling.\r\n* You can use your action to try to pin a creature grappled by you. The creature makes a Strength or Dexterity saving throw against your maneuver DC. On a failure, you and the creature are both restrained until the grapple ends.",
+    "desc": "You've developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:",
     "document": {
         "display_name": "5e 2014 Rules",
         "gamesystem": {

--- a/data/v2/en-publishing/a5e-ag/Feat.json
+++ b/data/v2/en-publishing/a5e-ag/Feat.json
@@ -1,7 +1,7 @@
 [
 {
   "fields": {
-    "desc": "You are a virtuoso of driving and piloting vehicles, able to push them beyond their normal limits and maneuver them with fluid grace through hazardous situations. You gain the following benefits:\r\n* You gain an expertise die on ability checks made to drive or pilot a vehicle.\r\n* While piloting a vehicle, you can use your reaction to take the Brake or Maneuver vehicle actions.\r\n* A vehicle you load can carry 25% more cargo than normal.\r\n* Vehicles you are piloting only suffer a malfunction when reduced to 25% of their hit points, not 50%. In addition, when the vehicle does suffer a malfunction, you roll twice on the maneuver table and choose which die to use for the result.\r\n* Vehicles you are piloting gain a bonus to their Armor Class equal to half your proficiency bonus.\r\n* When you Brake, you can choose to immediately stop the vehicle without traveling half of its movement speed directly forward.",
+    "desc": "You are a virtuoso of driving and piloting vehicles, able to push them beyond their normal limits and maneuver them with fluid grace through hazardous situations. You gain the following benefits:",
     "document": "a5e-ag",
     "name": "Ace Driver",
     "prerequisite": "Proficiency with a type of vehicle",
@@ -12,7 +12,7 @@
 },
 {
   "fields": {
-    "desc": "Your enhanced physical training grants you the following benefits:\r\n\r\n* Your Strength or Dexterity score increases by 1, to a maximum of 20.\r\n* When you are prone, standing up uses only 5 feet of your movement (instead of half).\r\n* Your speed is not halved from climbing.\r\n* You can make a running long jump or a running high jump after moving 5 feet on foot (instead of 10 feet).",
+    "desc": "Your enhanced physical training grants you the following benefits:",
     "document": "a5e-ag",
     "name": "Athletic",
     "prerequisite": "",
@@ -23,7 +23,7 @@
 },
 {
   "fields": {
-    "desc": "Always aware of your surroundings, you gain the following benefits:\r\n\r\n* When rolling initiative you gain a +5 bonus.\r\n* You can only be surprised if you are unconscious. A creature attacking you does not gain advantage from being hidden from you or unseen by you.",
+    "desc": "Always aware of your surroundings, you gain the following benefits:",
     "document": "a5e-ag",
     "name": "Attentive",
     "prerequisite": "",
@@ -34,7 +34,7 @@
 },
 {
   "fields": {
-    "desc": "You're comfortable casting, even in the chaos of battle.\r\n\r\n* You gain a 1d6 expertise die on concentration checks to maintain spells you have cast.\r\n* While wielding weapons and shields, you may cast spells with a seen component.\r\n* Instead of making an opportunity attack with a weapon, you may use your reaction to cast a spell with a casting time of 1 action. The spell must be one that only targets that creature.",
+    "desc": "You're comfortable casting, even in the chaos of battle.",
     "document": "a5e-ag",
     "name": "Battle Caster",
     "prerequisite": "Requires the ability to cast at least one spell of 1st-level or higher",
@@ -67,7 +67,7 @@
 },
 {
   "fields": {
-    "desc": "You know how to trade blows for more than inflicting harm.\r\n\r\n* You gain proficiency with the Deceptive Stance and Painful Pickpocket maneuvers, and do not have to spend exertion to activate them.\r\n* You gain an expertise die on Sleight of Hand checks.",
+    "desc": "You know how to trade blows for more than inflicting harm.",
     "document": "a5e-ag",
     "name": "Combat Thievery",
     "prerequisite": "",
@@ -78,7 +78,7 @@
 },
 {
   "fields": {
-    "desc": "You have absorbed some of the lessons of the world of spies, criminals, and others who operate in the shadows. You gain the following benefits:\r\n\r\n* You gain proficiency with thieves' tools, the poisoner's kit, or a rare weapon with the stealthy property.\r\n* You gain two skill tricks of your choice from the rogue class.",
+    "desc": "You have absorbed some of the lessons of the world of spies, criminals, and others who operate in the shadows. You gain the following benefits:",
     "document": "a5e-ag",
     "name": "Covert Training",
     "prerequisite": "",
@@ -89,7 +89,7 @@
 },
 {
   "fields": {
-    "desc": "You have devoted time to studying and practicing the art of crafting, gaining the following benefits: This feat can be selected multiple times, choosing a different type of crafted item each time.\r\n\r\n* Choose one of the following types of crafted item: armor, engineered items, potions, rings and rods, staves and wands, weapons, wondrous items. You gain advantage on checks made to craft, maintain, and repair that type of item.\r\n* You gain an expertise die on checks made to craft, maintain, and repair items.\r\n* You gain proficiency with two tools of your choice.\r\n\r\nThis feat can be selected multiple times, choosing a different type of crafted item each time.",
+    "desc": "You have devoted time to studying and practicing the art of crafting, gaining the following benefits:",
     "document": "a5e-ag",
     "name": "Crafting Expert",
     "prerequisite": "",
@@ -100,7 +100,7 @@
 },
 {
   "fields": {
-    "desc": "* If proficient with a crossbow, you ignore its loading property.\r\n* You do not have disadvantage on ranged attack rolls from being within 5 feet of a hostile creature.\r\n* When you attack with a one-handed weapon using the Attack action, you can use a bonus action to attack with a hand crossbow wielded in your off-hand.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Crossbow Expertise",
     "prerequisite": "",
@@ -111,7 +111,7 @@
 },
 {
   "fields": {
-    "desc": "Your natural talent or skill makes you lethal with a ranged weapon.\r\n\r\n* You gain proficiency with the Farshot Stance and Ricochet maneuvers, and do not have to spend exertion to activate them. \r\n* Before you make an attack with a ranged weapon you are proficient with, you can choose to take a penalty on the attack roll equal to your proficiency bonus. If the attack hits, you deal extra damage equal to double your proficiency bonus. This extra damage does not double on a critical hit.\r\n* You ignore half cover and three-quarters cover when making a ranged weapon attack.",
+    "desc": "Your natural talent or skill makes you lethal with a ranged weapon.",
     "document": "a5e-ag",
     "name": "Deadeye",
     "prerequisite": "8th level or higher",
@@ -133,7 +133,7 @@
 },
 {
   "fields": {
-    "desc": "* An ability score of your choice increases by 1.\r\n* When you gain inspiration through your destiny’s source of inspiration, you can choose one party member within 30 feet of you. That party member gains inspiration if they don’t have it already. Once you inspire a party member in this way, you can’t use this feature again on that party member until you finish a long rest.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Destiny’s Call",
     "prerequisite": "",
@@ -144,7 +144,7 @@
 },
 {
   "fields": {
-    "desc": "* While wielding a separate melee weapon in each hand, you gain a +1 bonus to Armor Class.\r\n* You can use two-weapon fighting with any two one-handed melee weapons so long as neither has the heavy property.\r\n* When you would normally draw or sheathe a one-handed weapon, you can instead draw or sheathe two one-handed weapons.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Dual-Wielding Expert",
     "prerequisite": "",
@@ -155,7 +155,7 @@
 },
 {
   "fields": {
-    "desc": "* You have advantage on Investigation and Perception checks made to detect secret doors.\r\n* You have advantage on saving throws made against traps.\r\n* You have resistance to damage dealt by traps.\r\n* You don’t take a −5 penalty on your passive Perception score from traveling at a fast pace.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Dungeoneer",
     "prerequisite": "",
@@ -166,7 +166,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Wisdom or Charisma score increases by 1.\r\n* You gain an expertise die on Insight checks made against other creatures.\r\n* When using a social skill and making a Charisma check another creature, you score a critical success on a roll of 19–20.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Empathic",
     "prerequisite": "",
@@ -177,7 +177,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain proficiency with the Victory Pose maneuver and do not have to spend exertion to activate it. In addition, you may use this maneuver with up to three different weapons you select instead of just one, and affect allies within 60 feet. \r\n* An ally affected by your Victory Pose gains an expertise die on their next saving throw against fear, and if they are rattled the condition ends for them.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Fear Breaker",
     "prerequisite": "",
@@ -188,7 +188,7 @@
 },
 {
   "fields": {
-    "desc": "You gain 3 fate points. Whenever you make an attack roll, ability check, or saving throw and do not have disadvantage, you can spend a fate point to roll an additional d20 and choose whichever result you wish. \r\nYou may do this after the initial roll has occurred, but before the outcome is known. If you have disadvantage, you may instead spend a fate point to choose one of the d20 rolls and reroll it.\r\nAlternatively, when you are attacked, you can choose to spend a fate point to force the attacking creature to reroll the attack. The creature resolves the attack with the result you choose. You regain all expended fate points when you finish a long rest.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Fortunate",
     "prerequisite": "",
@@ -199,7 +199,7 @@
 },
 {
   "fields": {
-    "desc": "* A creature that takes the Disengage action still provokes opportunity attacks from you. \r\n* You gain proficiency with the Warning Strike maneuver and do not have to spend exertion to activate it.\r\n* You can use your reaction to make a melee weapon attack against a creature within 5 feet that makes an attack against a target other than you if the target does not also have this feat.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Guarded Warrior",
     "prerequisite": "",
@@ -210,7 +210,7 @@
 },
 {
   "fields": {
-    "desc": "* When you take this feat, you gain a number of hit points equal to twice your level. \r\n* Whenever you gain a new level, you gain an additional 2 hit points to your hit point maximum.\r\n* During a short rest, you regain 1 additional hit point per hit die spent to heal.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Hardy Adventurer",
     "prerequisite": "",
@@ -221,7 +221,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Strength score increases by 1, to a maximum of 20.\r\n* You gain proficiency with heavy armor.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Heavily Outfitted",
     "prerequisite": "Proficiency with medium armor",
@@ -232,7 +232,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Strength score increases by 1, to a maximum of 20.\r\n* While wearing heavy armor, you reduce all bludgeoning, piercing, and slashing damage from nonmagical weapons by 3.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Heavy Armor Expertise",
     "prerequisite": "Proficiency with heavy armor",
@@ -243,7 +243,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain proficiency in your choice of one martial weapon, one rare weapon, or shields.\r\n* You gain two divine lessons of your choice from the herald class.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Heraldic Training",
     "prerequisite": "",
@@ -254,7 +254,7 @@
 },
 {
   "fields": {
-    "desc": "* Any stronghold you have or buy that is of frugal quality is automatically upgraded to average quality at no additional cost.\r\n* You gain a new follower for every 50 staff you have in your stronghold, rather than every 100 staff.\r\n* When you fulfill your destiny, choose a number of followers equal to your proficiency bonus. Each is upgraded to their most expensive version.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Idealistic Leader",
     "prerequisite": "",
@@ -265,7 +265,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Intelligence or Wisdom score increases by 1, to a maximum of 20. \r\n* Your passive Perception and passive Investigation scores increase by 5.\r\n* If you can see a creature’s mouth while it is speaking a language you know, you can read its lips.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Intuitive",
     "prerequisite": "",
@@ -276,7 +276,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Intelligence score increases by 1, to a maximum of 20.\r\n* You can recall anything you’ve seen or heard within a number of weeks equal to your Intelligence  modifier.\r\n* You know how long it will be before the next sunset or sunrise.\r\n* You know which way is north.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Keen Intellect",
     "prerequisite": "",
@@ -287,7 +287,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Strength or Dexterity score increases by 1, to a maximum of 20.\r\n* You gain proficiency with light armor.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Lightly Outfitted",
     "prerequisite": "",
@@ -298,7 +298,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Intelligence score increases by 1, to a maximum of 20.\r\n* You learn three languages of your choice.\r\n* You can invent ciphers and are able to teach a cipher you create to others. Anyone who knows the cipher can encode and read hidden messages made with it; the apparent text must be at least four times longer than the hidden message. A creature can detect the cipher’s presence if it spends a minute examining it and succeeds on an Investigation check against a DC of 8+ your proficiency bonus + your Intelligence modifier. If the check succeeds by 5 or more, they can read the hidden message.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Linguistics Expert",
     "prerequisite": "",
@@ -309,7 +309,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain proficiency in a combat tradition of your choice. \r\n* You learn two combat maneuvers from a combat tradition you know. If you don’t already know any combat maneuvers, both must be 1st degree. Combat maneuvers gained from this feat do not count toward the maximum number of combat maneuvers you know.\r\n* Your exertion pool increases by 3. If you do not have an exertion pool, you gain an exertion pool with 3 exertion, regaining your exertion whenever you finish a rest.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Martial Scholar",
     "prerequisite": "Proficiency with at least one martial weapon",
@@ -320,7 +320,7 @@
 },
 {
   "fields": {
-    "desc": "* Medium armor doesn’t impose disadvantage on your Dexterity (Stealth) checks.\r\n* When you are wearing medium armor, the maximum Dexterity modifier you can add to your Armor Class increases to 3.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Medium Armor Expert",
     "prerequisite": "Proficiency with medium armor",
@@ -331,7 +331,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Strength or Dexterity score increases by 1, to a maximum of 20.\r\n* You gain proficiency with medium armor and shields.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Moderately Outfitted",
     "prerequisite": "Proficiency with light armor",
@@ -342,7 +342,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain an expertise die on checks made to learn legends and lore about a creature you can see.\r\n* You learn the altered strike cantrip.\r\n* You gain proficiency with the Douse maneuver and do not have to spend exertion to activate it.\r\n* You gain the tracking skill specialty in Survival.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Monster Hunter",
     "prerequisite": "Proficiency with Survival, 8th level or higher",
@@ -353,7 +353,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain proficiency with the Lancer Strike maneuver and do not have to spend exertion to activate it.\r\n* When your mount is targeted by an attack, you can instead make yourself the attack’s target.\r\n* When your mount makes a Dexterity saving throw against an effect that deals half damage on a success, it takes no damage on a success and half damage on a failure.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Mounted Warrior",
     "prerequisite": "",
@@ -364,7 +364,7 @@
 },
 {
   "fields": {
-    "desc": "Choose a class: bard, cleric, druid, herald, sorcerer, warlock, or wizard.\r\n\r\n* You learn two cantrips of your choice from the class’s spell list. \r\n* Choose a 1st-level spell to learn from that spell list. Once between long rests, you can cast this spell without expending a spell slot. You can also cast this spell using a spell slot of the appropriate level (or the appropriate number of spell points if you have warlock levels).\r\n\r\nYour spellcasting ability for these spells is Intelligence for wizard, Wisdom for cleric or druid, Charisma for bard, herald, or sorcerer, or your choice of Intelligence, Wisdom, or Charisma for warlock.",
+    "desc": "Choose a class: bard, cleric, druid, herald, sorcerer, warlock, or wizard.",
     "document": "a5e-ag",
     "name": "Mystical Talent",
     "prerequisite": "",
@@ -375,7 +375,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Speed increases by 5 feet.\r\n* When making an Acrobatics or Athletics check during combat, you can choose to use your Strength or Dexterity modifier for either skill.\r\n* You gain proficiency with the Bounding Strike maneuver and do not have to spend exertion to activate it.\r\n* You can roll 1d4 in place of your normal damage for unarmed strikes. When rolling damage for your unarmed strikes, you can choose to deal bludgeoning, piercing, or slashing damage.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Natural Warrior",
     "prerequisite": "",
@@ -386,7 +386,7 @@
 },
 {
   "fields": {
-    "desc": "* When you use a healer’s satchel to stabilize a dying creature, it regains a number of hit points equal to your Wisdom modifier.\r\n* You can spend an action and one use of a healer’s satchel to tend to a creature. The creature regains 1d6 + 4 hit points, plus one hit point for each of its hit dice. The creature can’t regain hit points from this feat again until it finishes a rest.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Physician",
     "prerequisite": "",
@@ -397,7 +397,7 @@
 },
 {
   "fields": {
-    "desc": "* When you attack with a glaive, halberd, quarterstaff, or spear and no other weapon using the Attack action, as a bonus action you can make a melee attack with the weapon’s opposite end. This attack uses the same ability modifier as the primary attack, dealing 1d4 bludgeoning damage on a hit.\r\n* While you are wielding a glaive, halberd, pike, quarterstaff, or spear, a creature that enters your reach provokes an opportunity attack from you. A creature can use its reaction to avoid provoking an opportunity attack from you in this way.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Polearm Savant",
     "prerequisite": "",
@@ -408,7 +408,7 @@
 },
 {
   "fields": {
-    "desc": "* The range is doubled for any spell you cast that requires a spell attack roll.\r\n* You ignore half cover and three-quarters cover when making a ranged spell attack.\r\n* Choose one cantrip that requires an attack roll. The cantrip must be from the bard, cleric, druid, herald, sorcerer, warlock, or wizard spell list. You learn this cantrip and your spellcasting ability for it depends on the spell list you chose from: Intelligence for wizard, Wisdom for cleric or druid, Charisma for bard, herald, or sorcerer, or your choice of Intelligence, Wisdom, or Charisma for warlock.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Power Caster",
     "prerequisite": "The ability to cast at least one spell",
@@ -419,7 +419,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain proficiency with the Cleaving Swing maneuver and do not have to spend exertion to activate it. In addition, you can use Cleaving Swing with a versatile weapon wielded with two hands.\r\n* Before you make a melee attack with a two-handed weapon or versatile weapon wielded with two hands, if you are proficient with the weapon and do not have disadvantage you can declare a powerful attack. A powerful attack has disadvantage, but on a hit deals 10 extra damage.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Powerful Attacker",
     "prerequisite": "",
@@ -430,7 +430,7 @@
 },
 {
   "fields": {
-    "desc": "Upon gaining this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.\r\n* When you cast a spell that deals damage, your spell’s damage ignores damage resistance to the chosen type.\r\n* When you cast a spell that deals damage of the chosen type, you deal 1 additional damage for every damage die with a result of 1.\r\nThis feat can be selected multiple times, choosing a different damage type each time.",
+    "desc": "Upon gaining this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.",
     "document": "a5e-ag",
     "name": "Primordial Caster",
     "prerequisite": "The ability to cast at least one spell",
@@ -441,7 +441,7 @@
 },
 {
   "fields": {
-    "desc": "When you spend 10 minutes speaking inspirationally, you can choose up to 6 friendly creatures (including yourself) within 30 feet that can hear and understand you. Each creature gains temporary hit points equal to your level + your Charisma modifier. A creature can’t gain temporary hit points from this feat again until it has finished a rest.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Rallying Speaker",
     "prerequisite": "Charisma 13 or higher",
@@ -452,7 +452,7 @@
 },
 {
   "fields": {
-    "desc": "You’re able to form a greater bond with magic items. During a short rest, you can focus on a non-consumable magic item and create a unique bond with it called resonance. You can have resonance with only one item at a time. Attempting to resonate with another item fails until you end the resonance with your current item. When you resonate with an item, you gain the following benefits.\r\n\r\n* If the resonant item requires attunement and you meet the prerequisites to do so, you become attuned to the item. If you don’t meet the prerequisites, both the attunement and resonance with the item fails. This attunement doesn’t count toward the maximum number of items you can be attuned to. Unlike other attuned items, your attunement to this item doesn’t end from being more than 100 feet away from it for 24 hours.\r\n* Once per rest, as a bonus action, you can summon a resonant item, which appears instantly in your hand so long as it is located on the same plane of existence. You must have a free hand to use this feature and be able to hold the item. \r\n* If the resonant item is sentient, you have advantage on Charisma checks and saving throws made when resolving a conflict with the item.\r\n* If the resonant item is an artifact, you can ignore the effects of one minor detrimental property.\r\n\r\nYou lose resonance with an item if another creature attunes to it or gains resonance with it. You can also voluntarily end the resonance by focusing on the item during a short rest, or during a long rest if the item is not in your possession.",
+    "desc": "You’re able to form a greater bond with magic items. During a short rest, you can focus on a non-consumable magic item and create a unique bond with it called resonance. You can have resonance with only one item at a time. Attempting to resonate with another item fails until you end the resonance with your current item. When you resonate with an item, you gain the following benefits.",
     "document": "a5e-ag",
     "name": "Resonant Bond",
     "prerequisite": "",
@@ -463,7 +463,7 @@
 },
 {
   "fields": {
-    "desc": "You gain a ritual book containing spells that you can cast as rituals while holding it.\r\nChoose one of the following classes: bard, cleric, druid, herald, sorcerer, warlock, or wizard. When you acquire this feat, you create a ritual book holding two 1st-level spells of your choice from that class’ spell list. These spells must have the ritual tag. The class you choose determines your spellcasting ability for these spells: Intelligence for wizard, Wisdom for cleric or druid, Charisma for bard, herald, or sorcerer, or your choice of Intelligence, Wisdom, or Charisma for warlock.\r\nIf you come across a written spell with the ritual tag (like on a spell scroll or in a wizard’s spellbook), you can add it to your ritual book if the spell is on the spell list for the class you chose and its level is no higher than half your level (rounded up). Copying the spell into your ritual book costs 50 gold and 2 hours per level of the spell.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Rite Master",
     "prerequisite": "Intelligence or Wisdom 13 or higher",
@@ -474,7 +474,7 @@
 },
 {
   "fields": {
-    "desc": "You gain the following benefits while wielding a shield:\r\n* When you take the Attack action on your turn, as a bonus action you can make a Shove maneuver against a creature within 5 feet of you.\r\n* When you make a Dexterity saving throw against a spell or harmful effect that only targets you, if you aren’t incapacitated you gain a bonus equal to your shield’s Armor Class bonus.\r\n* When you succeed on a Dexterity saving throw against an effect that deals half damage on a success, you can use your reaction to take no damage by protecting yourself with your shield.",
+    "desc": "You gain the following benefits while wielding a shield:",
     "document": "a5e-ag",
     "name": "Shield Focus",
     "prerequisite": "",
@@ -485,7 +485,7 @@
 },
 {
   "fields": {
-    "desc": "Choose three skills, tools, languages, or any combination of these. You gain proficiency with each of your three choices. If you already have proficiency in a chosen skill, you instead gain a skill specialty with that skill.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Skillful",
     "prerequisite": "",
@@ -496,7 +496,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Speed increases by 10 feet.\r\n* You can Dash through difficult terrain without requiring additional movement.\r\n* Whenever you attack a creature, for the rest of your turn you don’t provoke opportunity attacks from that creature.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Skirmisher",
     "prerequisite": "",
@@ -507,7 +507,7 @@
 },
 {
   "fields": {
-    "desc": "*You gain proficiency with the Purge Magic maneuver and do not have to spend exertion to activate it.\r\n* When a creature concentrating on a spell is damaged by you, it has disadvantage on its concentration check to maintain the spell it is concentrating on.\r\n* You have advantage on saving throws made against spells cast within 30 feet of you.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Spellbreaker",
     "prerequisite": "",
@@ -518,7 +518,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Constitution score increases by 1, to a maximum of 20.\r\n* You regain an additional number of hit points equal to double your Constitution modifier (minimum 2) whenever you roll a hit die to regain hit points.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Stalwart",
     "prerequisite": "",
@@ -529,7 +529,7 @@
 },
 {
   "fields": {
-    "desc": "* You can try to hide from a creature even while you are only lightly obscured from that creature.\r\n* Your position isn’t revealed when you miss with a ranged weapon attack against a creature you are hidden from.\r\n* Dim light does not impose disadvantage when you make Perception checks.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Stealth Expert",
     "prerequisite": "Dexterity 13 or higher",
@@ -540,7 +540,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Strength or Constitution score increases by 1, to a maximum of 20.\r\n* You can roll 1d4 in place of your normal damage for unarmed strikes.\r\n* You are proficient with improvised weapons.\r\n* You can use a bonus action to make a Grapple maneuver against a target you hit with an unarmed strike or improvised weapon on your turn.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Street Fighter",
     "prerequisite": "",
@@ -551,7 +551,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain proficiency with the Dangerous Strikes maneuver and do not have to spend exertion to activate it.\r\n* You gain proficiency in Medicine. If you are already proficient, you instead gain an expertise die.\r\n* You gain an expertise die on Medicine checks made to diagnose the cause of or treat wounds.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Surgical Combatant",
     "prerequisite": "",
@@ -562,7 +562,7 @@
 },
 {
   "fields": {
-    "desc": "* When you are reduced to 0 or fewer hit points, you can use your reaction to move up to your Speed before falling unconscious. Moving in this way doesn’t provoke opportunity attacks.\r\n* On the first turn that you start with 0 hit points and must make a death saving throw, you make that saving throw with advantage.\r\n* When you take massive damage that would kill you instantly, you can use your reaction to make a death saving throw. If the saving throw succeeds, you instead fall unconscious and are dying. \r\n* Medicine checks made to stabilize you have advantage. \r\n* Once between long rests, when a creature successfully stabilizes you, at the start of your next turn you regain 1 hit point.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Survivor",
     "prerequisite": "",
@@ -573,7 +573,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Speed increases by 5 feet. \r\n* You gain proficiency with the Charge, Rapid Drink, and Swift Stance maneuvers, and do not have to spend exertion to activate them.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Swift Combatant",
     "prerequisite": "8th level or higher",
@@ -584,7 +584,7 @@
 },
 {
   "fields": {
-    "desc": "* When using the Help action to aid an ally in attacking a creature, the targeted creature can be up to 30 feet away instead of 5 feet.\r\n* If an ally benefiting from your Help action scores a critical hit on the targeted creature, you can use your reaction to make a single weapon attack against that creature. Your attack scores a critical hit on a roll of 19–20. If you already have a feature that increases the range of your critical hits, your critical hit range for that attack is increased by 1 (maximum 17–20). \r\n* When a creature is damaged by an attack that was aided by the use of your Help action, you don’t provoke opportunity attacks from that creature until the end of your next turn.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Tactical Support",
     "prerequisite": "",
@@ -595,7 +595,7 @@
 },
 {
   "fields": {
-    "desc": "Choose one ability score. The chosen ability score increases by 1, to a maximum of 20, and you gain proficiency in saving throws using it.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Tenacious",
     "prerequisite": "",
@@ -606,7 +606,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Charisma score increases by 1, to a maximum of 20. \r\n* You have advantage on Deception and Performance checks made when attempting to mimic another creature’s looks, mannerisms, or speech.\r\n* You have a natural talent for perfectly mimicking the sounds of other creatures you’ve heard make sound for at least 1 minute. A suspicious listener can see through your perfect mimicry by succeeding on a Wisdom (Insight) check opposed by your Charisma (Deception) check.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Thespian",
     "prerequisite": "",
@@ -617,7 +617,7 @@
 },
 {
   "fields": {
-    "desc": "* Your Strength or Dexterity score increases by 1, to a maximum of 20.\r\n* You gain proficiency with four weapons of your choice. Three of these must be a simple or a martial weapon. The fourth choice can be a simple, martial, or rare weapon.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Weapons Specialist",
     "prerequisite": "",
@@ -628,7 +628,7 @@
 },
 {
   "fields": {
-    "desc": "* You are treated as royalty (or as closely as possible) by most commoners and traders, and as an equal when meeting other authority figures (who make time in their schedule to see you when requested to do so).\r\n* You have passive investments and income that allow you to maintain a high quality of living. You have a rich lifestyle and do not need to pay for it.\r\n* You gain a second Prestige Center. This must be an area where you have spent at least a week of time.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Well-Heeled",
     "prerequisite": "Prestige rating of 2 or higher",
@@ -639,7 +639,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain proficiency with the herbalism kit, navigator’s kit, a simple ranged weapon, or a martial ranged weapon.\r\n* You gain two exploration knacks of your choice from the ranger class.",
+    "desc": "",
     "document": "a5e-ag",
     "name": "Woodcraft Training",
     "prerequisite": "",

--- a/data/v2/en-publishing/a5e-ag/FeatBenefit.json
+++ b/data/v2/en-publishing/a5e-ag/FeatBenefit.json
@@ -521,7 +521,7 @@
 },
 {
   "fields": {
-    "desc": "Upon gaining this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.\r\n\r\nWhen you cast a spell that deals damage, your spell’s damage ignores damage resistance to the chosen type.",
+    "desc": "When you cast a spell that deals damage, your spell’s damage ignores damage resistance to the chosen type.",
     "name": "",
     "parent": "a5e-ag_primordial-caster",
     "type": null

--- a/data/v2/wizards-of-the-coast/srd-2014/Feat.json
+++ b/data/v2/wizards-of-the-coast/srd-2014/Feat.json
@@ -1,7 +1,7 @@
 [
 {
   "fields": {
-    "desc": "You've developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:\r\n* You have advantage on attack rolls against a creature you are grappling.\r\n* You can use your action to try to pin a creature grappled by you. The creature makes a Strength or Dexterity saving throw against your maneuver DC. On a failure, you and the creature are both restrained until the grapple ends.",
+    "desc": "You've developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:",
     "document": "srd-2014",
     "name": "Grappler",
     "prerequisite": "Strength 13 or higher",


### PR DESCRIPTION
## Description

This PR resolves some errors in the V2 Feat data where copy was duplicated across the `"desc"` and `"benefits"` sections. Where copy better fits one catagory it was removed from the other.

## Related Issues

Closes #809 

## How was this tested?

- `pytest` (all tests passing)
- Spot checked on local Django dev server
