### PR TITLE
Added missing srd-2024 WeaponPropertyAssignment data

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2024/WeaponPropertyAssignment.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/WeaponPropertyAssignment.json
@@ -21,7 +21,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 25/100; Needle",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_blowgun"
@@ -101,7 +101,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 20/60",
     "document": "srd-2024",
     "property": "srd-2024_thrown-wp",
     "weapon": "srd-2024_dagger"
@@ -121,7 +121,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 20/60",
     "document": "srd-2024",
     "property": "srd-2024_thrown-wp",
     "weapon": "srd-2024_dart"
@@ -311,7 +311,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 30/120; Bolt",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_hand-crossbow"
@@ -361,7 +361,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 20/60",
     "document": "srd-2024",
     "property": "srd-2024_thrown-wp",
     "weapon": "srd-2024_handaxe"
@@ -381,7 +381,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 100/400; Bolt",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_heavy-crossbow"
@@ -441,7 +441,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 30/120",
     "document": "srd-2024",
     "property": "srd-2024_thrown-wp",
     "weapon": "srd-2024_javelin"
@@ -481,7 +481,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "unless mounted",
     "document": "srd-2024",
     "property": "srd-2024_two-handed-wp",
     "weapon": "srd-2024_lance"
@@ -491,7 +491,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 80/320; Bolt",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_light-crossbow"
@@ -551,7 +551,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 20/60",
     "document": "srd-2024",
     "property": "srd-2024_thrown-wp",
     "weapon": "srd-2024_light-hammer"
@@ -561,7 +561,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 150/600; Arrow",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_longbow"
@@ -671,7 +671,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 40/120; Bullet",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_musket"
@@ -751,7 +751,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 30/90; Bullet",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_pistol"
@@ -851,7 +851,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 80/320; Arrow",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_shortbow"
@@ -931,7 +931,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 30/120; Bullet",
     "document": "srd-2024",
     "property": "srd-2024_ammunition-wp",
     "weapon": "srd-2024_sling"
@@ -961,7 +961,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 20/60",
     "document": "srd-2024",
     "property": "srd-2024_thrown-wp",
     "weapon": "srd-2024_spear"
@@ -981,7 +981,7 @@
 },
 {
   "fields": {
-    "detail": null,
+    "detail": "Range 20/60",
     "document": "srd-2024",
     "property": "srd-2024_thrown-wp",
     "weapon": "srd-2024_trident"


### PR DESCRIPTION
## Description

This PR adds some missing data to the `srd-2024` WeaponPropertyAssignment source data. Principally, details on Weapon ranges that were absent from the existing dataset.

## Related Issue

Closes #818 

## How was this tested

- Spot checked on local Django server
- `pytest` (all tests passing)