### PR TITLE
Removed unneed asterisks from FeatBenefit 'desc' fields

### DIFF
--- a/data/v2/green-ronin/tdcs/FeatBenefit.json
+++ b/data/v2/green-ronin/tdcs/FeatBenefit.json
@@ -1,7 +1,7 @@
 [
 {
   "fields": {
-    "desc": "* You can drink a potion as a Bonus action, instead of as an action.",
+    "desc": "You can drink a potion as a Bonus action, instead of as an action.",
     "name": "",
     "parent": "tdcs_rapid-drinker",
     "type": null
@@ -11,7 +11,7 @@
 },
 {
   "fields": {
-    "desc": "* You have advantage on any saving throws triggered by ingesting an alcoholic or dangerous substance.",
+    "desc": "You have advantage on any saving throws triggered by ingesting an alcoholic or dangerous substance.",
     "name": "",
     "parent": "tdcs_rapid-drinker",
     "type": null

--- a/data/v2/kobold-press/toh/FeatBenefit.json
+++ b/data/v2/kobold-press/toh/FeatBenefit.json
@@ -1,7 +1,7 @@
 [
 {
   "fields": {
-    "desc": "* Increase your Wisdom score by 1, to a maximum of 20.",
+    "desc": "Increase your Wisdom score by 1, to a maximum of 20.",
     "name": "",
     "parent": "toh_boundless-reserves",
     "type": null
@@ -11,7 +11,7 @@
 },
 {
   "fields": {
-    "desc": "* When you start your turn and have no ki points remaining, you can use a reaction to spend one Hit Die. Roll the die and add your Constitution modifier to it. You regain expended ki points equal to up to half the total (minimum of 1). You can never have more ki points than the maximum for your level. Hit Dice spent using this feat can't be used to regain hit points during a short rest. You regain spent Hit Dice as normal.",
+    "desc": "When you start your turn and have no ki points remaining, you can use a reaction to spend one Hit Die. Roll the die and add your Constitution modifier to it. You regain expended ki points equal to up to half the total (minimum of 1). You can never have more ki points than the maximum for your level. Hit Dice spent using this feat can't be used to regain hit points during a short rest. You regain spent Hit Dice as normal.",
     "name": "",
     "parent": "toh_boundless-reserves",
     "type": null
@@ -31,7 +31,7 @@
 },
 {
   "fields": {
-    "desc": "* You have advantage on saving throws against effects that cause you to suffer a level of exhaustion.",
+    "desc": "You have advantage on saving throws against effects that cause you to suffer a level of exhaustion.",
     "name": "",
     "parent": "toh_diehard",
     "type": null
@@ -41,7 +41,7 @@
 },
 {
   "fields": {
-    "desc": "* You have advantage on death saving throws.",
+    "desc": "You have advantage on death saving throws.",
     "name": "",
     "parent": "toh_diehard",
     "type": null
@@ -51,7 +51,7 @@
 },
 {
   "fields": {
-    "desc": "* Increase your Intelligence or Wisdom score by 1, to a maximum of 20.",
+    "desc": "Increase your Intelligence or Wisdom score by 1, to a maximum of 20.",
     "name": "",
     "parent": "toh_floriographer",
     "type": null
@@ -61,7 +61,7 @@
 },
 {
   "fields": {
-    "desc": "* You learn Floriography, the language of flowers. Similar to Druidic and Thieves' Cant, Floriography is a secret language often used to communicate subtle ideas, symbolic meaning, and even basic messages. Floriography is conveyed through the combinations of colors, styles, and even types of flowers in bouquets, floral arrangements, and floral illustrations, often with a gift-giving component.",
+    "desc": "You learn Floriography, the language of flowers. Similar to Druidic and Thieves' Cant, Floriography is a secret language often used to communicate subtle ideas, symbolic meaning, and even basic messages. Floriography is conveyed through the combinations of colors, styles, and even types of flowers in bouquets, floral arrangements, and floral illustrations, often with a gift-giving component.",
     "name": "",
     "parent": "toh_floriographer",
     "type": null
@@ -71,7 +71,7 @@
 },
 {
   "fields": {
-    "desc": "* Your fluency with the subtle messages in floral displays gives you a keen eye for discerning subtle or hidden messages elsewhere. You have advantage on Intelligence (Investigation) and Wisdom (Insight) checks to notice and discern hidden messages of a visual nature, such as the runes of a magic trap or the subtle hand signals passing between two individuals.",
+    "desc": "Your fluency with the subtle messages in floral displays gives you a keen eye for discerning subtle or hidden messages elsewhere. You have advantage on Intelligence (Investigation) and Wisdom (Insight) checks to notice and discern hidden messages of a visual nature, such as the runes of a magic trap or the subtle hand signals passing between two individuals.",
     "name": "",
     "parent": "toh_floriographer",
     "type": null
@@ -81,7 +81,7 @@
 },
 {
   "fields": {
-    "desc": "* Increase your Wisdom score by 1, to a maximum of 20.",
+    "desc": "Increase your Wisdom score by 1, to a maximum of 20.",
     "name": "",
     "parent": "toh_forest-denizen",
     "type": null
@@ -91,7 +91,7 @@
 },
 {
   "fields": {
-    "desc": "* You can discern if a plant or fungal growth is safe to eat.",
+    "desc": "You can discern if a plant or fungal growth is safe to eat.",
     "name": "",
     "parent": "toh_forest-denizen",
     "type": null
@@ -101,7 +101,7 @@
 },
 {
   "fields": {
-    "desc": "* You learn to speak, read, and write Sylvan.",
+    "desc": "You learn to speak, read, and write Sylvan.",
     "name": "",
     "parent": "toh_forest-denizen",
     "type": null
@@ -111,7 +111,7 @@
 },
 {
   "fields": {
-    "desc": "* You have advantage on Strength (Athletics) and Dexterity (Acrobatics) checks you make to escape from being grappled or restrained as long as you are being grappled or restrained by nonmagical vegetation or a beast's action such as a giant frog's bite or a spider's web.",
+    "desc": "You have advantage on Strength (Athletics) and Dexterity (Acrobatics) checks you make to escape from being grappled or restrained as long as you are being grappled or restrained by nonmagical vegetation or a beast's action such as a giant frog's bite or a spider's web.",
     "name": "",
     "parent": "toh_forest-denizen",
     "type": null
@@ -121,7 +121,7 @@
 },
 {
   "fields": {
-    "desc": "* You learn the *treeheal* (see the Magic and Spells chapter) cantrip and two other druid cantrips of your choice.",
+    "desc": "You learn the *treeheal* (see the Magic and Spells chapter) cantrip and two other druid cantrips of your choice.",
     "name": "",
     "parent": "toh_friend-of-the-forest",
     "type": null
@@ -131,7 +131,7 @@
 },
 {
   "fields": {
-    "desc": "* You also learn the *speak with animals* spell and can cast it once without expending a spell slot. Once you cast it, you must finish a short or long rest before you can cast it in this way again. Your spellcasting ability for these spells is Wisdom.",
+    "desc": "You also learn the *speak with animals* spell and can cast it once without expending a spell slot. Once you cast it, you must finish a short or long rest before you can cast it in this way again. Your spellcasting ability for these spells is Wisdom.",
     "name": "",
     "parent": "toh_friend-of-the-forest",
     "type": null
@@ -141,7 +141,7 @@
 },
 {
   "fields": {
-    "desc": "* Increase your Strength score by 1, to a maximum of 20.",
+    "desc": "Increase your Strength score by 1, to a maximum of 20.",
     "name": "",
     "parent": "toh_giant-foe",
     "type": null
@@ -151,7 +151,7 @@
 },
 {
   "fields": {
-    "desc": "* If you normally have disadvantage on attack rolls made with weapons with the Heavy property due to your size, you don't have disadvantage on those attack rolls.",
+    "desc": "If you normally have disadvantage on attack rolls made with weapons with the Heavy property due to your size, you don't have disadvantage on those attack rolls.",
     "name": "",
     "parent": "toh_giant-foe",
     "type": null
@@ -161,7 +161,7 @@
 },
 {
   "fields": {
-    "desc": "* When a giant attacks you, any critical hit from it against you becomes a normal hit.",
+    "desc": "When a giant attacks you, any critical hit from it against you becomes a normal hit.",
     "name": "",
     "parent": "toh_giant-foe",
     "type": null
@@ -171,7 +171,7 @@
 },
 {
   "fields": {
-    "desc": "* Whenever you make an Intelligence (History) check related to the culture or origins of a giant, you are considered proficient in the History skill and add double your proficiency bonus to the check, instead of your normal proficiency bonus.",
+    "desc": "Whenever you make an Intelligence (History) check related to the culture or origins of a giant, you are considered proficient in the History skill and add double your proficiency bonus to the check, instead of your normal proficiency bonus.",
     "name": "",
     "parent": "toh_giant-foe",
     "type": null
@@ -181,7 +181,7 @@
 },
 {
   "fields": {
-    "desc": "* Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+    "desc": "Increase your Strength or Dexterity score by 1, to a maximum of 20.",
     "name": "",
     "parent": "toh_harrier",
     "type": null
@@ -191,7 +191,7 @@
 },
 {
   "fields": {
-    "desc": "* When you use your Shadow Traveler trait or cast misty step, you have advantage on the next attack you make before the end of your turn.",
+    "desc": "When you use your Shadow Traveler trait or cast misty step, you have advantage on the next attack you make before the end of your turn.",
     "name": "",
     "parent": "toh_harrier",
     "type": null
@@ -201,7 +201,7 @@
 },
 {
   "fields": {
-    "desc": "* Increase your Wisdom score by 1, to a maximum of 20",
+    "desc": "Increase your Wisdom score by 1, to a maximum of 20",
     "name": "",
     "parent": "toh_inner-resilience",
     "type": null
@@ -211,7 +211,7 @@
 },
 {
   "fields": {
-    "desc": "* You have 3 ki points, which you can spend to fuel the Patient Defense or Step of the Wind features from the monk class. When you spend a ki point, it is unavailable until you finish a short or long rest, at the end of which you draw all of your expended ki back into yourself. You must spend at least 30 minutes of the rest meditating to regain your ki points",
+    "desc": "You have 3 ki points, which you can spend to fuel the Patient Defense or Step of the Wind features from the monk class. When you spend a ki point, it is unavailable until you finish a short or long rest, at the end of which you draw all of your expended ki back into yourself. You must spend at least 30 minutes of the rest meditating to regain your ki points",
     "name": "",
     "parent": "toh_inner-resilience",
     "type": null
@@ -221,7 +221,7 @@
 },
 {
   "fields": {
-    "desc": "* If you already have ki points, your ki point maximum increases by 3 instead.",
+    "desc": "If you already have ki points, your ki point maximum increases by 3 instead.",
     "name": "",
     "parent": "toh_inner-resilience",
     "type": null
@@ -231,7 +231,7 @@
 },
 {
   "fields": {
-    "desc": "* Through growls, barks, and gestures, you can communicate simple ideas with canines. For the purposes of this feat, a \"canine\" is any beast with dog or wolf-like features. You can understand them in return, though this is often limited to knowing the creature's current or most recent state, such as \"hungry\", \"content\", or \"in danger.\"",
+    "desc": "Through growls, barks, and gestures, you can communicate simple ideas with canines. For the purposes of this feat, a \"canine\" is any beast with dog or wolf-like features. You can understand them in return, though this is often limited to knowing the creature's current or most recent state, such as \"hungry\", \"content\", or \"in danger.\"",
     "name": "",
     "parent": "toh_part-of-the-pack",
     "type": null
@@ -241,7 +241,7 @@
 },
 {
   "fields": {
-    "desc": "* As an action, you can howl to summon a wolf to assist you. The wolf appears in 1d4 rounds and remains within 50 feet of you until 1 hour elapses or until it dies, whichever occurs first. You can't control the wolf, but it doesn't attack you or your companions. It acts on its own initiative, and it attacks creatures attacking you or your companions. If you are 5th level or higher, your howl summons a number of wolves equal to your proficiency bonus. When your howl summons multiple wolves, you have a 50 percent chance that one of the wolves is a dire wolf instead. Your summoned pack can have no more than one dire wolf. While at least one wolf is with you, you have advantage on Wisdom (Survival) checks to hunt for food or to find shelter. At the GM's discretion, you may not be able to summon a wolf or multiple wolves if you are indoors or in a region where wolves aren't native, such as the middle of the sea. Once you have howled to summon a wolf or wolves with this feat, you must finish a long rest before you can do so again.",
+    "desc": "As an action, you can howl to summon a wolf to assist you. The wolf appears in 1d4 rounds and remains within 50 feet of you until 1 hour elapses or until it dies, whichever occurs first. You can't control the wolf, but it doesn't attack you or your companions. It acts on its own initiative, and it attacks creatures attacking you or your companions. If you are 5th level or higher, your howl summons a number of wolves equal to your proficiency bonus. When your howl summons multiple wolves, you have a 50 percent chance that one of the wolves is a dire wolf instead. Your summoned pack can have no more than one dire wolf. While at least one wolf is with you, you have advantage on Wisdom (Survival) checks to hunt for food or to find shelter. At the GM's discretion, you may not be able to summon a wolf or multiple wolves if you are indoors or in a region where wolves aren't native, such as the middle of the sea. Once you have howled to summon a wolf or wolves with this feat, you must finish a long rest before you can do so again.",
     "name": "",
     "parent": "toh_part-of-the-pack",
     "type": null
@@ -251,7 +251,7 @@
 },
 {
   "fields": {
-    "desc": "* When you cast a spell that deals damage, you can use a reaction to change the type of damage the spell deals to cold damage.",
+    "desc": "When you cast a spell that deals damage, you can use a reaction to change the type of damage the spell deals to cold damage.",
     "name": "",
     "parent": "toh_rimecaster",
     "type": null
@@ -261,7 +261,7 @@
 },
 {
   "fields": {
-    "desc": "* When you cast a spell that deals cold damage, you gain resistance to cold damage until the start of your next turn. If you already have resistance to cold damage, you are immune to cold damage until the start of your next turn instead.",
+    "desc": "When you cast a spell that deals cold damage, you gain resistance to cold damage until the start of your next turn. If you already have resistance to cold damage, you are immune to cold damage until the start of your next turn instead.",
     "name": "",
     "parent": "toh_rimecaster",
     "type": null
@@ -271,7 +271,7 @@
 },
 {
   "fields": {
-    "desc": "* Increase your Charisma score by 1, to a maximum of 20.",
+    "desc": "Increase your Charisma score by 1, to a maximum of 20.",
     "name": "",
     "parent": "toh_sorcerous-vigor",
     "type": null
@@ -281,7 +281,7 @@
 },
 {
   "fields": {
-    "desc": "* When you start your turn and have no sorcery points remaining, you can use a reaction to spend one Hit Die. Roll the die and add your Constitution modifier to it. You regain expended sorcery points equal to up to half the total (minimum of 1). You can never have more sorcery points than the maximum for your level. Hit Dice spent using this feat can't be used to regain hit points during a short rest. You regain spent Hit Dice as normal.",
+    "desc": "When you start your turn and have no sorcery points remaining, you can use a reaction to spend one Hit Die. Roll the die and add your Constitution modifier to it. You regain expended sorcery points equal to up to half the total (minimum of 1). You can never have more sorcery points than the maximum for your level. Hit Dice spent using this feat can't be used to regain hit points during a short rest. You regain spent Hit Dice as normal.",
     "name": "",
     "parent": "toh_sorcerous-vigor",
     "type": null
@@ -291,7 +291,7 @@
 },
 {
   "fields": {
-    "desc": "* You gain proficiency in the Stealth and Survival skills.",
+    "desc": "You gain proficiency in the Stealth and Survival skills.",
     "name": "",
     "parent": "toh_stalker",
     "type": null
@@ -301,7 +301,7 @@
 },
 {
   "fields": {
-    "desc": "* You have advantage on Wisdom (Survival) checks made to track a creature you have seen in the past 24 hours.",
+    "desc": "You have advantage on Wisdom (Survival) checks made to track a creature you have seen in the past 24 hours.",
     "name": "",
     "parent": "toh_stalker",
     "type": null
@@ -311,7 +311,7 @@
 },
 {
   "fields": {
-    "desc": "* When you score a critical hit on a ranged attack roll, you can stun the target until the start of your next turn instead of doubling the damage.",
+    "desc": "When you score a critical hit on a ranged attack roll, you can stun the target until the start of your next turn instead of doubling the damage.",
     "name": "",
     "parent": "toh_stunning-sniper",
     "type": null


### PR DESCRIPTION
## Description

This PR removed prepended asterisks from the `"desc"` field for `FeatBenefit`s from the Tome of Heroes and Tal'Dorei setting book. These characters were causing trouble for our Markdown parser on the front-end by creating unnecessary doubly-nested unordered lists.

## Related Issue
Closes #851 

## How was this tested?
- Spot checked on local Django development server
- `pytest` (all tests green)