### PR TITLE
[V2 DATA] Added A5e Marshal class

### DIFF
--- a/data/v2/en-publishing/a5e-ag/CharacterClass.json
+++ b/data/v2/en-publishing/a5e-ag/CharacterClass.json
@@ -14,5 +14,18 @@
   },
   "model": "api_v2.characterclass",
   "pk": "a5e_marshal"
+},
+{
+  "fields": {
+    "caster_type": "NONE",
+    "document": "a5e-ag",
+    "hit_dice": null,
+    "name": "Gambling General",
+    "primary_abilities": [],
+    "saving_throws": [],
+    "subclass_of": "a5e_marshal"
+  },
+  "model": "api_v2.characterclass",
+  "pk": "a5e_gambling-general"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/CharacterClass.json
+++ b/data/v2/en-publishing/a5e-ag/CharacterClass.json
@@ -40,5 +40,18 @@
   },
   "model": "api_v2.characterclass",
   "pk": "a5e_swift-strategist"
+},
+{
+  "fields": {
+    "caster_type": "NONE",
+    "document": "a5e-ag",
+    "hit_dice": null,
+    "name": "Talented Tactician",
+    "primary_abilities": [],
+    "saving_throws": [],
+    "subclass_of": "a5e_marshal"
+  },
+  "model": "api_v2.characterclass",
+  "pk": "a5e_talented-tactician"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/CharacterClass.json
+++ b/data/v2/en-publishing/a5e-ag/CharacterClass.json
@@ -27,5 +27,18 @@
   },
   "model": "api_v2.characterclass",
   "pk": "a5e_gambling-general"
+},
+{
+  "fields": {
+    "caster_type": "NONE",
+    "document": "a5e-ag",
+    "hit_dice": null,
+    "name": "Swift Strategist",
+    "primary_abilities": [],
+    "saving_throws": [],
+    "subclass_of": "a5e_marshal"
+  },
+  "model": "api_v2.characterclass",
+  "pk": "a5e_swift-strategist"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/CharacterClass.json
+++ b/data/v2/en-publishing/a5e-ag/CharacterClass.json
@@ -1,0 +1,18 @@
+[
+{
+  "fields": {
+    "caster_type": "NONE",
+    "document": "a5e-ag",
+    "hit_dice": "D10",
+    "name": "Marshal",
+    "primary_abilities": [],
+    "saving_throws": [
+      "wis",
+      "con"
+    ],
+    "subclass_of": null
+  },
+  "model": "api_v2.characterclass",
+  "pk": "a5e_marshal"
+}
+]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -1,0 +1,78 @@
+[
+{
+  "fields": {
+    "desc": "",
+    "document": "a5e-ag",
+    "feature_type": "PROFICIENCY_BONUS",
+    "name": "Proficiency Bonus",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_proficiency-bonus"
+},
+{
+  "fields": {
+    "desc": "",
+    "document": "a5e-ag",
+    "feature_type": "CLASS_TABLE_DATA",
+    "name": "Commanding Presence",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_commanding-presence-range"
+},
+{
+  "fields": {
+    "desc": "",
+    "document": "a5e-ag",
+    "feature_type": "CLASS_TABLE_DATA",
+    "name": "Followers",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_follower-count"
+},
+{
+  "fields": {
+    "desc": "",
+    "document": "a5e-ag",
+    "feature_type": "CLASS_TABLE_DATA",
+    "name": "Maneuvers Known",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_maneuvers-known"
+},
+{
+  "fields": {
+    "desc": "",
+    "document": "a5e-ag",
+    "feature_type": "CLASS_TABLE_DATA",
+    "name": "Maneuver Degree",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_maneuver-degree"
+},
+{
+  "fields": {
+    "desc": "",
+    "document": "a5e-ag",
+    "feature_type": "CLASS_TABLE_DATA",
+    "name": "Lessons Known",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_lessons-known"
+},
+{
+  "fields": {
+    "desc": "At 4th, 8th, 12th, 16th, and 19th level, you can increase one ability score by 2 or two ability scores by 1, to a maximum of 20.",
+    "document": "a5e-ag",
+    "name": "Ability Score Improvement",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_ability-score-improvement"
+}
+]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -96,5 +96,95 @@
   },
   "model": "api_v2.classfeature",
   "pk": "a5e_marshal_starting-equipment"
+},
+{
+  "fields": {
+    "desc": "Starting at 1st level, you have a Commanding Presence that extends from you in a 10-foot radius.\n\nWhen you take the Attack action, you can forgo making one attack to allow a creature within range of your Commanding Presence to make an attack instead. If the target can hear or see you, it can use its reaction to either cast a cantrip or make one weapon attack.\n\nThe radius of your Commanding Presence increases to 20 feet at 5th level, 30 feet at 10th level, 45 feet at 15th level, and 60 feet at 20th level.",
+    "document": "a5e-ag",
+    "name": "Commanding Presence",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_commanding-presence"
+},
+{
+  "fields": {
+    "desc": "Also starting at 1st level, you can use a bonus action to choose a creature within 30 feet of you. If the target can hear or see you, it regains hit points equal to 1d8 + your marshal level. Once you use this feature, you must finish a long rest before you can use it again\n\nYou can target two creatures simultaneously with this feature at 3rd level, and starting at 7th level you regain use of this feature after finishing a short or long rest",
+    "document": "a5e-ag",
+    "name": "Rallying Surge",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_rallying-surge"
+},
+{
+  "fields": {
+    "desc": "At 2nd level, you gain the ability to use combat maneuvers. You gain proficiency in two combat traditions from the following list: Biting Zephyr, Mirror's Glint, Mist and Shade, Rapid Current, Razor's Edge, Sanguine Knot, Spirited Steed, Unending Wheel. You learn two maneuvers of your choice from traditions you are proficient with.\n\nYou gain an exertion pool equal to twice your proficiency bonus, and you regain any spent exertion when you finish a rest. You use your maneuvers by spending points from your exertion pool. The Maneuvers Known column of the Marshal table shows when you learn more maneuvers from a tradition you are proficient with, while the Maneuver Degree column shows the highest-degree maneuver you can select at a given level.\n\nAdditionally, whenever you learn a new maneuver, you can choose one of the maneuvers you know and replace it with another maneuver of the same degree from a tradition you are proficient with.",
+    "document": "a5e-ag",
+    "name": "Combat Maneuvers",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_combat-maneuvers"
+},
+{
+  "fields": {
+    "desc": "Also at 2nd level, you learn a lesson of war of your choice. Your lessons are detailed at the end of the class description. The Lessons Known column of the Marshal table shows when you learn more lessons of war.",
+    "document": "a5e-ag",
+    "name": "Lessons of War",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_lessons-of-war"
+},
+{
+  "fields": {
+    "desc": "At 3rd level, you choose an archetype that focuses on the military stratagems you devise. Your choice grants you features at 3rd level and again at 7th, 11th, 15th, and 18th level.",
+    "document": "a5e-ag",
+    "name": "Marshal Archetype",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_marshal-archetype"
+},
+{
+  "fields": {
+    "desc": "Also at 3rd level, you can use a bonus action to choose a creature you can see within 30 feet. Until the start of your next turn, creatures able to hear or see you gain an expertise die on attacks made against that creature.",
+    "document": "a5e-ag",
+    "name": "Mark Foe",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_mark-foe"
+},
+{
+  "fields": {
+    "desc": "Starting at 5th level, you learn one combat maneuver from the Sanguine Knot tradition. The degree of this maneuver can't be higher than the highest-degree maneuver you can learn. This combat maneuver does not count against the number of combat maneuvers that you know.\n\nIn addition, when a creature makes an attack granted by your Commanding Presence, it can simultaneously use one Sanguine Knot combat maneuver that you know. If the creature does not have any exertion points to spend on combat maneuvers, it does not require exertion points for that use but it can't benefit from Combat Directives again until it finishes a rest.",
+    "document": "a5e-ag",
+    "name": "Combat Directives",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_combat-directives"
+},
+{
+  "fields": {
+    "desc": "Starting at 5th level, when you take the Attack action on your turn, you can attack twice instead of once. At 11th level, you can attack three times instead of once.",
+    "document": "a5e-ag",
+    "name": "Extra Attack",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_extra-attack"
+},
+{
+  "fields": {
+    "desc": "At 5th level, you gain one inexperienced follower. At 10th, 15th, and 20th level, you gain an additional follower, or one of your followers becomes more experienced. If one of your followers dies, after 1 month you receive word that their replacement is ready to join you.",
+    "document": "a5e-ag",
+    "name": "Followers",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_followers"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -397,5 +397,65 @@
   },
   "model": "api_v2.classfeature",
   "pk": "a5e_gambling-general_canny-adversary"
+},
+{
+  "fields": {
+    "desc": "At 3rd level when you select this archetype, choose one of the following.\n\n## Fast Feet\nWhenever a creature starts its turn within your Commanding Presence, you can choose to increase that creature's Speed by 5 feet until the end of its turn.\n\n## Fast Retreat\nOnce per round when you take the Attack action, you can forgo making one attack to allow a creature within your Commanding Presence to move up to half its Speed without provoking opportunity attacks.",
+    "document": "a5e-ag",
+    "name": "Make Haste",
+    "parent": "a5e_swift-strategist"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_swift-strategist_make-haste"
+},
+{
+  "fields": {
+    "desc": "Also at 3rd level, you increase your speed by 10 feet whenever you're wearing light or no armor and not wielding a shield. In addition, when your movement would provoke an opportunity attack, you impose disadvantage on the attack roll made against you.\n\nAt 15th level, the increase to your speed becomes 20 feet.",
+    "document": "a5e-ag",
+    "name": "Skirmisher",
+    "parent": "a5e_swift-strategist"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_swift-strategist_skirmisher"
+},
+{
+  "fields": {
+    "desc": "At 7th level, choose either Acrobatics or Athletics. Creatures you choose within your Commanding Presence add your Charisma modifier (minimum +1) to checks using the chosen skill.",
+    "document": "a5e-ag",
+    "name": "Nimble Troops",
+    "parent": "a5e_swift-strategist"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_swift-strategist_nimble-troops"
+},
+{
+  "fields": {
+    "desc": "At 11th level, choose one of the following:\n\n## Miraculous Protector\nWhen a creature within your Commanding Presence is critically hit, you can use your reaction to become the target of the attack instead. Once you have used this feature, you cannot do so again until you finish a rest.\n\n## Take Cover\nWhen you and at least one other creature within your Commanding Presence would make a saving throw, you can choose to make your saving throw with disadvantage. If you do, creatures you choose within your Commanding Presence make that saving throw with advantage.",
+    "document": "a5e-ag",
+    "name": "Glorious Sacrifice",
+    "parent": "a5e_swift-strategist"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_swift-strategist_glorious-sacrifice"
+},
+{
+  "fields": {
+    "desc": "At 15th level, choose one of the following:\n\n## Fortifying Encouragement\nWhenever you succeed on a saving throw, you can choose one friendly creature within 60 feet of you. If the target can see or hear you, it the target gains temporary hit points equal to 5 + your Charisma modifier.\n\n## Get Them Out\nWhen a creature within your Commanding Presence would make a saving throw against an area effect, you can use your reaction to shout at them, and that creature can use its reaction to move up to half its Speed. If the creature ends its movement outside the area, the area effect has no effect on them. Once you use this feature, you can't do so again until you finish a long rest.",
+    "document": "a5e-ag",
+    "name": "Portentous Escape",
+    "parent": "a5e_swift-strategist"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_swift-strategist_portentous-escape"
+},
+{
+  "fields": {
+    "desc": "At 18th level, choose one of the following.\n\n## Among the Ranks\nCreatures you choose have disadvantage on opportunity attacks made against creatures within your Commanding Presence\n\n## March Together\nThe first time you move on your turn, each creature you choose that is within your Commanding Presence can use its reaction to move up to 10 feet, provided the creature's Speed is at least 10 feet.",
+    "document": "a5e-ag",
+    "name": "Unbound Horde",
+    "parent": "a5e_swift-strategist"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_swift-strategist_unbound-horde"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -347,5 +347,55 @@
   },
   "model": "api_v2.classfeature",
   "pk": "a5e_marshal_lessons-of-war-list"
+},
+{
+  "fields": {
+    "desc": "At 3rd level when you select this archetype, choose one of the following:\n\n## Daring Assault\nWhile you are conscious, any ally within your Commanding Presence that makes an attack roll can choose to roll with a -5 penalty. If the attack hits, the attack deals an extra 2d6 damage. At 15th level, the amount of extra damage increases to 3d6.\n\n## Daring Charge\nWhile you are conscious, an ally that starts its turn within your Commanding Presence can use an action to move up to twice its Speed in a straight line and take the Attack action. Until the end of that ally's next turn, creatures they did not attack on their turn have advantage on attack rolls against them",
+    "document": "a5e-ag",
+    "name": "Daring Commander",
+    "parent": "a5e_gambling-general"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_gambling-general_daring-commander"
+},
+{
+  "fields": {
+    "desc": "At 7th level, choose one of the following.\n\n## Desperate Avoidance\nWhen you make a saving throw, you can choose to make the saving throw with advantage. If you do, you make attack rolls with disadvantage until the end of your next turn. Once you use this feature, you can't do so again until you finish a rest.\n\n## Frantic Avoidance\nWhen you would make a saving throw against an area effect, you can use your reaction to move up to half your Speed. If you end your movement outside the area, it has no effect on you. Once you use this feature, you can't do so again until you finish a long rest.",
+    "document": "a5e-ag",
+    "name": "Defensive Measures",
+    "parent": "a5e_gambling-general"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_gambling-general_defensive-measures"
+},
+{
+  "fields": {
+    "desc": "At 11th level, choose one of the following.\n\n## Stand Firm\nWhile you are conscious, when an ally within your Commanding Presence would make a saving throw against an effect that deals half damage on a success, that ally can choose to make the saving throw with disadvantage. If they do and the saving throw succeeds, the ally takes no damage instead.\n\n## Stand Strong\nWhile you are conscious, when an ally within your Commanding Presence is hit by a melee weapon attack, they can use their reaction to make a melee weapon attack against the creature that attacked them.",
+    "document": "a5e-ag",
+    "name": "Hold the Line",
+    "parent": "a5e_gambling-general"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_gambling-general_hold-the-line"
+},
+{
+  "fields": {
+    "desc": "At 15th level, choose one of the following.\n\n## Risky Gambit\nYou can use a bonus action to choose one willing creature within your Commanding Presence. The target immediately provokes an opportunity attack from one creature that can reach it. If the creature makes the opportunity attack,attack rolls against that creature are made with advantage until the start of your next turn.\n\n## Risky Foray\nWhen a creature starts its turn within your Commanding Presence, you can use your reaction to spur them into violent action. Until the start of its next turn, your ally gains an expertise die on melee weapon attacks, and creatures gain an expertise die on melee weapon attack rolls against it.",
+    "document": "a5e-ag",
+    "name": "Risky Tactics",
+    "parent": "a5e_gambling-general"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_gambling-general_risky-tactics"
+},
+{
+  "fields": {
+    "desc": "At 18th level, choose one of the following.\n\n## Feinting Retreat\nWhen you take the Disengage action, until the start of your next turn, whenever a creature you choose ends its movement within your Commanding Presence, it provokes an opportunity attack.\n\n## Lay the Trap\nWhile you are conscious, whenever a creature makes an attack roll against you and misses, you and one creature you choose have advantage on the next attack roll they make against the triggering creature before the end of your next turn.",
+    "document": "a5e-ag",
+    "name": "Canny Adversary",
+    "parent": "a5e_gambling-general"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_gambling-general_canny-adversary"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -457,5 +457,55 @@
   },
   "model": "api_v2.classfeature",
   "pk": "a5e_swift-strategist_unbound-horde"
+},
+{
+  "fields": {
+    "desc": "Starting at 3rd level when you choose this archetype, whenever you roll initiative, you gain a tactics die, which is a d4. While you have this die, when a creature within 60 feet that can hear or see you would make an attack, you can roll the tactics die and add the result to that creature's attack roll. Once rolled, the tactics die is lost until you regain it at the start of your next turn. The tactics die disappears when the combat ends.\n\nIf you start your turn and no one has rolled the tactics die, you can trade out the die for a die of the next larger size, such that a d4 becomes a d6, a d6 becomes a d8, and so on, up to a maximum of d12.",
+    "document": "a5e-ag",
+    "name": "Tactical Edge",
+    "parent": "a5e_talented-tactician"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_talented-tactician_tactical-edge"
+},
+{
+  "fields": {
+    "desc": "At 7th level, choose either Culture, History, or Nature. You gain proficiency in the chosen skill and an expertise die on checks made using that skill.",
+    "document": "a5e-ag",
+    "name": "Student of War",
+    "parent": "a5e_talented-tactician"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_talented-tactician_student-of-war"
+},
+{
+  "fields": {
+    "desc": "Starting at 11th level, you devise a set of communication cues. Any creature with whom you've shared these cues—usually taking 10 minutes of discussion and practice—does not need to share a language with you to benefit from this feature.\n\nAdditionally, you can use a bonus action on your turn to spend 5 exertion points and make it easier for you and your allies to help each other with certain skills. For the next 10 minutes, your chosen allies can take theHelp action as a bonus action to help each other. This coordination requires you to maintain concentration (as if concentrating on a spell), and both chosen creatures—the one helping and the one making the ability check—must be within 30 feet of you at the time the ability check is made.\n\nEach turn, you can use your bonus action to change which creatures benefit from the coordination each turn. The skills that can benefit from this feature are Acrobatics, Animal Handling, Athletics, Deception, Insight, Intimidation, Investigation, Stealth, and Survival.\n\nIf you have proficiency in Stealth, this coordination can happen silently via surreptitious signals. If you have proficiency in Deception, this coordination can happen as a series of code words interspersed with other conversation. An onlooker needs to succeed on an Insight check contested by your ability check—whether Stealth or Deception—to realize the coordination is taking place.",
+    "document": "a5e-ag",
+    "name": "Operations Leader",
+    "parent": "a5e_talented-tactician"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_talented-tactician_operations-leader"
+},
+{
+  "fields": {
+    "desc": "At 15th level, choose one of the following.\n\n## More Tactical\n\nWhenever you gain a tactics die, you gain an additional tactics die, to a maximum of two dice. The second tactics die can be used like the first and increases size in the manner described under the Tactical Edge class feature.\n\n## Tactical Efficacy\nYour tactics die begins at d6. When you reach 20th level, your tactics die begins at d8. After the tactics die is rolled, when regained it reverts to a d4.",
+    "document": "a5e-ag",
+    "name": "Superior Tactics",
+    "parent": "a5e_talented-tactician"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_talented-tactician_superior-tactics"
+},
+{
+  "fields": {
+    "desc": "At 18th level, choose one of the following.\n\n## Dig Deeper\nYou can use a bonus action on your turn to allow a creature to regain the use of an origin trait or class feature that would normally be regained by finishing a short rest. You can use this feature twice, and you regain all expended uses when you finish a long rest.\n\n## Reach Further\nWhile you are conscious, when a creature you choose within the radius of your Commanding Presence would drop to 0 hit points, that creature can use its reaction to roll your tactics die and gain temporary hit points equal to the result plus your Charisma modifier (minimum 1). Once a creature has benefited from your tactics die in this way, it can't do so again until it finishes a long rest.",
+    "document": "a5e-ag",
+    "name": "Hidden Resources",
+    "parent": "a5e_talented-tactician"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_talented-tactician_hidden-resources"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -74,5 +74,27 @@
   },
   "model": "api_v2.classfeature",
   "pk": "a5e_marshal_ability-score-improvement"
+},
+{
+  "fields": {
+    "desc": "**Armor:** Light armor, medium armor, heavy armor, shields\n**Weapons:** Simple weapons, martial weapons\n**Tools:** None\n**Saving Throws:** Wisdom, Charisma\n**Skills:** Choose two from Athletics, History, Insight, Intimidation, Medicine, Perception, and Persuasion",
+    "feature_type": "PROFICIENCIES",
+    "document": "a5e-ag",
+    "name": "Proficiencies",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_proficiencies"
+},
+{
+  "fields": {
+    "desc": "You begin the game with 200 gp. You can select your own gear or choose one of the following equipment packages. Also consult the Suggested Equipment section of your chosen background.\n\n- **Skirmisher’s Set (Cost 193 gp):** 6 javelins, longsword, hauberk, light shield, explorer's pack\n- **Soldier's Set (Cost 111 gp):** Battleaxe, scimitar, 2 spears,longbow and quiver with 20 arrows, padded leather, dungeoneer's pack",
+    "feature_type": "STARTING_EQUIPMENT",
+    "document": "a5e-ag",
+    "name": "Equipment",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_starting-equipment"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -336,5 +336,16 @@
   },
   "model": "api_v2.classfeature",
   "pk": "a5e_marshal_supreme-stronghold"
+},
+{
+  "fields": {
+    "desc": "When you gain access to a new lesson of war, choose one of the following.\n\n### Exacting\nYou gain proficiency with navigator's tools, or if you're already proficient, an expertise die on checks made using them. When determining the distance you travel while journeying, you can make a DC 10 navigator's tools check to travel an additional number of miles equal to your proficiency bonus.\n\n### Keep Walking\nOnce between long rests, you can choose a number of allies equal to twice your proficiency bonus who can hear or see you. Each ally can travel an additional hour before needing to make a Constitution saving throw for a forced march.\n\n### Lay of the Land\nBy spending 10 minutes observing the area in a 2-mile radius, you can spend 2 exertion points to pick out where there are choke points, large swaths of cover, watercourses, vegetation that can offer concealment, ridgelines, and so on. You gain an expertise die on Engineering and Survival checks made within the area, as well as on checks made to prepare an ambush or realize you are being ambushed.\n\n### Rewarding Repute\nWhenever you visit a settlement, the commoners there tell you all the valuable information they can about their home, including the history of nearby ruins, the general features of the immediate wilderness, and how populated the region is. You gain an expertise die on Nature and Survival checks made within 10 miles of any settlement you have visited.\n\n### Soldier Kitting\nYou and a number of creatures equal to your proficiency bonus can carry one additional bulky item.\n\n### Team Tactics\nWhen more than one creature takes the Help action to aid an ally making an ability check, for each additional creature helping the check is made with a +1 bonus. Only a number of additional creatures equal to half your proficiency bonus are able to Help in this way.\n\n### Teamwork\nWhen you are involved in a group check, all members of the check gain an expertise die. Once you use this feature, you can't do so again until you finish a long rest.",
+    "document": "a5e-ag",
+    "feature_type": "CLASS_FEATURE_OPTION_LIST",
+    "name": "Lessons of War",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_lessons-of-war-list"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -246,5 +246,95 @@
   },
   "model": "api_v2.classfeature",
   "pk": "a5e_marshal_rouse-the-troops"
+},
+{
+  "fields": {
+    "desc": "Starting at 12th level, the lessons you've learned on the battlefield become useful tools beyond the realm of combat. Choose one of the following:\n\n## Calm\nWhen you first meet an NPC, you can choose to remain silent and communicate through nonverbal cues. So long as the NPC has a CR lower than your level, you remain silent for 1 minute, and the NPC stays within sight of you for the duration, they act as if you succeeded on an Intimidation check.\n\nIn addition, you gain an expertise die on Insight checks.\n\n## Resolute\nWhenever you make an Intelligence, Wisdom, or Charisma check against a creature and fail, you gain an expertise die on your next Intelligence, Wisdom, or Charisma check made against that creature.\n\n## Responsive\nWhen you overhear an interesting conversation between NPCs, you can interject so seamlessly and casually that the speakers think they already know you, answering one question you ask before realizing that they don't. In addition, you gain an expertise die on Persuasion checks.",
+    "document": "a5e-ag",
+    "name": "Commanding Demeanor",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_commanding-demeanor"
+},
+{
+  "fields": {
+    "desc": "Starting at 13th level, you and creatures you choose have advantage on saving throws against the charmed or frightened conditions while within your Commanding Presence.",
+    "document": "a5e-ag",
+    "name": "Dauntless",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_dauntless"
+},
+{
+  "fields": {
+    "desc": "Also at 13th level, you gain an average, grade 4 stronghold (castle, house, or training hall). Unlike normal strongholds, you can't sell this stronghold",
+    "document": "a5e-ag",
+    "name": "Stronghold",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_stronghold"
+},
+{
+  "fields": {
+    "desc": "Starting at 14th level, you can use the Help action as a bonus action. In addition, when you take the Help action, choose one of the following effects:\n\n- One frightened creature within 30 feet that can hear or see you is no longer frightened.\n- One creature within 5 feet gains temporary hit points equal to your Charisma modifier (minimum 1).\n- You touch a living creature that has 0 hit points. The creature regains 1 hit point.",
+    "document": "a5e-ag",
+    "name": "Advantageous Action",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_advantageous-action"
+},
+{
+  "fields": {
+    "desc": "At 16th level, your stronghold is upgraded to grade 5.",
+    "document": "a5e-ag",
+    "name": "Greater Stronghold",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_greater-stronghold"
+},
+{
+  "fields": {
+    "desc": "Beginning at 17th level, you can focus your mind to identify any enemy's weaknesses. Once per rest, you can use a bonus action to choose one creature you can see within 60 feet and expose a flaw in its defenses. Until the end of your next turn, any creature that can hear or see you has advantage on attack rolls made against that creature, and their attacks and spells deal an extra 6 damage to it.",
+    "document": "a5e-ag",
+    "name": "Critical Weakness",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_critical-weakness"
+},
+{
+  "fields": {
+    "desc": "Starting at 18th level, you choose one of the following:\n\n## Hero\nNobles and royalty treat you as an equal, granting you free food, lodging, and a place in their court for a number of days up to your marshal level.\n\n## Iconoclast\nWhenever you arrive in a settlement, you are visited by 1d4+1 bards, scholars, and sages who ask you to recount your recent exploits. In exchange, they each either share a piece of information they think might be relevant to your current quest or make an Intelligence, Wisdom, or Charisma check (with a +5 bonus) to answer a specific question on your behalf.\n\n## Slaughterer\nBandit and pirate captains, crimelords, intelligent monsters of ill intent, and even fiends know who you are and that you are a valuable ally, doing their best to persuade you to take up the sword against their enemies. Whenever you encounter such a creature, it spends its first action (even in combat) declaring that it knows of your prowess and offering an alliance.",
+    "document": "a5e-ag",
+    "name": "Impressive Reputation",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_impresive-reputation"
+},
+{
+  "fields": {
+    "desc": "At 20th level, creatures within your Commanding Presence add your Charisma modifier (minimum 1) to saving throws. Additionally, choose one of the following:\n\n## Commander's Expertise\nWhenever a creature uses your Commanding Presence to make an attack or use a combat maneuver, it gains an expertise die. If the combat maneuver has a save DC, it increases by an amount equal to the result of the expertise die. This expertise die can be increased to a maximum of a d12.\n\n## Feedback Loop\nWhenever a creature uses your Commanding Presence and successfully hits a target, you gain a reaction. You must use this reaction before the start of your next turn or it is lost.\n\n## Rapid Deployment\nAfter initiative is rolled and until combat ends, your Speed increases by 20 feet, and creatures you choose that can see or hear you increase their Speed by 20 feet.",
+    "document": "a5e-ag",
+    "name": "Legendary Commander",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_legendary-commander"
+},
+{
+  "fields": {
+    "desc": "Also at 20th level, your stronghold is upgraded to grade 6.",
+    "document": "a5e-ag",
+    "name": "Supreme Stronghold",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_supreme-stronghold"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeature.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeature.json
@@ -186,5 +186,65 @@
   },
   "model": "api_v2.classfeature",
   "pk": "a5e_marshal_followers"
+},
+{
+  "fields": {
+    "desc": "Beginning at 6th level, when you roll initiative, you and each creature you choose within your Commanding Presence gains anexpertise die to their initiative roll.\n\nAdditionally, when you roll for initiative, you can switch your result with that of any ally you can see.",
+    "document": "a5e-ag",
+    "name": "Call to Arms",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_call-to-arms"
+},
+{
+  "fields": {
+    "desc": "At 6th level, you add half your proficiency bonus to your Prestige rating.\n\nIn addition, your reputation strongly affects how you are perceived, and when it becomes known that you are in a settlement, people treat you accordingly. At the Narrator's discretion, there may be settlements (such as an enemy's war camp) where you can't utilize this feature. Choose one of the following:\n\n## Famous\nWhen you arrive in a settlement, after you reveal who you are, local authority figures seek you out to make\n\n## Infamous\nWhen you arrive in a settlement, after you reveal who you are, common folk hurry to get out of your way, and when you corner a commoner to ask about something local, they rapidly tell you whatever details they think you might want to know. In addition, you gain an expertise die on Intimidation checks.\n\n## Maverick\nWhen you arrive in a settlement, after you reveal who you are, the local watch starts keeping an eye on you. Heads of illegal organizations might introduce themselves to you if they have goals well suited to your talents. Additionally, guards expect you're up to no good and are quick to leave their posts to follow you.",
+    "document": "a5e-ag",
+    "name": "Marshal Renown",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_marshal-renown"
+},
+{
+  "fields": {
+    "desc": "Also at 6th level, whenever you learn a new lesson of war or replace an existing one, you can instead choose from fighter soldiering knacks.",
+    "document": "a5e-ag",
+    "name": "Versatile Exploration",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_versatile-exploration"
+},
+{
+  "fields": {
+    "desc": "Beginning at 9th level, once per long rest, when a creature you can see that can hear or see you fails an ability check or saving throw, you can use your reaction to allow them to reroll the triggering ability check or saving throw.\n\nStarting at 13th level, you regain use of this feature after finishing a short or long rest.",
+    "document": "a5e-ag",
+    "name": "Spur Ally",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_spur-ally"
+},
+{
+  "fields": {
+    "desc": "Starting at 10th level, your capacity to direct your companions broadens. Choose one tradition that you know combat maneuvers from. You are able to use Combat Directives to grant uses of combat maneuvers from the chosen tradition.\n\nAt 15th level, choose a second tradition that you know combat maneuvers from.",
+    "document": "a5e-ag",
+    "name": "Expanded Directives",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_expanded-directives"
+},
+{
+  "fields": {
+    "desc": "Also starting at 10th level, you can spend 1 minute speaking words of encouragement and support to reinvigorate your companions. Each creature of your choice that can hear or understand you can spend any number of Hit Dice to regain hit points without having to finish a short rest. In addition, each creature spends at least one Hit Die in this way can remove one level of fatigue or strife it is currently suffering. Once a creature has removed a level of fatigue or strife in this way, it can't do so again until it finishes a long rest.",
+    "document": "a5e-ag",
+    "name": "Rouse the Troops",
+    "parent": "a5e_marshal"
+  },
+  "model": "api_v2.classfeature",
+  "pk": "a5e_marshal_rouse-the-troops"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
@@ -1,0 +1,1182 @@
+[
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 12,
+    "parent": "a5e_marshal_ability-score-improvement"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_ability-score-improvement_12"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 16,
+    "parent": "a5e_marshal_ability-score-improvement"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_ability-score-improvement_16"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 4,
+    "parent": "a5e_marshal_ability-score-improvement"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_ability-score-improvement_4"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 8,
+    "parent": "a5e_marshal_ability-score-improvement"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_ability-score-improvement_8"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 19,
+    "parent": "a5e_marshal_ability-score-improvement"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_ability-score-improvement_19"
+},
+{
+  "fields": {
+    "column_value": "+2",
+    "detail": null,
+    "level": 1,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_1"
+},
+{
+  "fields": {
+    "column_value": "+4",
+    "detail": null,
+    "level": 10,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_10"
+},
+{
+  "fields": {
+    "column_value": "+4",
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_11"
+},
+{
+  "fields": {
+    "column_value": "+4",
+    "detail": null,
+    "level": 12,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_12"
+},
+{
+  "fields": {
+    "column_value": "+5",
+    "detail": null,
+    "level": 13,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_13"
+},
+{
+  "fields": {
+    "column_value": "+5",
+    "detail": null,
+    "level": 14,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_14"
+},
+{
+  "fields": {
+    "column_value": "+5",
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_15"
+},
+{
+  "fields": {
+    "column_value": "+5",
+    "detail": null,
+    "level": 16,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_16"
+},
+{
+  "fields": {
+    "column_value": "+6",
+    "detail": null,
+    "level": 17,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_17"
+},
+{
+  "fields": {
+    "column_value": "+6",
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_18"
+},
+{
+  "fields": {
+    "column_value": "+6",
+    "detail": null,
+    "level": 19,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_19"
+},
+{
+  "fields": {
+    "column_value": "+2",
+    "detail": null,
+    "level": 2,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_2"
+},
+{
+  "fields": {
+    "column_value": "+6",
+    "detail": null,
+    "level": 20,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_20"
+},
+{
+  "fields": {
+    "column_value": "+2",
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_3"
+},
+{
+  "fields": {
+    "column_value": "+2",
+    "detail": null,
+    "level": 4,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_4"
+},
+{
+  "fields": {
+    "column_value": "+3",
+    "detail": null,
+    "level": 5,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_5"
+},
+{
+  "fields": {
+    "column_value": "+3",
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_6"
+},
+{
+  "fields": {
+    "column_value": "+3",
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_7"
+},
+{
+  "fields": {
+    "column_value": "+3",
+    "detail": null,
+    "level": 8,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_8"
+},
+{
+  "fields": {
+    "column_value": "+4",
+    "detail": null,
+    "level": 9,
+    "parent": "a5e_marshal_proficiency-bonus"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_proficiency-bonus_9"
+},
+{
+  "fields": {
+    "column_value": "10 feet",
+    "detail": null,
+    "level": 1,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_1"
+},
+{
+  "fields": {
+    "column_value": "30 feet",
+    "detail": null,
+    "level": 10,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_10"
+},
+{
+  "fields": {
+    "column_value": "30 feet",
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_11"
+},
+{
+  "fields": {
+    "column_value": "30 feet",
+    "detail": null,
+    "level": 12,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_12"
+},
+{
+  "fields": {
+    "column_value": "30 feet",
+    "detail": null,
+    "level": 13,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_13"
+},
+{
+  "fields": {
+    "column_value": "10 feet",
+    "detail": null,
+    "level": 14,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_14"
+},
+{
+  "fields": {
+    "column_value": "45 feet",
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_15"
+},
+{
+  "fields": {
+    "column_value": "45 feet",
+    "detail": null,
+    "level": 16,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_16"
+},
+{
+  "fields": {
+    "column_value": "45 feet",
+    "detail": null,
+    "level": 17,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_17"
+},
+{
+  "fields": {
+    "column_value": "45 feet",
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_18"
+},
+{
+  "fields": {
+    "column_value": "45 feet",
+    "detail": null,
+    "level": 19,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_19"
+},
+{
+  "fields": {
+    "column_value": "10 feet",
+    "detail": null,
+    "level": 2,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_2"
+},
+{
+  "fields": {
+    "column_value": "60 feet",
+    "detail": null,
+    "level": 20,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_20"
+},
+{
+  "fields": {
+    "column_value": "10 feet",
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_3"
+},
+{
+  "fields": {
+    "column_value": "10 feet",
+    "detail": null,
+    "level": 4,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_4"
+},
+{
+  "fields": {
+    "column_value": "20 feet",
+    "detail": null,
+    "level": 5,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_5"
+},
+{
+  "fields": {
+    "column_value": "20 feet",
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_6"
+},
+{
+  "fields": {
+    "column_value": "20 feet",
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_7"
+},
+{
+  "fields": {
+    "column_value": "20 feet",
+    "detail": null,
+    "level": 8,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_8"
+},
+{
+  "fields": {
+    "column_value": "20 feet",
+    "detail": null,
+    "level": 9,
+    "parent": "a5e_marshal_commanding-presence-range"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence-range_9"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 10,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_10"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_11"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 12,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_12"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 13,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_13"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 14,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_14"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_15"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 16,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_16"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 17,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_17"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_18"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 19,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_19"
+},
+{
+  "fields": {
+    "column_value": "4",
+    "detail": null,
+    "level": 20,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_20"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 5,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_5"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_6"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_7"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 8,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_8"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 9,
+    "parent": "a5e_marshal_follower-count"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_follower-count_9"
+},
+{
+  "fields": {
+    "column_value": "6",
+    "detail": null,
+    "level": 10,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_10"
+},
+{
+  "fields": {
+    "column_value": "7",
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_11"
+},
+{
+  "fields": {
+    "column_value": "7",
+    "detail": null,
+    "level": 12,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_12"
+},
+{
+  "fields": {
+    "column_value": "8",
+    "detail": null,
+    "level": 13,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_13"
+},
+{
+  "fields": {
+    "column_value": "8",
+    "detail": null,
+    "level": 14,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_14"
+},
+{
+  "fields": {
+    "column_value": "9",
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_15"
+},
+{
+  "fields": {
+    "column_value": "9",
+    "detail": null,
+    "level": 16,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_16"
+},
+{
+  "fields": {
+    "column_value": "10",
+    "detail": null,
+    "level": 17,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_17"
+},
+{
+  "fields": {
+    "column_value": "10",
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_18"
+},
+{
+  "fields": {
+    "column_value": "11",
+    "detail": null,
+    "level": 19,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_19"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 2,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_2"
+},
+{
+  "fields": {
+    "column_value": "11",
+    "detail": null,
+    "level": 20,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_20"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_3"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 4,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_4"
+},
+{
+  "fields": {
+    "column_value": "4",
+    "detail": null,
+    "level": 5,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_5"
+},
+{
+  "fields": {
+    "column_value": "4",
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_6"
+},
+{
+  "fields": {
+    "column_value": "5",
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_7"
+},
+{
+  "fields": {
+    "column_value": "5",
+    "detail": null,
+    "level": 8,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_8"
+},
+{
+  "fields": {
+    "column_value": "6",
+    "detail": null,
+    "level": 9,
+    "parent": "a5e_marshal_maneuvers-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuvers-known_9"
+},
+{
+  "fields": {
+    "column_value": "3rd",
+    "detail": null,
+    "level": 10,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_10"
+},
+{
+  "fields": {
+    "column_value": "3rd",
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_11"
+},
+{
+  "fields": {
+    "column_value": "4th",
+    "detail": null,
+    "level": 12,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_12"
+},
+{
+  "fields": {
+    "column_value": "4th",
+    "detail": null,
+    "level": 13,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_13"
+},
+{
+  "fields": {
+    "column_value": "4th",
+    "detail": null,
+    "level": 14,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_14"
+},
+{
+  "fields": {
+    "column_value": "4th",
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_15"
+},
+{
+  "fields": {
+    "column_value": "5th",
+    "detail": null,
+    "level": 16,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_16"
+},
+{
+  "fields": {
+    "column_value": "5th",
+    "detail": null,
+    "level": 17,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_17"
+},
+{
+  "fields": {
+    "column_value": "5th",
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_18"
+},
+{
+  "fields": {
+    "column_value": "5th",
+    "detail": null,
+    "level": 19,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_19"
+},
+{
+  "fields": {
+    "column_value": "1st",
+    "detail": null,
+    "level": 2,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_2"
+},
+{
+  "fields": {
+    "column_value": "5th",
+    "detail": null,
+    "level": 20,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_20"
+},
+{
+  "fields": {
+    "column_value": "1st",
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_3"
+},
+{
+  "fields": {
+    "column_value": "2nd",
+    "detail": null,
+    "level": 4,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_4"
+},
+{
+  "fields": {
+    "column_value": "2nd",
+    "detail": null,
+    "level": 5,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_5"
+},
+{
+  "fields": {
+    "column_value": "2nd",
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_6"
+},
+{
+  "fields": {
+    "column_value": "2nd",
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_7"
+},
+{
+  "fields": {
+    "column_value": "3rd",
+    "detail": null,
+    "level": 8,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_8"
+},
+{
+  "fields": {
+    "column_value": "3rd",
+    "detail": null,
+    "level": 9,
+    "parent": "a5e_marshal_maneuver-degree"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_maneuver-degree_9"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 10,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_10"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_11"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 12,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_12"
+},
+{
+  "fields": {
+    "column_value": "3",
+    "detail": null,
+    "level": 13,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_13"
+},
+{
+  "fields": {
+    "column_value": "4",
+    "detail": null,
+    "level": 14,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_14"
+},
+{
+  "fields": {
+    "column_value": "4",
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_15"
+},
+{
+  "fields": {
+    "column_value": "4",
+    "detail": null,
+    "level": 16,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_16"
+},
+{
+  "fields": {
+    "column_value": "4",
+    "detail": null,
+    "level": 17,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_17"
+},
+{
+  "fields": {
+    "column_value": "5",
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_18"
+},
+{
+  "fields": {
+    "column_value": "5",
+    "detail": null,
+    "level": 19,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_19"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 2,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_2"
+},
+{
+  "fields": {
+    "column_value": "5",
+    "detail": null,
+    "level": 20,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_20"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_3"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 4,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_4"
+},
+{
+  "fields": {
+    "column_value": "1",
+    "detail": null,
+    "level": 5,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_5"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_6"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_7"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 8,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_8"
+},
+{
+  "fields": {
+    "column_value": "2",
+    "detail": null,
+    "level": 9,
+    "parent": "a5e_marshal_lessons-known"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-known_9"
+}
+]

--- a/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
@@ -1538,5 +1538,55 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "a5e_swift-strategist_unbound-horde"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_talented-tactician_tactical-edge"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_talented-tactician_tactical-edge"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_talented-tactician_student-of-war"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_talented-tactician_student-of-war"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_talented-tactician_operations-leader"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_talented-tactician_operations-leader"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_talented-tactician_superior-tactics"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_talented-tactician_superior-tactics"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_talented-tactician_hidden-resources"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_talented-tactician_hidden-resources"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
@@ -1338,5 +1338,95 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "a5e_marshal_rouse-the-troops"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 12,
+    "parent": "a5e_marshal_commanding-demeanor"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-demeanor"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 13,
+    "parent": "a5e_marshal_dauntless"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_dauntless"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 13,
+    "parent": "a5e_marshal_stronghold"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_stronghold"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 14,
+    "parent": "a5e_marshal_advantageous-action"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_advantageous-action"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 16,
+    "parent": "a5e_marshal_greater-stronghold"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_greater-stronghold"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 17,
+    "parent": "a5e_marshal_critical-weakness"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_critical-weakness"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_marshal_impresive-reputation"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_impresive-reputation"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 20,
+    "parent": "a5e_marshal_legendary-commander"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_legendary-commander"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 20,
+    "parent": "a5e_marshal_supreme-stronghold"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_supreme-stronghold"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
@@ -1478,5 +1478,65 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "a5e_gambling-general_canny-adversary"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_swift-strategist_make-haste"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_swift-strategist_make-haste"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_swift-strategist_skirmisher"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_swift-strategist_skirmisher"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_swift-strategist_nimble-troops"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_swift-strategist_nimble-troops"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_swift-strategist_glorious-sacrifice"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_swift-strategist_glorious-sacrifice"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_swift-strategist_portentous-escape"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_swift-strategist_portentous-escape"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_swift-strategist_unbound-horde"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_swift-strategist_unbound-horde"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
@@ -1428,5 +1428,55 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "a5e_marshal_supreme-stronghold"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_gambling-general_daring-commander"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_gambling-general_daring-commander"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 7,
+    "parent": "a5e_gambling-general_defensive-measures"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_gambling-general_defensive-measures"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 11,
+    "parent": "a5e_gambling-general_hold-the-line"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_gambling-general_hold-the-line"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 15,
+    "parent": "a5e_gambling-general_risky-tactics"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_gambling-general_risky-tactics"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 18,
+    "parent": "a5e_gambling-general_canny-adversary"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_gambling-general_canny-adversary"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
@@ -1178,5 +1178,106 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "a5e_marshal_lessons-known_9"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 1,
+    "parent": "a5e_marshal_commanding-presence"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_commanding-presence"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 1,
+    "parent": "a5e_marshal_rallying-surge"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_rallying-surge"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 2,
+    "parent": "a5e_marshal_combat-maneuvers"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_combat-maneuvers"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 2,
+    "parent": "a5e_marshal_lessons-of-war"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_lessons-of-war"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_marshal_marshal-archetype"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_marshal-archetype"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "a5e_marshal_mark-foe"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_mark-foe"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 5,
+    "parent": "a5e_marshal_combat-directives"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_combat-directives"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": "two attacks",
+    "level": 5,
+    "parent": "a5e_marshal_extra-attack"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_extra-attack_5"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": "three attacks",
+    "level": 11,
+    "parent": "a5e_marshal_extra-attack"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_extra-attack_11"
+}
+,
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 5,
+    "parent": "a5e_marshal_followers"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_followers"
 }
 ]

--- a/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
+++ b/data/v2/en-publishing/a5e-ag/ClassFeatureItem.json
@@ -1268,8 +1268,7 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "a5e_marshal_extra-attack_11"
-}
-,
+},
 {
   "fields": {
     "column_value": null,
@@ -1279,5 +1278,65 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "a5e_marshal_followers"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_call-to-arms"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_call-to-arms"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_marshal-renown"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_marshal-renown"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 6,
+    "parent": "a5e_marshal_versatile-exploration"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_versatile-exploration"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 9,
+    "parent": "a5e_marshal_spur-ally"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_spur-ally"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 10,
+    "parent": "a5e_marshal_expanded-directives"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_expanded-directives"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 10,
+    "parent": "a5e_marshal_rouse-the-troops"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "a5e_marshal_rouse-the-troops"
 }
 ]


### PR DESCRIPTION
## Description

This PR adds the *Marshal* class (and subclasses) from the Level Up Advanced 5e SRD (https://a5esrd.com/a5esrd) to the Open5e API (V2).

While adding this add has been a long term goal of this project, I have only opted to add one class here as a stress-test for our `CharacterClass` model to make sure it is capable of fully expressing character class data from different sources (compare PR #808 which performs a similar task for the Tales of Valiant classes).

Overall I was satisfied with how our model performed. I am uncertain how best to handle A5e's **Maneuvers**, which is necessary information to present to users who are building martial classes using A5e, but not actually part of the class data.

## How was this tested

- Spot checked on local Django test server
- `pytest` (all passing)