### PR TITLE
[FEATURE] Added `v2/magicitems` endpoint

### DIFF
--- a/api_v2/tests/test_router.py
+++ b/api_v2/tests/test_router.py
@@ -29,7 +29,7 @@ class APIV2RootTest(APITestCase):
         self.assertContains(response, 'publishers', count=2)
         self.assertContains(response, 'licenses', count=2)
         self.assertContains(response, 'gamesystems', count=2)
-        self.assertContains(response, 'items', count=4) #include itemsets
+        self.assertContains(response, 'items', count=6) #include itemsets
         self.assertContains(response, 'itemsets', count=2)
         self.assertContains(response, 'weapons', count=2)
         self.assertContains(response, 'armor', count=2)

--- a/api_v2/urls.py
+++ b/api_v2/urls.py
@@ -6,6 +6,7 @@ from api_v2 import views
 
 router = routers.DefaultRouter()
 router.register(r'items',views.ItemViewSet)
+router.register(r'magicitems', views.MagicItemViewSet, basename="magicitems")
 router.register(r'itemsets',views.ItemSetViewSet)
 router.register(r'itemcategories',views.ItemCategoryViewSet)
 router.register(r'documents',views.DocumentViewSet)

--- a/api_v2/views/__init__.py
+++ b/api_v2/views/__init__.py
@@ -15,7 +15,7 @@ from .feat import FeatFilterSet, FeatViewSet
 
 from .species import SpeciesFilterSet, SpeciesViewSet
 
-from .item import ItemFilterSet, ItemViewSet
+from .item import ItemFilterSet, ItemViewSet, MagicItemViewSet
 from .item import ItemSetFilterSet, ItemSetViewSet
 from .item import ItemCategoryViewSet
 from .item import ItemRarityViewSet

--- a/api_v2/views/item.py
+++ b/api_v2/views/item.py
@@ -57,6 +57,21 @@ class ItemFilterSet(FilterSet):
             'document__gamesystem__key': ['in','iexact'],
         }
 
+# used in ItemViewSet and MagicItemViewSet - factored out for DRYness
+item_prefetch_fields = [
+    'armor',
+    'category',
+    'damage_immunities',
+    'damage_resistances',
+    'damage_vulnerabilities',
+    'document',
+    'weapon__properties',
+    'weapon__damage_type',
+    'weapon__document',
+    'weapon__properties__property',
+    'rarity',
+    'size',
+]
 
 class ItemViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     """
@@ -69,20 +84,20 @@ class ItemViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
     filterset_class = ItemFilterSet
 
     select_related_fields = ['armor', 'weapon']
-    prefetch_related_fields = [
-        'armor',
-        'category',
-        'damage_immunities',
-        'damage_resistances',
-        'damage_vulnerabilities',
-        'document',
-        'weapon__properties',
-        'weapon__damage_type',
-        'weapon__document',
-        'weapon__properties__property',
-        'rarity',
-        'size',
-    ]
+    prefetch_related_fields = item_prefetch_fields
+
+class MagicItemViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
+    """
+    list: API endpoint for returning a list of magic items.
+
+    retrieve: API endpoint for returning a particular magic item.
+    """
+    queryset = models.Item.objects.filter(rarity__isnull=False).order_by('pk')
+    serializer_class = serializers.ItemSerializer
+    filterset_class = ItemFilterSet
+    
+    select_related_fields = ['armor', 'weapon']
+    prefetch_related_fields = item_prefetch_fields
 
 class ItemRarityViewSet(viewsets.ReadOnlyModelViewSet):
     """


### PR DESCRIPTION
## Description

This PR adds the `/magicitems` endpoint to the V2 API. This endpoints serves up `Item` model data, but with mundane items filtered out. Functionally, it returns the same data as `/v2/items/?is_magic_item=true`

This endpoint is especially useful on the Open5e website, where mundane and magical items are split across seperate top-level pages for UX reaons.

## Related Issue

Closes #833 

## How was this tested
- Spot checked PR on local Django server
- Ran `pytest` (updated one test case that didn't reflect that `/api_v2/urls.py` now contained 6 instances of the work `"item"`)