### PR TITLE
Updated `SRD-2014` Dragon breath weapon recharge data

### DIFF
--- a/api_v2/tests/responses/TestObjects.test_creature_ancient_example.approved.json
+++ b/api_v2/tests/responses/TestObjects.test_creature_ancient_example.approved.json
@@ -92,11 +92,14 @@
             "action_type": "ACTION",
             "attacks": [],
             "desc": "The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 91 (26d6) fire damage on a failed save, or half as much damage on a successful one.",
-            "legendary_action_cost": 1,
+            "legendary_action_cost": null,
             "limited_to_form": null,
             "name": "Fire Breath",
             "order_in_statblock": 5,
-            "usage_limits": null
+            "usage_limits": {
+                "param": 5,
+                "type": "RECHARGE_ON_ROLL"
+            }
         },
         {
             "action_type": "ACTION",

--- a/data/v2/wizards-of-the-coast/srd-2014/CreatureAction.json
+++ b/data/v2/wizards-of-the-coast/srd-2014/CreatureAction.json
@@ -124,12 +124,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales acid in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Acid Breath",
     "order": 5,
     "parent": "srd_adult-black-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-black-dragon_acid-breath"
@@ -319,12 +319,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales lightning in a 90-foot line that is 5 ft. wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Lightning Breath",
     "order": 5,
     "parent": "srd_adult-blue-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-blue-dragon_lightning-breath"
@@ -409,12 +409,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 45 (13d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_adult-brass-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-brass-dragon_breath-weapons"
@@ -544,12 +544,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Lightning Breath.** The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.\n**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 19 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_adult-bronze-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-bronze-dragon_breath-weapons"
@@ -694,12 +694,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Acid Breath.** The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one.\n**Slowing Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_adult-copper-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-copper-dragon_breath-weapons"
@@ -829,12 +829,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 66 (12d10) fire damage on a failed save, or half as much damage on a successful one.\n**Weakening Breath.** The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 21 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_adult-gold-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-gold-dragon_breath-weapons"
@@ -1039,12 +1039,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 56 (16d6) poison damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Poison Breath",
     "order": 5,
     "parent": "srd_adult-green-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-green-dragon_poison-breath"
@@ -1144,12 +1144,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 63 (18d6) fire damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Fire Breath",
     "order": 5,
     "parent": "srd_adult-red-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-red-dragon_fire-breath"
@@ -1249,12 +1249,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Cold Breath.** The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 20 Constitution saving throw, taking 58 (13d8) cold damage on a failed save, or half as much damage on a successful one.\n**Paralyzing Breath.** The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a DC 20 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_adult-silver-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-silver-dragon_breath-weapons"
@@ -1414,12 +1414,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Cold Breath",
     "order": 5,
     "parent": "srd_adult-white-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_adult-white-dragon_cold-breath"
@@ -1568,8 +1568,8 @@
     "name": "Acid Breath",
     "order": 5,
     "parent": "srd_ancient-black-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-black-dragon_acid-breath"
@@ -1759,12 +1759,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Lightning Breath",
     "order": 5,
     "parent": "srd_ancient-blue-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-blue-dragon_lightning-breath"
@@ -1849,12 +1849,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons:\n**Fire Breath.** The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_ancient-brass-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-brass-dragon_breath-weapons"
@@ -1999,12 +1999,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Lightning Breath.** The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one.\n**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 23 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_ancient-bronze-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-bronze-dragon_breath-weapons"
@@ -2149,12 +2149,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Acid Breath.** The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 63 (14d8) acid damage on a failed save, or half as much damage on a successful one.\n**Slowing Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 22 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_ancient-copper-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-copper-dragon_breath-weapons"
@@ -2299,12 +2299,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 71 (13d10) fire damage on a failed save, or half as much damage on a successful one.\n**Weakening Breath.** The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 24 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_ancient-gold-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-gold-dragon_breath-weapons"
@@ -2509,12 +2509,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 77 (22d6) poison damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Poison Breath",
     "order": 5,
     "parent": "srd_ancient-green-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-green-dragon_poison-breath"
@@ -2614,12 +2614,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 91 (26d6) fire damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Fire Breath",
     "order": 5,
     "parent": "srd_ancient-red-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-red-dragon_fire-breath"
@@ -2719,12 +2719,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n\n**Cold Breath.** The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 24 Constitution saving throw, taking 67 (15d8) cold damage on a failed save, or half as much damage on a successful one.\n\n **Paralyzing Breath.** The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a DC 24 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 5,
     "parent": "srd_ancient-silver-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-silver-dragon_breath-weapons"
@@ -2884,12 +2884,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 72 (16d8) cold damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Cold Breath",
     "order": 5,
     "parent": "srd_ancient-white-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_ancient-white-dragon_cold-breath"
@@ -3664,12 +3664,12 @@
     "action_type": "ACTION",
     "desc": "The behir exhales a line of lightning that is 20 ft. long and 5 ft. wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Lightning Breath",
     "order": 3,
     "parent": "srd_behir",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_behir_lightning-breath"
@@ -3769,12 +3769,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (5d8) acid damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Acid Breath",
     "order": 1,
     "parent": "srd_black-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_black-dragon-wyrmling_acid-breath"
@@ -3889,12 +3889,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Lightning Breath",
     "order": 1,
     "parent": "srd_blue-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_blue-dragon-wyrmling_lightning-breath"
@@ -3979,12 +3979,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 14 (4d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 1,
     "parent": "srd_brass-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_brass-dragon-wyrmling_breath-weapons"
@@ -4009,12 +4009,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Lightning Breath.** The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 16 (3d10) lightning damage on a failed save, or half as much damage on a successful one.\n**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 12 Strength saving throw. On a failed save, the creature is pushed 30 feet away from the dragon.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 1,
     "parent": "srd_bronze-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_bronze-dragon-wyrmling_breath-weapons"
@@ -4309,12 +4309,12 @@
     "action_type": "ACTION",
     "desc": "The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 31 (7d8) fire damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Fire Breath",
     "order": 4,
     "parent": "srd_chimera",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_chimera_fire-breath"
@@ -4639,12 +4639,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Acid Breath.** The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 18 (4d8) acid damage on a failed save, or half as much damage on a successful one.\n**Slowing Breath.** The dragon exhales gas in a 1 5-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 1,
     "parent": "srd_copper-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_copper-dragon-wyrmling_breath-weapons"
@@ -7189,12 +7189,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 22 (4d10) fire damage on a failed save, or half as much damage on a successful one.\n**Weakening Breath.** The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 1,
     "parent": "srd_gold-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_gold-dragon-wyrmling_breath-weapons"
@@ -7279,12 +7279,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 11 Constitution saving throw, taking 21 (6d6) poison damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Poison Breath",
     "order": 1,
     "parent": "srd_green-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_green-dragon-wyrmling_poison-breath"
@@ -7564,12 +7564,12 @@
     "action_type": "ACTION",
     "desc": "The veteran exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Fire Breath",
     "order": 4,
     "parent": "srd_half-red-dragon-veteran",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_half-red-dragon-veteran_fire-breath"
@@ -7729,12 +7729,12 @@
     "action_type": "ACTION",
     "desc": "The hound exhales fire in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Fire Breath",
     "order": 1,
     "parent": "srd_hell-hound",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_hell-hound_fire-breath"
@@ -8254,12 +8254,12 @@
     "action_type": "ACTION",
     "desc": "The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Poison Breath",
     "order": 3,
     "parent": "srd_iron-golem",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 6,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_iron-golem_poison-breath"
@@ -8854,12 +8854,12 @@
     "action_type": "ACTION",
     "desc": "The mephit exhales a 15-foot cone of fire. Each creature in that area must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Fire Breath",
     "order": 1,
     "parent": "srd_magma-mephit",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 6,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_magma-mephit_fire-breath"
@@ -10519,12 +10519,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Fire Breath",
     "order": 1,
     "parent": "srd_red-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_red-dragon-wyrmling_fire-breath"
@@ -11194,12 +11194,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Cold Breath.** The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a DC 13 Constitution saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one.\n**Paralyzing Breath.** The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 1,
     "parent": "srd_silver-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_silver-dragon-wyrmling_breath-weapons"
@@ -13249,12 +13249,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a DC 12 Constitution saving throw, taking 22 (5d8) cold damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Cold Breath",
     "order": 1,
     "parent": "srd_white-dragon-wyrmling",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_white-dragon-wyrmling_cold-breath"
@@ -13373,8 +13373,8 @@
     "name": "Cold Breath",
     "order": 1,
     "parent": "srd_winter-wolf",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_winter-wolf_cold-breath"
@@ -13549,12 +13549,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 49 (11d8) acid damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Acid Breath",
     "order": 3,
     "parent": "srd_young-black-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-black-dragon_acid-breath"
@@ -13643,8 +13643,8 @@
     "name": "Lightning Breath",
     "order": 3,
     "parent": "srd_young-blue-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-blue-dragon_lightning-breath"
@@ -13684,12 +13684,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 42 (12d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 3,
     "parent": "srd_young-brass-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-brass-dragon_breath-weapons"
@@ -13744,12 +13744,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Lightning Breath.** The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 15 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one.\n**Repulsion Breath.** The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 15 Strength saving throw. On a failed save, the creature is pushed 40 feet away from the dragon.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 3,
     "parent": "srd_young-bronze-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-bronze-dragon_breath-weapons"
@@ -13804,12 +13804,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Acid Breath.** The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 40 (9d8) acid damage on a failed save, or half as much damage on a successful one.\n**Slowing Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 3,
     "parent": "srd_young-copper-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-copper-dragon_breath-weapons"
@@ -13864,12 +13864,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 55 (10d10) fire damage on a failed save, or half as much damage on a successful one.\n**Weakening Breath.** The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 3,
     "parent": "srd_young-gold-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-gold-dragon_breath-weapons"
@@ -13954,12 +13954,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a DC 14 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Poison Breath",
     "order": 3,
     "parent": "srd_young-green-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-green-dragon_poison-breath"
@@ -13999,12 +13999,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Fire Breath",
     "order": 3,
     "parent": "srd_young-red-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-red-dragon_fire-breath"
@@ -14044,12 +14044,12 @@
     "action_type": "ACTION",
     "desc": "The dragon uses one of the following breath weapons.\n**Cold Breath.** The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 17 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one.\n**Paralyzing Breath.** The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Breath Weapons",
     "order": 3,
     "parent": "srd_young-silver-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-silver-dragon_breath-weapons"
@@ -14119,12 +14119,12 @@
     "action_type": "ACTION",
     "desc": "The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 15 Constitution saving throw, taking 45 (10d8) cold damage on a failed save, or half as much damage on a successful one.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Cold Breath",
     "order": 3,
     "parent": "srd_young-white-dragon",
-    "uses_param": null,
-    "uses_type": null
+    "uses_param": 5,
+    "uses_type": "RECHARGE_ON_ROLL"
   },
   "model": "api_v2.creatureaction",
   "pk": "srd_young-white-dragon_cold-breath"


### PR DESCRIPTION
## Description

This PR fixes errors in the `SRD-2014` CreatureAction data. All dragon breath weapons were missing their recharge information, this has now been added in.

One of the test cases needed to be updated to accurately reflect the correct shape of the new data returned by the API.

## Related Issue

Closes #848 

## How was this tested?
- Spot checked on local Django dev server
- `pytest` (all tests green)