### PR TITLE
Added missing srd-2014 Armor of Resistance variations

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2014/Item.json
+++ b/data/v2/wizards-of-the-coast/srd-2014/Item.json
@@ -726,6 +726,267 @@
 },
 {
   "fields": {
+    "armor": "srd_hide",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Hide)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "12.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-hide"
+},
+{
+  "fields": {
+    "armor": "srd_chain-shirt",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Chain Shirt)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "20.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-chain-shirt"
+},
+{
+  "fields": {
+    "armor": "srd_scale-mail",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Scale Mail)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "45.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-scale-mail"
+},
+{
+  "fields": {
+    "armor": "srd_breastplate",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Breastplate)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "20.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-breastplate"
+},
+{
+  "fields": {
+    "armor": "srd_half-plate",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Half Plate)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "40.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-half-plate"
+},
+{
+  "fields": {
+    "armor": "srd_ring-mail",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Ring Mail)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "40.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-ring-mail"
+},
+{
+  "fields": {
+    "armor": "srd_chain-mail",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Chain Mail)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "55.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-chain-mail"
+},
+{
+  "fields": {
+    "armor": "srd_splint",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Splint)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "60.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-splint"
+},
+{
+  "fields": {
+    "armor": "srd_plate",
+    "armor_class": 0,
+    "armor_detail": "",
+    "category": "armor",
+    "cost": null,
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "desc": "You have resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly from the options below.\n\n| d10 | Damage Type |\n|-----|-------------|\n| 1   | Acid        |\n| 2   | Cold        |\n| 3   | Fire        |\n| 4   | Force       |\n| 5   | Lightning   |\n| 6   | Necrotic    |\n| 7   | Poison      |\n| 8   | Psychic     |\n| 9   | Radiant     |\n| 10  | Thunder     |",
+    "document": "srd-2014",
+    "hit_dice": null,
+    "hit_points": 0,
+    "name": "Armor of Resistance (Plate)",
+    "nonmagical_attack_immunity": false,
+    "nonmagical_attack_resistance": false,
+    "rarity": "rare",
+    "requires_attunement": true,
+    "size": "tiny",
+    "weapon": null,
+    "weight": "65.000"
+  },
+  "model": "api_v2.item",
+  "pk": "srd_armor-of-resistance-plate"
+},
+{
+  "fields": {
     "armor": "srd_plate",
     "armor_class": 0,
     "armor_detail": "",


### PR DESCRIPTION
## Description

This PR fixes a bug in the V2 `srd-2014` data where medium and heavy armor variations of the Armor of Resistance magic item were missing from the data set.

## Related Issue

Closes #830 

## How was this tested?
- Spot checked on local Django development server
- `pytest` (all tests passing)