### PR TITLE
Added 'desc' field to WeaponPropertySummarySerializer

### DIFF
--- a/api_v2/serializers/item.py
+++ b/api_v2/serializers/item.py
@@ -51,7 +51,7 @@ class WeaponPropertySerializer(GameContentSerializer):
 class WeaponPropertySummarySerializer(GameContentSerializer):
     class Meta:
         model = models.WeaponProperty
-        fields = ['name', 'type', 'url']
+        fields = ['name', 'type', 'url', 'desc']
 
 class WeaponPropertyAssignmentSerializer(GameContentSerializer):
     property = WeaponPropertySummarySerializer()

--- a/api_v2/tests/responses/TestObjects.test_item_melee_weapon_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_melee_weapon_example.approved.json
@@ -51,6 +51,7 @@
             {
                 "detail": null,
                 "property": {
+                    "desc": "When making an attack with a finesse weapon, you use your choice of your Strength or Dexterity modifier for the attack and damage rolls. You must use the same modifier for both rolls.",
                     "name": "Finesse",
                     "type": null,
                     "url": "http://localhost:8000/v2/weaponproperties/srd-2014_finesse-wp/"
@@ -59,6 +60,7 @@
             {
                 "detail": null,
                 "property": {
+                    "desc": "A light weapon is small and easy to handle, making it ideal for use when fighting with two weapons.",
                     "name": "Light",
                     "type": null,
                     "url": "http://localhost:8000/v2/weaponproperties/srd-2014_light-wp/"

--- a/api_v2/tests/responses/TestObjects.test_item_ranged_weapon_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_item_ranged_weapon_example.approved.json
@@ -51,6 +51,7 @@
             {
                 "detail": "range 150/600",
                 "property": {
+                    "desc": "You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. Each time you attack with the weapon, you expend one piece of ammunition. Drawing the ammunition from a quiver, case, or other container is part of the attack (you need a free hand to load a one-\u00ad\u2010\u2011handed weapon). At the end of the battle, you can recover half your expended ammunition by taking a minute to search the battlefield.\n\nIf you use a weapon that has the ammunition property to make a melee attack, you treat the weapon as an improvised weapon (see \u201cImprovised Weapons\u201d later in the section). A sling must be loaded to deal any damage when used in this way.",
                     "name": "Ammunition",
                     "type": null,
                     "url": "http://localhost:8000/v2/weaponproperties/srd-2014_ammunition-wp/"
@@ -59,6 +60,7 @@
             {
                 "detail": null,
                 "property": {
+                    "desc": "This weapon requires two hands when you attack with it.",
                     "name": "Two-Handed",
                     "type": null,
                     "url": "http://localhost:8000/v2/weaponproperties/srd-2014_two-handed-wp/"

--- a/api_v2/tests/responses/TestObjects.test_weapon_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_weapon_example.approved.json
@@ -31,6 +31,7 @@
         {
             "detail": null,
             "property": {
+                "desc": "When making an attack with a finesse weapon, you use your choice of your Strength or Dexterity modifier for the attack and damage rolls. You must use the same modifier for both rolls.",
                 "name": "Finesse",
                 "type": null,
                 "url": "/v2/weaponproperties/srd-2014_finesse-wp/"
@@ -39,6 +40,7 @@
         {
             "detail": null,
             "property": {
+                "desc": "A light weapon is small and easy to handle, making it ideal for use when fighting with two weapons.",
                 "name": "Light",
                 "type": null,
                 "url": "/v2/weaponproperties/srd-2014_light-wp/"

--- a/api_v2/tests/responses/TestObjects.test_weapon_with_mastery_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_weapon_with_mastery_example.approved.json
@@ -31,6 +31,7 @@
         {
             "detail": null,
             "property": {
+                "desc": "If you hit a creature with this weapon, that creature has Disadvantage on its next attack roll before the start of your next turn.",
                 "name": "Sap",
                 "type": "Mastery",
                 "url": "/v2/weaponproperties/srd-2024_sap-mastery/"
@@ -39,6 +40,7 @@
         {
             "detail": "1d10",
             "property": {
+                "desc": "A Versatile weapon can be used with one or two hands. A damage value in parentheses appears with the property. The weapon deals that damage when used with two hands to make a melee attack.",
                 "name": "Versatile",
                 "type": null,
                 "url": "/v2/weaponproperties/srd-2024_versatile-wp/"


### PR DESCRIPTION
## Description

This PR addresses an issue where weapons returned by the `/v2/items` endpoint didn't include any information about their Weapon Properties, beside their name and API URL.

With the `"desc"` field being added to the `WeaponPropertySummarySerializer`, this information (which is especially helpful for surfacing the D&D 2024 Weapon Mastery Properties) can be easily surfaced on pages such as the [single-view Equipment page for weapons](https://beta.open5e.com/equipment/srd-2024_longbow).

## Related Issue

Closes #822 

## How was this tested?

- Spot checked using the Django developement server (`pipenv run python manage.py runserver`)
- `pipenv run pytest` (all tests passing, once cases were updated to reflect the changes made to the API response)