### PR TITLE
Fixed markdown errors in Creature Spellcasting actions/traits

### DIFF
--- a/data/v2/en-publishing/a5e-mm/CreatureAction.json
+++ b/data/v2/en-publishing/a5e-mm/CreatureAction.json
@@ -7099,15 +7099,15 @@
     "action_type": "LEGENDARY_ACTION",
     "desc": "The ankheg regains the spent legendary action at the start of its turn.",
     "form_condition": null,
-    "legendary_cost": 1,
-    "name": "The ankhegqueenhas 1 legendary action it can take at the end of another creatures turn",
+    "legendary_cost": null,
+    "name": "The Ankheg Queen has 1 legendary action it can take at the end of another creatures turn",
     "order": 0,
     "parent": "a5e-mm_ankheg-queen",
     "uses_param": null,
     "uses_type": null
   },
   "model": "api_v2.creatureaction",
-  "pk": "a5e-mm_ankheg-queen_the-ankhegqueenhas-1-legendary-action-it-can-take-at-the-end-of-another-creatures-turn"
+  "pk": "a5e-mm_ankheg-queen_legendary-action-count"
 },
 {
   "fields": {

--- a/data/v2/en-publishing/a5e-mm/CreatureTrait.json
+++ b/data/v2/en-publishing/a5e-mm/CreatureTrait.json
@@ -21,7 +21,7 @@
 },
 {
   "fields": {
-    "desc": "The aboleths spellcasting ability is Charisma (spell save DC 16). It can innately cast the following spells, requiring no components: 3/day each: detect thoughts (range 120 ft, desc: ), project image (range 1 mile), phantasmal force",
+    "desc": "The aboleths spellcasting ability is Charisma (spell save DC 16). It can innately cast the following spells, requiring no components:\n- **3/Day Each:** Detect Thoughts (range 120 ft), Project Image (range 1 mile), Phantasmal Force",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_aboleth",
     "type": null
@@ -91,7 +91,7 @@
 },
 {
   "fields": {
-    "desc": "The naga is an 11th level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16). The naga has the following cleric spells prepared\n which it can cast with only vocalized components:\n Cantrips (at will): mending\n thaumaturgy\n 1st-level (4 slots): command\n cure wounds\n false life\n 2nd-level (3 slots): calm emotions\n hold person\n locate object\n 3rd-level (3 slots) clairvoyance\n create food and water\n 4th-level (3 slots): divination\n freedom of movement\n 5th-level (2 slots): flame strike\n geas\n scrying\n 6th-level (1 slot): forbiddance",
+    "desc": "The naga is an 11th level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16). The Naga has the following cleric spells prepared which it can cast with only vocalized components:\n\n- **Cantrips** (at will): Mending, Thaumaturgy\n- **1st-Level** (4 slots): Command, Cure Wounds, False Life\n- **2nd-Level** (3 slots): Calm Emotions, Hold Person, Locate Object\n- **3rd-Level** (3 slots): Clairvoyance, Create Food and Water\n- **4th-Level** (3 slots): Divination, Freedom of Movement\n- **5th-Level** (2 slots): Flame Strike, Geas, Scrying\n- **6th-Level** (1 slot): Forbiddance",
     "name": "Spellcasting",
     "parent": "a5e-mm_accursed-guardian-naga",
     "type": null
@@ -121,7 +121,7 @@
 },
 {
   "fields": {
-    "desc": "The acolyte is a 2nd level spellcaster. Their spellcasting ability is Wisdom (spell save DC 12\n +4 to hit with spell attacks). They have the following cleric spells prepared:\n Cantrips (at will): light\n sacred flame\n thaumaturgy\n 1st-level (3 slots): bless\n cure wounds\n sanctuary",
+    "desc": "The acolyte is a 2nd level spellcaster. Their spellcasting ability is Wisdom (spell save DC 12 +4to hit with spell attacks). They have the following cleric spells prepared:\n\n- **Cantrips** (at will): Light, Sacred Flame, Thaumaturgy\n- **1st-Level** (3 slots): Bless, Cure Wounds, Sanctuary",
     "name": "Spellcasting",
     "parent": "a5e-mm_acolyte",
     "type": null
@@ -141,7 +141,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:calm emotions, charm person, mass suggestion, modify memory",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Calm Emotions, Charm Person, Mass Suggestion, Modify Memory",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-amethyst-dragon",
     "type": null
@@ -181,7 +181,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components. 3/day each: animate dead, fog cloud, legend lore, pass without trace, speak with dead",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Animate Dead, Fog Cloud, Legend Lore, Pass Without Trace, Speak with Dead",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-black-dragon-lich",
     "type": null
@@ -211,7 +211,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components. 3/day each:fog cloud, pass without trace, legend lore, speak with dead",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Fog Cloud, Pass Without Trace, Legend Lore, Speak with Dead",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-black-dragon",
     "type": null
@@ -261,7 +261,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components. 3/day each:blur, silent image, blight, hypnotic pattern",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Blur, Silent Image, Blight, Hypnotic Pattern",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-blue-dragon",
     "type": null
@@ -281,7 +281,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 16). It can innately cast the following spells, requiring no material components. 3/day each:comprehend languages, identify, commune, legend lore",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 16). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**comprehend languages, Identify, Commune, Legend Lore",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-brass-dragon",
     "type": null
@@ -331,7 +331,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components. 3/day each:fog cloud, speak with animals,commune with nature, speak with plants",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Fog Cloud, Speak with Animals, Commune with Nature, speak with plants",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-bronze-dragon",
     "type": null
@@ -351,7 +351,7 @@
 },
 {
   "fields": {
-    "desc": "The dragon can accurately predict the weather up to 7 days in advance and is never considered surprised while conscious. Additionally, by submerging itself in a body of water and spending 1 minute in concentration, it can cast scrying, requiring no components. The scrying orb appears in a space in the same body of water.",
+    "desc": "The dragon can accurately predict the weather up to 7 days in advance and is never considered surprised while conscious. Additionally, by submerging itself in a body of water and spending 1 minute in concentration, it can cast Scrying, requiring no components. The Scrying orb appears in a space in the same body of water.",
     "name": "Oracle of the Coast",
     "parent": "a5e-mm_adult-bronze-dragon",
     "type": null
@@ -371,7 +371,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components. 3/day each:hideous laughter, suggestion, mislead, polymorph",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Hideous Laughter, Suggestion, Mislead, Polymorph",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-copper-dragon",
     "type": null
@@ -421,7 +421,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components. 3/day each:locate animals or plants, spike growth, stone shape, wall of stone",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Locate Animals or Plants, Spike Growth, Stone Shape, wall of stone",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-earth-dragon",
     "type": null
@@ -451,7 +451,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components. 3/day each:confusion, dominate person, hideous laughter, suggestion",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Confusion, Dominate Person, Hideous Laughter, Suggestion",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-emerald-dragon",
     "type": null
@@ -481,7 +481,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 21). It can innately cast the following spells, requiring no material components. 3/day each:bless, healing word,banishment, greater restoration",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 21). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Bless, Healing Word, Banishment, Greater Restoration",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-gold-dragon",
     "type": null
@@ -521,7 +521,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components. 3/day each:animal messenger, tongues, modify memory, scrying",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Animal Messenger, Tongues, Modify Memory, Scrying",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-green-dragon",
     "type": null
@@ -551,7 +551,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:command, hold person, glyph of warding, wall of fire",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Command, Hold Person, glyph of warding, Wall of Fire",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-red-dragon",
     "type": null
@@ -621,7 +621,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components. 3/day each:create or destroy water, fog cloud, control water, freedom of movement",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Create or Destroy Water, Fog Cloud, Control Water, Freedom of Movement",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-river-dragon",
     "type": null
@@ -661,7 +661,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components. 3/day each:comprehend languages, detect thoughts, telekinesis, wall of force",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**comprehend languages, Detect Thoughts, Telekinesis, wall of force",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-sapphire-dragon",
     "type": null
@@ -731,7 +731,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 20). It can innately cast the following spells, requiring no material components. 3/day each:darkness, detect evil and good, bane, create undead",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 20). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Darkness, Detect Evil and Good, Bane, Create Undead",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-shadow-dragon",
     "type": null
@@ -761,7 +761,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:charm person, faerie fire,awaken, geas",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n\n- **3/Day Each:** Charm Person, Faerie Fire, Awaken, Geas",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-silver-dragon",
     "type": null
@@ -791,7 +791,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components. 3/day each:dominate beast, fire shield, animal friendship, sleet storm",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Dominate Beast, Fire Shield, Animal Friendship, Sleet Storm",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_adult-white-dragon",
     "type": null
@@ -841,7 +841,7 @@
 },
 {
   "fields": {
-    "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, can't travel to or from the Material Plane)",
+    "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Charm Person, Command, Telekinesis\n- **3/Day**:  Flame Strike, Hold Monster, Lightning Bolt\n- **1/Day:** Commune, Greater Restoration, Heroes Feast, Plane Shift (self only, can't travel to or from the Material Plane)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_aklea",
     "type": null
@@ -912,7 +912,7 @@
 {
   "fields": {
     "desc": "For 1 hour, the drinker can breathe underwater",
-    "name": "Potion of water breathing",
+    "name": "Potion of Water Breathing",
     "parent": "a5e-mm_alchemist",
     "type": null
   },
@@ -981,7 +981,7 @@
 },
 {
   "fields": {
-    "desc": "The aboleths spellcasting ability is Charisma (spell save DC 16). It can innately cast the following spells, requiring no components: 3/day each: detect thoughts (range 120 ft, desc: ), project image (range 1 mile), phantasmal force",
+    "desc": "The aboleths spellcasting ability is Charisma (spell save DC 16). It can innately cast the following spells, requiring no components:\n- **3/Day Each:** Detect Thoughts (range 120 ft), Project Image (range 1 mile), Phantasmal Force",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-aboleth",
     "type": null
@@ -1001,7 +1001,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 22). It can innately cast the following spells, requiring no material components. 3/day each:calm emotions, charm person, mass suggestion, modify memory,  1/day:plane shift, project image",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 22). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Calm Emotions, Charm Person, Mass Suggestion, Modify Memory\n- **1/Day:** Plane Shift, Project Image",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-amethyst-dragon",
     "type": null
@@ -1051,7 +1051,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:fog cloud, pass without trace, legend lore, speak with dead,  1/day each: create undead, insect plague",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Fog Cloud, Pass Without Trace, Legend Lore, Speak with Dead\n- **1/Day Each:** Create Undead, insect plague",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-black-dragon",
     "type": null
@@ -1101,7 +1101,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 21). It can innately cast the following spells, requiring no material components. 3/day each:blur, silent image, blight, hypnotic pattern,  1/day each:control water, mirage arcane",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 21). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Blur, Silent Image, Blight, Hypnotic Pattern \n- **1/Day Each:** Control Water, mirage arcane",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-blue-dragon",
     "type": null
@@ -1121,7 +1121,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:comprehend languages, identify, commune, legend lore,  1/day:teleport, true seeing",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n\n- **3/Day Each:** comprehend languages, Identify, Commune, Legend Lore\n- **1/Day:** Teleport, True Seeing",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-brass-dragon",
     "type": null
@@ -1171,7 +1171,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 20). It can innately cast the following spells, requiring no material components. 3/day each:fog cloud, speak with animals,commune with nature, speak with plants,  1/day:control weather, etherealness",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 20). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Fog Cloud, Speak with Animals, Commune with Nature, speak with plants, \n- **1/Day:** Control Weather, etherealness",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-bronze-dragon",
     "type": null
@@ -1191,7 +1191,7 @@
 },
 {
   "fields": {
-    "desc": "The dragon can accurately predict the weather up to 7 days in advance and is never considered surprised while conscious. Additionally, by submerging itself in a body of water and spending 1 minute in concentration, it can cast scrying, requiring no components. The scrying orb appears in a space in the same body of water.",
+    "desc": "The dragon can accurately predict the weather up to 7 days in advance and is never considered surprised while conscious. Additionally, by submerging itself in a body of water and spending 1 minute in concentration, it can cast Scrying, requiring no components. The Scrying orb appears in a space in the same body of water.",
     "name": "Oracle of the Coast",
     "parent": "a5e-mm_ancient-bronze-dragon",
     "type": null
@@ -1211,7 +1211,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:hideous laughter, suggestion, mislead, polymorph,  1/day:irresistible dance, mass suggestion",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Hideous Laughter, Suggestion, Mislead, Polymorph\n- **1/Day:** Irresistible Dance, Mass Suggestion",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-copper-dragon",
     "type": null
@@ -1261,7 +1261,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components. 3/day each:locate animals or plants, spike growth, stone shape, wall of stone,  1/day:earthquake, move earth",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Locate Animals or Plants, Spike Growth, Stone Shape, wall of stone,\n- **1/Day:** earthquake, Move Earth",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-earth-dragon",
     "type": null
@@ -1291,7 +1291,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 21). It can innately cast the following spells, requiring no material components. 3/day each:confusion, dominate person, hideous laughter, suggestion,  1/day:irresistible dance, symbol",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 21). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Confusion, Dominate Person, Hideous Laughter, Suggestion\n- **1/Day:** Irresistible Dance, Symbol",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-emerald-dragon",
     "type": null
@@ -1321,7 +1321,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 25). It can innately cast the following spells, requiring no material components. 3/day each:bless, healing word,banishment, greater restoration,  1/day:divine word, hallow",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 25). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Bless, Healing Word, Banishment, Greater Restoration,\n- **1/Day:** Divine Word, Hallow",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-gold-dragon",
     "type": null
@@ -1371,7 +1371,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:animal messenger, tongues, modify memory, scrying,  1/day:mass suggestion, telepathic bond",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Animal Messenger, Tongues, Modify Memory, Scrying\n- **1/Day:** Mass Suggestion, Telepathic Bond",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-green-dragon",
     "type": null
@@ -1401,7 +1401,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 22). It can innately cast the following spells, requiring no material components. 3/day each:command, hold person, glyph of warding, wall of fire,  1/day each:antimagic field, dominate monster",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 22). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Command, Hold Person, glyph of warding, Wall of Fire\n- **1/Day Each:** Antimagic Field, Dominate Monster",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-red-dragon",
     "type": null
@@ -1471,7 +1471,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 20). It can innately cast the following spells, requiring no material components. 3/day each:create or destroy water, fog cloud, control water, freedom of movement,  1/day each:control weather, wall of ice",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 20). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Create or Destroy Water, Fog Cloud, Control Water, Freedom of Movement\n- **1/Day Each:** Control Weather, Wall of Ice",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-river-dragon",
     "type": null
@@ -1511,7 +1511,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 20). It can innately cast the following spells, requiring no material components. 3/day each:comprehend languages, detect thoughts, telekinesis, wall of force,  1/day:etherealness, mind blank",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 20). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**comprehend languages, Detect Thoughts, Telekinesis, wall of force,\n- **1/Day:** etherealness, Mind Blank",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-sapphire-dragon",
     "type": null
@@ -1581,7 +1581,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 23). It can innately cast the following spells, requiring no material components. 3/day each:darkness, detect evil and good, bane, create undead,  1/day:hallow, magic jar",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 23). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Darkness, Detect Evil and Good, Bane, Create Undead,\n- **1/Day:** Hallow, Magic Jar",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-shadow-dragon",
     "type": null
@@ -1611,7 +1611,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 23). It can innately cast the following spells, requiring no material components. 3/day each:charm person, faerie fire,awaken, geas,  1/day:heroes feast, telepathic bond",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 23). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Charm Person, Faerie Fire, Awaken, Geas\n- **1/Day:** Heroes Feast, Telepathic Bond",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-silver-dragon",
     "type": null
@@ -1641,7 +1641,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components. 3/day each:dominate beast, fire shield, animal friendship, sleet storm,  1/day each:control weather, wall of ice",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Dominate Beast, Fire Shield, Animal Friendship, Sleet Storm\n- **1/Day Each:** Control Weather, Wall of Ice",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ancient-white-dragon",
     "type": null
@@ -1671,7 +1671,7 @@
 },
 {
   "fields": {
-    "desc": "The DC for dispel magic to destroy this creature is 19.",
+    "desc": "The DC for Dispel Magic to destroy this creature is 19.",
     "name": "Spell-created",
     "parent": "a5e-mm_animated-armor",
     "type": null
@@ -1681,7 +1681,7 @@
 },
 {
   "fields": {
-    "desc": "The apprentice mage is a 2nd level spellcaster. Their spellcasting ability is Intelligence (spell save DC 12\n +4 to hit with spell attacks). They have the following wizard spells prepared:\n Cantrips (at will): fire bolt\n light\n prestidigitation\n 1st-level (3 slots): detect magic\n magic missile\n shield",
+    "desc": "The apprentice mage is a 2nd level spellcaster. Their spellcasting ability is Intelligence (spell save DC 12 +4 to hit with spell attacks). They have the following wizard spells prepared:\n\n- **Cantrips** (at will): Fire Bolt, Light, Prestidigitation\n- **1st-Level** (3 slots): Detect Magic, Magic Missile, Shield",
     "name": "Spellcasting",
     "parent": "a5e-mm_apprentice-mage",
     "type": null
@@ -1711,7 +1711,7 @@
 },
 {
   "fields": {
-    "desc": "The arcane blademaster is a 20th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 19\n +11 to hit with spell attacks). The arcane blademaster has the following wizard spells prepared:\n Cantrips (at will): acid splash\n fire bolt\n shocking grasp\n true strike\n 1st-level (4 slots): burning hands\n charm person\n magic missile\n sleep\n 2nd-level (3 slots): magic weapon\n misty step\n see invisibility\n 3rd-level (3 slots): dispel magic\n fireball\n fly\n lightning bolt\n tongues\n 4th-level (3 slots): fire shield\n stoneskin\n wall of fire\n 5th-level (3 slots): cone of cold\n conjure elemental\n hold monster\n telekinesis\n 6th-level (2 slots): globe of invulnerability\n sunbeam\n 7th-level (2 slots): teleport\n unholy star\n 8th-level (1 slot): power word stun\n 9th-level (1 slot): meteor swarm",
+    "desc": "The arcane blademaster is a 20th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 19 +11 to hit with spell attacks). The arcane blademaster has the following wizard spells prepared:\n\n- **Cantrips** (at will): Acid Splash, Fire Bolt, Shocking Grasp, true strike\n- **1st-Level** (4 slots): Burning Hands, Charm Person, Magic Missile, sleep\n- **2nd-Level** (3 slots): Magic Weapon, Misty Step, See Invisibility\n- **3rd-Level** (3 slots): Dispel Magic, Fireball, fly, Lightning Bolt, Tongues\n- **4th-Level** (3 slots): Fire Shield, stoneskin, Wall of Fire\n- **5th-level** (3 slots): Cone of Cold, Conjure Elemental, Hold Monster, Telekinesis\n- **6th-level** (2 slots): Globe of Invulnerability, Sunbeam\n- **7th-Level** (2 slots): Teleport, Unholy Star\n- **8th-Level** (1 slot): Power Word Stun\n- **9th-Level** (1 slot): Meteor Swarm",
     "name": "Spellcasting",
     "parent": "a5e-mm_arcane-blademaster",
     "type": null
@@ -1761,7 +1761,7 @@
 },
 {
   "fields": {
-    "desc": "The archfeys spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components: At will: animal messenger, detect evil and good, detect magic, disguise self, 3/day each: charm person, scrying, zone of truth, 1/day each: dream, geas, heroes feast, magic circle, polymorph (self only)",
+    "desc": "The archfeys spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Animal Messenger, Detect Evil and Good, Detect Magic, Disguise Self\n- **3/Day Each:** Charm Person, Scrying, Zone of Truth,\n- **1/Day Each:** Dream, Geas, Heroes Feast, Magic Circle, Polymorph (self only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_archfey",
     "type": null
@@ -1781,7 +1781,7 @@
 },
 {
   "fields": {
-    "desc": "When the mind blank spell is active, the archmage is immune to psychic damage, any effect that would read their emotions or thoughts, divination spells, and the charmed condition.",
+    "desc": "When the Mind Blank spell is active, the archmage is immune to psychic damage, any effect that would read their emotions or thoughts, divination spells, and the charmed condition.",
     "name": "Mind Blank",
     "parent": "a5e-mm_archmage",
     "type": null
@@ -1791,7 +1791,7 @@
 },
 {
   "fields": {
-    "desc": "The archmage is an 18th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 17\n +9 to hit with spell attacks). The archmage can cast shield at level 1 and alter self at level 2 without expending a spell slot. They have the following wizard spells prepared:\n Cantrips (at will): fire bolt\n light\n mage hand\n message\n prestidigitation\n 1st-level (4 slots): detect magic\n identify\n mage armor\n shield\n 2nd-level (4 slots): alter self\n detect thoughts\n suggestion\n 3rd-level (3 slots): counterspell\n lightning bolt\n sending\n 4th-level (3 slots): confusion\n hallucinatory terrain\n locate creature\n 5th-level (3 slots): cone of cold\n mislead\n scrying\n 6th-level (1 slot): globe of invulnerability\n true seeing\n 7th-level (1 slot): teleport\n 8th-level (1 slot): mind blank\n 9th-level (1 slot): foresight",
+    "desc": "The archmage is an 18th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 17 +9 to hit with spell attacks). The archmage can cast shield at level 1 and Alter Self at level 2 without expending a spell slot. They have the following wizard spells prepared:\n\n- **Cantrips** (at will): Fire Bolt, Light, Mage Hand, Message, Prestidigitation\n- **1st-Level** (4 slots): Detect Magic, Identify, Mage Armor, Shield\n- **2nd-Level** (4 slots): Alter Self, Detect Thoughts, Suggestion\n- **3rd-Level** (3 slots): Counterspell, Lightning Bolt, Sending\n- **4th-Level** (3 slots): Confusion, Hallucinatory Terrain, Locate Creature\n- **5th-Level** (3 slots): Cone of Cold, Mislead, Scrying\n- **6th-Level** (1 slot): Globe of Invulnerability, True Seeing\n- **7th-Level** (1 slot): Teleport\n- **8th-Level** (1 slot): Mind Blank\n- **9th-Level** (1 slot): Foresight",
     "name": "Spellcasting",
     "parent": "a5e-mm_archmage",
     "type": null
@@ -1821,7 +1821,7 @@
 },
 {
   "fields": {
-    "desc": "The archpriest is a 20th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 18\n +10 to hit with spell attacks). The archpriest has the following cleric spells prepared.\n Cantrips (at will): light\n mending\n sacred flame\n spare the dying\n thaumaturgy\n 1st-level (4 slots): bane\n bless\n cure wounds\n inflict wounds\n 2nd-level (3 slots): hold person\n lesser restoration\n spiritual weapon\n 3rd-level (3 slots): bestow curse\n dispel magic\n revivify\n 4th-level (3 slots): banishment\n guardian of faith\n stone shape\n 5th-level (3 slots): contagion\n flame strike\n greater restoration\n mass cure wounds\n 6th-level (2 slots): blade barrier\n planar ally\n true seeing\n 7th-level (2 slots): conjure celestial\n divine word\n fire storm\n 8th-level (1 slot): antimagic field\n 9th-level (1 slot): mass heal",
+    "desc": "The archpriest is a 20th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 18 +10 to hit with spell attacks). The archpriest has the following cleric spells prepared.\n\n- **Cantrips** (at will): Light, Mending, Sacred Flame, Spare the Dying, Thaumaturgy\n- **1st-Level** (4 slots): Bane, Bless, Cure Wounds, Inflict Wounds\n- **2nd-Level** (3 slots): Hold Person, Lesser Restoration, Spiritual Weapon\n- **3rd-Level** (3 slots): Bestow Curse, Dispel Magic, Revivify\n- **4th-Level** (3 slots): Banishment, Guardian of Faith, Stone Shape\n- **5th-Level** (3 slots): Contagion, Flame Strike, Greater Restoration, Mass Cure Wounds\n- **6th-Level** (2 slots): Blade Barrier, Planar Ally, True Seeing\n- **7th-Level** (2 slots): Conjure Celestial, Divine Word, Fire Storm\n- **8th-Level** (1 slot): Antimagic Field\n- **9th-Level** (1 slot): Mass Heal",
     "name": "Spellcasting",
     "parent": "a5e-mm_archpriest",
     "type": null
@@ -2141,7 +2141,7 @@
 },
 {
   "fields": {
-    "desc": "If defeated in combat, the banshee returns on the anniversary of its death. It can be permanently put to rest only by finding and casting remove curse on its grave or by righting whatever wrong was done to it.",
+    "desc": "If defeated in combat, the banshee returns on the anniversary of its death. It can be permanently put to rest only by finding and casting Remove Curse on its grave or by righting whatever wrong was done to it.",
     "name": "Unquiet Spirit",
     "parent": "a5e-mm_banshee",
     "type": null
@@ -2941,7 +2941,7 @@
 },
 {
   "fields": {
-    "desc": "The giants spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components: At will: detect magic, fog cloud, light, 3/day each: feather fall, fly, misty step, telekinesis, 1/day each: control weather, gaseous form",
+    "desc": "The giants spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Detect Magic, Fog Cloud, light,\n- **3/Day Each:** feather fall, fly, Misty Step, Telekinesis\n- **1/Day Each:** Control Weather, Gaseous Form",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_cloud-giant-noble",
     "type": null
@@ -2961,7 +2961,7 @@
 },
 {
   "fields": {
-    "desc": "The giants spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components: At will: detect magic, fog cloud, light, 3/day each: feather fall, fly, misty step, telekinesis, 1/day each: control weather, gaseous form",
+    "desc": "The giants spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Detect Magic, Fog Cloud, light,\n- **3/Day Each:** feather fall, fly, Misty Step, Telekinesis\n- **1/Day Each:** Control Weather, Gaseous Form",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_cloud-giant",
     "type": null
@@ -3101,7 +3101,7 @@
 },
 {
   "fields": {
-    "desc": "The couatls spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components: At will: detect evil and good, detect magic, 3/day each: create food and water, detect thoughts, lesser restoration, 1/day each: dream, greater restoration, scrying",
+    "desc": "The couatls spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Detect Evil and Good, Detect Magic,\n- **3/Day Each:** Create Food and Water, Detect Thoughts, Lesser Restoration\n- **1/Day Each:** Dream, Greater Restoration, Scrying",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_couatl",
     "type": null
@@ -3121,7 +3121,7 @@
 },
 {
   "fields": {
-    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components: At will: dancing lights, disguise self, invisibility, minor illusion, 1/day: geas",
+    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** dancing lights, Disguise Self, Invisibility, Minor Illusion\n- **1/Day:**  Geas",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_coven-green-hag",
     "type": null
@@ -3171,7 +3171,7 @@
 },
 {
   "fields": {
-    "desc": "A creature that makes a bargain with the hag is magically cursed for 30 days. While it is cursed, the target automatically fails saving throws against the hags scrying and geas spells, and the hag can cast control weather centered on the creature.",
+    "desc": "A creature that makes a bargain with the hag is magically cursed for 30 days. While it is cursed, the target automatically fails saving throws against the hags Scrying and Geas spells, and the hag can cast Control Weather centered on the creature.",
     "name": "Curse",
     "parent": "a5e-mm_coven-sea-hag",
     "type": null
@@ -3181,7 +3181,7 @@
 },
 {
   "fields": {
-    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components: At will: dancing lights, disguise self, 1/day: control weather, geas, scrying",
+    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** dancing lights, Disguise Self\n- **1/Day:** Control Weather, Geas, Scrying",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_coven-sea-hag",
     "type": null
@@ -3191,7 +3191,7 @@
 },
 {
   "fields": {
-    "desc": "A creature that accepts a gift from the hag is magically cursed for 30 days. While it is cursed, the target automatically fails saving throws against the hags charm person, geas, and scrying spells, and the hag can cast control weather centered on the creature.",
+    "desc": "A creature that accepts a gift from the hag is magically cursed for 30 days. While it is cursed, the target automatically fails saving throws against the hags Charm Person, Geas, and Scrying spells, and the hag can cast Control Weather centered on the creature.",
     "name": "Curse",
     "parent": "a5e-mm_coven-winter-hag",
     "type": null
@@ -3211,7 +3211,7 @@
 },
 {
   "fields": {
-    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components: At will: charm person, dancing lights, invisibility, minor illusion, passwall (ice only), 1/day: control weather (extreme cold), geas, scrying, 1/day each: cone of cold, wall of ice",
+    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Charm Person, dancing lights, Invisibility, Minor Illusion, Passwall (ice only)\n- **1/Day:** Control Weather (extreme cold), Geas, Scrying\n- **1/Day Each:** Cone of Cold, Wall of Ice",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_coven-winter-hag",
     "type": null
@@ -3271,7 +3271,7 @@
 },
 {
   "fields": {
-    "desc": "The cult fanatic is a 4th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 12\n +4 to hit with spell attacks). They have the following cleric spells prepared:\n Cantrips (at will): light\n sacred flame\n thaumaturgy\n 1st-level (4 slots): ceremony\n command\n detect evil and good\n inflict wounds\n 2nd-level (3 slots): blindness/deafness\n hold person",
+    "desc": "The cult fanatic is a 4th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 12 +4 to hit with spell attacks). They have the following cleric spells prepared:\n\n- **Cantrips** (at will): Light, Sacred Flame, Thaumaturgy\n- **1st-Level** (4 slots): Ceremony, Command, Detect Evil and Good, Inflict Wounds\n- **2nd-Level** (3 slots): Blindness/Deafness, Hold Person",
     "name": "Spellcasting",
     "parent": "a5e-mm_cult-fanatic",
     "type": null
@@ -3411,7 +3411,7 @@
 },
 {
   "fields": {
-    "desc": "The deep dwarf can innately cast enlarge/reduce (self only, enlarge only) and invisibility (self only) once per long rest without using material components, using Intelligence for their spellcasting ability.",
+    "desc": "The deep dwarf can innately cast enlarge/reduce (self only, enlarge only) and Invisibility (self only) once per long rest without using material components, using Intelligence for their spellcasting ability.",
     "name": "Deep Dwarf Magic",
     "parent": "a5e-mm_deep-dwarf-soldier",
     "type": null
@@ -3441,7 +3441,7 @@
 },
 {
   "fields": {
-    "desc": "The deep gnome can innately cast blindness/deafness (blindness only), disguise self, and nondetection once per long rest without using material components, using Intelligence for their spellcasting ability.",
+    "desc": "The deep gnome can innately cast blindness/deafness (blindness only), Disguise Self, and nondetection once per long rest without using material components, using Intelligence for their spellcasting ability.",
     "name": "Deep Gnome Magic",
     "parent": "a5e-mm_deep-gnome-scout",
     "type": null
@@ -3651,7 +3651,7 @@
 },
 {
   "fields": {
-    "desc": "The divis innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components: At will: alter self (can assume Medium or Large form), detect magic, stone shape, 3/day each: creation, move earth, passwall, tongues, 1/day each: conjure elemental (earth elemental only), plane shift (to Elemental Plane of Earth only)",
+    "desc": "The divis innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Alter Self (can assume Medium or Large form), Detect Magic, Stone Shape\n- **3/Day Each:** Creation, Move Earth, Passwall, Tongues,\n- **1/Day Each:** Conjure Elemental (earth elemental only), Plane Shift (to Elemental Plane of Earth only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_divi-noble",
     "type": null
@@ -3671,7 +3671,7 @@
 },
 {
   "fields": {
-    "desc": "The divis innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components: At will: alter self (can assume Medium or Large form), detect magic, stone shape, 3/day each: creation, move earth, passwall, tongues, 1/day each: conjure elemental (earth elemental only), plane shift (to Elemental Plane of Earth only)",
+    "desc": "The divis innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Alter Self (can assume Medium or Large form), Detect Magic, Stone Shape\n- **3/Day Each:** Creation, Move Earth, Passwall, Tongues\n- **1/Day Each:** Conjure Elemental (earth elemental only), Plane Shift (to Elemental Plane of Earth only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_divi",
     "type": null
@@ -3681,7 +3681,7 @@
 },
 {
   "fields": {
-    "desc": "The djinnis innate spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components: At will: alter self (can assume Medium or Large form), detect magic, wind wall, 3/day each: creation, major image, tongues, wind walk, 1/day each: conjure elemental (air elemental only), control weather, create food and water (10 supply), plane shift (to Elemental Plane of Air only)",
+    "desc": "The djinnis innate spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Alter Self (can assume Medium or Large form), Detect Magic, Wind Wall\n- **3/Day Each:** Creation, Major Image, Tongues, Wind Walk\n- **1/Day Each:** Conjure Elemental (air elemental only), Control Weather, Create Food and Water (10 supply), Plane Shift (to Elemental Plane of Air only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_djinni-noble",
     "type": null
@@ -3691,7 +3691,7 @@
 },
 {
   "fields": {
-    "desc": "The djinnis innate spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components: At will: alter self (can assume Medium or Large form), detect magic, wind wall, 3/day each: creation, major image, tongues, wind walk, 1/day each: conjure elemental (air elemental only), control weather, create food and water (10 supply), plane shift (to Elemental Plane of Air only)",
+    "desc": "The djinnis innate spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Alter Self (can assume Medium or Large form), Detect Magic, Wind Wall\n- **3/Day Each:** Creation, Major Image, Tongues, Wind Walk\n- **1/Day Each:** Conjure Elemental (air elemental only), Control Weather, Create Food and Water (10 supply), Plane Shift (to Elemental Plane of Air only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_djinni",
     "type": null
@@ -3721,7 +3721,7 @@
 },
 {
   "fields": {
-    "desc": "The cult fanatic is a 4th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 12\n +4 to hit with spell attacks). They have the following cleric spells prepared:\n Cantrips (at will): light\n sacred flame\n thaumaturgy\n 1st-level (4 slots): ceremony\n command\n detect evil and good\n inflict wounds\n 2nd-level (3 slots): blindness/deafness\n hold person",
+    "desc": "The cult fanatic is a 4th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 12 +4to hit with spell attacks). They have the following cleric spells prepared:\n\n- **Cantrips** (at will): Light, Sacred Flame, Thaumaturgy\n- **1st-Level** (4 slots): Ceremony, Command, Detect Evil and Good, Inflict Wounds\n- **2nd-Level** (3 slots): Blindness/Deafness, Hold Person",
     "name": "Spellcasting",
     "parent": "a5e-mm_dragon-cultist",
     "type": null
@@ -3741,7 +3741,7 @@
 },
 {
   "fields": {
-    "desc": "The dragon turtles spellcasting ability is Wisdom (spell save DC 17). It can innately cast the following spells, requiring no components: 3/day each: control weather, water breathing, zone of truth",
+    "desc": "The dragon turtles spellcasting ability is Wisdom (spell save DC 17). It can innately cast the following spells, requiring no components:\n- **3/Day Each:** Control Weather, Water Breathing, Zone of Truth",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_dragon-turtle",
     "type": null
@@ -3971,7 +3971,7 @@
 },
 {
   "fields": {
-    "desc": "The druid is a 4th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 12\n +4 to hit with spell attacks). They have the following druid spells prepared:\n Cantrips (at will): druidcraft\n produce flame\n shillelagh\n 1st-level (4 slots): entangle\n longstrider\n speak with animals\n thunderwave\n 2nd-level (3 slots): animal messenger\n barkskin",
+    "desc": "The druid is a 4th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 12 +4to hit with spell attacks). They have the following druid spells prepared:\n\n- **Cantrips** (at will): Druidcraft, Produce Flame, Shillelagh\n- **1st-Level** (4 slots): Entangle, Longstrider, Speak with Animals, Thunderwave\n- **2nd-Level** (3 slots): Animal Messenger, Barkskin",
     "name": "Spellcasting",
     "parent": "a5e-mm_druid",
     "type": null
@@ -4111,7 +4111,7 @@
 },
 {
   "fields": {
-    "desc": "The efreetis innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components: At will: alter self (can assume Medium or Large form), detect magic, 3/day each: creation, gaseous form, major image, tongues, 1/day each: conjure elemental (fire elemental only), plane shift (to Elemental Plane of Fire only)",
+    "desc": "The efreetis innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Alter Self (can assume Medium or Large form), Detect Magic,\n- **3/Day Each:** Creation, Gaseous Form, Major Image, Tongues\n- **1/Day Each:** Conjure Elemental (fire elemental only), Plane Shift (to Elemental Plane of Fire only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_efreeti-noble",
     "type": null
@@ -4121,7 +4121,7 @@
 },
 {
   "fields": {
-    "desc": "The efreetis innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components: At will: alter self (can assume Medium or Large form), detect magic, 3/day each: creation, gaseous form, major image, tongues, 1/day each: conjure elemental (fire elemental only), plane shift (to Elemental Plane of Fire only)",
+    "desc": "The efreetis innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Alter Self (can assume Medium or Large form), Detect Magic,\n- **3/Day Each:** Creation, Gaseous Form, Major Image, Tongues\n- **1/Day Each:** Conjure Elemental (fire elemental only), Plane Shift (to Elemental Plane of Fire only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_efreeti",
     "type": null
@@ -4221,7 +4221,7 @@
 },
 {
   "fields": {
-    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a bless, hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
+    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a Bless, Hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
     "name": "Resting Place",
     "parent": "a5e-mm_elder-vampire",
     "type": null
@@ -4271,7 +4271,7 @@
 },
 {
   "fields": {
-    "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, can't travel to or from the Material Plane)",
+    "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Charm Person, Command, Telekinesis\n- **3/Day**:  flame strike, Hold Monster, Lightning Bolt\n- **1/Day** Commune, Greater Restoration, Heroes Feast, Plane Shift (self only, can't travel to or from the Material Plane)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_empyrean",
     "type": null
@@ -4371,7 +4371,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons innate spellcasting ability is Charisma (spell save DC 13). It can innately cast spells, requiring no material components. The dragon gains additional spells as it ages. 5 years old, at will: dancing lights, mage hand, minor illusion, 10 years old, 1/day: suggestion, 30 years old, 1/day: major image, 50 years old, 1/day: hallucinatory terrain",
+    "desc": "The dragons innate spellcasting ability is Charisma (spell save DC 13). It can innately cast spells, requiring no material components. The dragon gains additional spells as it ages:\n\n- **5 years old, at will:** Dancing Lights, Mage Hand, Minor Illusion\n- **10 years old, 1/Day**: Suggestion\n- **30 years old, 1/Day**: Major Image\n- **50 years old, 1/Day**: Hallucinatory Terrain",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_faerie-dragon-familiar",
     "type": null
@@ -4381,7 +4381,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons innate spellcasting ability is Charisma (spell save DC 13). It can innately cast spells, requiring no material components. The dragon gains additional spells as it ages. 5 years old, at will: dancing lights, mage hand, minor illusion, 10 years old, 1/day: suggestion, 30 years old, 1/day: major image, 50 years old, 1/day: hallucinatory terrain",
+    "desc": "The dragons innate spellcasting ability is Charisma (spell save DC 13). It can innately cast spells, requiring no material components. The dragon gains additional spells as it ages:\n\n- **5 years old, at will:** Dancing Lights, Mage Hand, Minor Illusion\n- **10 years old, 1/Day**: Suggestion\n- **30 years old, 1/Day**: Major Image\n- **50 years old, 1/Day**: Hallucinatory Terrain",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_faerie-dragon",
     "type": null
@@ -4471,7 +4471,7 @@
 },
 {
   "fields": {
-    "desc": "The nobles spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components: At will: animal messenger, detect evil and good, detect magic, disguise self, 3/day each: charm person, scrying, zone of truth, 1/day each: dream, geas, heroes feast, magic circle, polymorph (self only)",
+    "desc": "The nobles spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Animal Messenger, Detect Evil and Good, Detect Magic, Disguise Self\n- **3/Day Each:** Charm Person, Scrying, Zone of Truth,\n- **1/Day Each:** Dream, Geas, Heroes Feast, Magic Circle, Polymorph (self only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_faerie-noble",
     "type": null
@@ -4541,7 +4541,7 @@
 },
 {
   "fields": {
-    "desc": "The planetars spellcasting ability is Charisma (spell save DC 20). The planetar can innately cast the following spells, requiring no material components: 1/day each: commune, control weather, raise dead",
+    "desc": "The planetars spellcasting ability is Charisma (spell save DC 20). The planetar can innately cast the following spells, requiring no material components:\n\n- **1/Day Each:** Commune, Control Weather, Raise Dead",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_fallen-planetar",
     "type": null
@@ -4561,7 +4561,7 @@
 },
 {
   "fields": {
-    "desc": "The solars spellcasting ability is Charisma (spell save DC 25). The solar can innately cast the following spells, requiring no material components: 1/day each: commune, control weather, resurrection",
+    "desc": "The solars spellcasting ability is Charisma (spell save DC 25). The solar can innately cast the following spells, requiring no material components:\n\n- **1/Day Each:** Commune, Control Weather, Resurrection",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_fallen-solar",
     "type": null
@@ -4841,7 +4841,7 @@
 },
 {
   "fields": {
-    "desc": "The DC for dispel magic to destroy this creature is 19.",
+    "desc": "The DC for Dispel Magic to destroy this creature is 19.",
     "name": "Spell-created",
     "parent": "a5e-mm_flying-sword",
     "type": null
@@ -4871,7 +4871,7 @@
 },
 {
   "fields": {
-    "desc": "The illusionist can communicate with Small and Tiny beasts, and can innately cast blur, disguise self, and major image once each per long rest with no material components.",
+    "desc": "The illusionist can communicate with Small and Tiny beasts, and can innately cast Blur, Disguise Self, and Major Image once each per long rest with no material components.",
     "name": "Forest Ways",
     "parent": "a5e-mm_forest-gnome-illusionist",
     "type": null
@@ -4881,7 +4881,7 @@
 },
 {
   "fields": {
-    "desc": "The mage is a 9th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 14\n +6 to hit with spell attacks). They have the following wizard spells prepared:\n Cantrips (at will): fire bolt\n light\n mage hand\n prestidigitation\n 1st-level (4 slots): detect magic\n identify\n mage armor\n shield\n 2nd-level (3 slots): alter self\n misty step\n 3rd-level (3 slots): hypnotic pattern\n counterspell\n fireball\n 4th-level (3 slots): dimension door\n greater invisibility\n 5th-level (1 slot): cone of cold",
+    "desc": "The mage is a 9th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 14 +6 to hit with spell attacks). They have the following wizard spells prepared:\n\n- **Cantrips** (at will): Fire Bolt, Light, Mage Hand, Prestidigitation\n- **1st-Level** (4 slots): Detect Magic, Identify, Mage Armor, Shield\n- **2nd-Level** (3 slots): Alter Self, Misty Step\n- **3rd-Level** (3 slots): Hypnotic Pattern, Counterspell, Fireball\n- **4th-Level** (3 slots): Dimension Door, Greater Invisibility\n- **5th-Level** (1 slot): Cone of Cold",
     "name": "Spellcasting",
     "parent": "a5e-mm_forest-gnome-illusionist",
     "type": null
@@ -4891,7 +4891,7 @@
 },
 {
   "fields": {
-    "desc": "The scout can communicate with Small and Tiny beasts, and can innately cast blur, disguise self, and major image once each per long rest with no material components.",
+    "desc": "The scout can communicate with Small and Tiny beasts, and can innately cast Blur, Disguise Self, and Major Image once each per long rest with no material components.",
     "name": "Forest ways",
     "parent": "a5e-mm_forest-gnome-scout",
     "type": null
@@ -4931,7 +4931,7 @@
 },
 {
   "fields": {
-    "desc": "The gods innate spellcasting ability is Wisdom (save DC 17).The god can try to cast flame strike or spirit guardians at will with no material component. When the god tries to cast the spell, roll 1d6. On a 1, 2, or 3 on the die, the spell visibly fails and has no effect. The gods action for the turn is not wasted, but it can't be used to cast a spell.",
+    "desc": "The gods innate spellcasting ability is Wisdom (save DC 17).The god can try to cast Flame Strikeor Spirit Guardians at will with no material component. When the god tries to cast the spell, roll 1d6. On a 1, 2, or 3 on the die, the spell visibly fails and has no effect. The gods action for the turn is not wasted, but it can't be used to cast a spell.",
     "name": "Flawed Spellcasting",
     "parent": "a5e-mm_forgotten-god",
     "type": null
@@ -5171,7 +5171,7 @@
 },
 {
   "fields": {
-    "desc": "If defeated in combat, the ghost returns in 24 hours. It can be put to rest permanently only by finding and casting remove curse on its remains or by resolving the unfinished business that keeps it from journeying to the afterlife.",
+    "desc": "If defeated in combat, the ghost returns in 24 hours. It can be put to rest permanently only by finding and casting Remove Curse on its remains or by resolving the unfinished business that keeps it from journeying to the afterlife.",
     "name": "Unquiet Spirit",
     "parent": "a5e-mm_ghost",
     "type": null
@@ -5411,7 +5411,7 @@
 },
 {
   "fields": {
-    "desc": "The giant lanternfishs innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components. At will: charm person, disguise self (humanoid form), major image, misty step, 1/day each: geas, hallucinatory terrain, hypnotic pattern, scrying",
+    "desc": "The giant lanternfishs innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components.\n\n- **At Will:** Charm Person, Disguise Self (humanoid form), Major Image, Misty Step\n- **1/Day Each:** Geas, Hallucinatory Terrain, Hypnotic Pattern, Scrying",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_giant-lanternfish",
     "type": null
@@ -5811,7 +5811,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:fog cloud, pass without trace, legend lore, speak with dead,  1/day each:create undead, insect plague, time stop",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Fog Cloud, Pass Without Trace, Legend Lore, Speak with Dead\n- **1/Day Each:**Create Undead, insect plague, time stop",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_great-wyrm-black-dragon",
     "type": null
@@ -5871,7 +5871,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 21). It can innately cast the following spells, requiring no material components. 3/day each:blur, silent image, blight, hypnotic pattern,  1/day each:control water, mirage arcane,antipathy/sympathy",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 21). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Blur, Silent Image, Blight, Hypnotic Pattern \n- **1/Day Each:** Control Water, mirage arcane,antipathy/sympathy",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_great-wyrm-blue-dragon",
     "type": null
@@ -5901,7 +5901,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 25). It can innately cast the following spells, requiring no material components. 3/day each:bless, healing word,banishment, greater restoration,  1/day each:divine word, hallow, holy aura",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 25). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Bless, Healing Word, Banishment, Greater Restoration\n- **1/Day Each:** Divine Word, Hallow, Holy Aura",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_great-wyrm-gold-dragon",
     "type": null
@@ -5951,7 +5951,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:animal messenger, tongues, modify memory, scrying,  1/day:mass suggestion, telepathic bond,glibness",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Animal Messenger, Tongues, Modify Memory, Scrying\n- **1/Day:** Mass Suggestion, Telepathic Bond, Glibness",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_great-wyrm-green-dragon",
     "type": null
@@ -5991,7 +5991,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 22). It can innately cast the following spells, requiring no material components. 3/day each:command, hold person, glyph of warding, wall of fire,  1/day each:antimagic field, dominate monster, storm of vengeance",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 22). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Command, Hold Person, glyph of warding, Wall of Fire\n- **1/Day Each:** Antimagic Field, Dominate Monster, storm of vengeance",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_great-wyrm-red-dragon",
     "type": null
@@ -6061,7 +6061,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components. 3/day each:dominate beast, fire shield, animal friendship, sleet storm,  1/day each:control weather, wall of ice, reverse gravity",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 18). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Dominate Beast, Fire Shield, Animal Friendship, Sleet Storm\n- **1/Day Each:**Control Weather, Wall of Ice, Reverse Gravity",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_great-wyrm-white-dragon",
     "type": null
@@ -6081,7 +6081,7 @@
 },
 {
   "fields": {
-    "desc": "The sphinxs spellcasting ability is Wisdom (spell save DC 18). It can cast the following spells, requiring no material components: At will: detect evil and good, detect magic, minor illusion, spare the dying, 3/day each: dispel magic, identify, lesser restoration, remove curse, scrying, tongues, zone of truth, 1/day each: contact other plane, flame strike, freedom of movement, greater restoration, legend lore, heroes feast",
+    "desc": "The sphinxs spellcasting ability is Wisdom (spell save DC 18). It can cast the following spells, requiring no material components:\n\n- **At Will:** Detect Evil and Good, Detect Magic, Minor Illusion, Spare the Dying\n- **3/Day Each:** Dispel Magic, Identify, Lesser Restoration, Remove Curse, Scrying Tongues, Zone of Truth,\n- **1/Day Each:** contact other plane, flame strike, Freedom of Movement, Greater Restoration, Legend Lore, Heroes Feast",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_greater-sphinx",
     "type": null
@@ -6141,7 +6141,7 @@
 },
 {
   "fields": {
-    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components: At will: dancing lights, disguise self, invisibility, minor illusion, 1/day: geas",
+    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** dancing lights, Disguise Self, Invisibility, Minor Illusion\n- **1/Day:**  Geas",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_green-hag",
     "type": null
@@ -6291,7 +6291,7 @@
 },
 {
   "fields": {
-    "desc": "The naga is an 11th level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16). The naga has the following cleric spells prepared\n which it can cast with only vocalized components:\n Cantrips (at will): mending\n thaumaturgy\n 1st-level (4 slots): command\n cure wounds\n 2nd-level (3 slots): calm emotions\n hold person\n 3rd-level (3 slots) clairvoyance\n create food and water\n 4th-level (3 slots): divination\n freedom of movement\n 5th-level (2 slots): flame strike\n geas\n 6th-level (1 slot): forbiddance",
+    "desc": "The naga is an 11th level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16). The naga has the following cleric spells prepared which it can cast with only vocalized components:\n\n\n- **Cantrips** (at will): Mending, Thaumaturgy\n- **1st-Level** (4 slots): Command, Cure Wounds\n- **2nd-Level** (3 slots): Calm Emotions, Hold Person\n- **3rd-Level** (3 slots) Clairvoyance, Create Food and Water\n- **4th-Level** (3 slots): Divination, freedom of movement\n- **5th-Level** (2 slots): Flame Strike, Geas\n- **6th-Level** (1 slot): forbiddance",
     "name": "Spellcasting",
     "parent": "a5e-mm_guardian-naga",
     "type": null
@@ -6401,7 +6401,7 @@
 },
 {
   "fields": {
-    "desc": "The priest is an 11th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 15\n +7 to hit with spell attacks). They have the following cleric spells prepared:\n Cantrips (at will): light\n sacred flame\n thaumaturgy\n 1st-level (4 slots): ceremony\n detect evil and good\n healing word\n 2nd-level (3 slots): augury\n hold person\n zone of truth\n 3rd-level (3 slots): daylight\n remove curse\n 4th-level (3 slots): divination\n guardian of faith\n revivify\n 5th-level (2 slots): flame strike\n greater restoration\n raise dead\n 6th-level (1 slots): heal",
+    "desc": "The priest is an 11th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 15 +7 to hit with spell attacks). They have the following cleric spells prepared:\n\n- **Cantrips** (at will): Light, Sacred Flame, Thaumaturgy\n- **1st-Level** (4 slots): Ceremony, Detect Evil and Good, Healing Word\n- **2nd-Level** (3 slots): Augury, Hold Person, Zone of Truth\n- **3rd-Level** (3 slots): Daylight, Remove Curse\n- **4th-Level** (3 slots): Divination, Guardian of Faith, Revivify\n- **5th-Level** (2 slots): Flame Strike, Greater Restoration, Raise Dead\n- **6th-Level** (1 slots): Heal",
     "name": "Spellcasting",
     "parent": "a5e-mm_high-priest",
     "type": null
@@ -7351,7 +7351,7 @@
 },
 {
   "fields": {
-    "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components: At will: charm person, command, telekinesis, 3/day: flame strike, hold monster, lightning bolt, 1/day: commune, greater restoration, heroes feast, plane shift (self only, can't travel to or from the Material Plane)",
+    "desc": "The empyreans innate spellcasting ability is Charisma (spell save DC 23). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Charm Person, Command, Telekinesis\n- **3/Day**: flame strike, Hold Monster, Lightning Bolt\n- **1/Day** Commune, Greater Restoration, Heroes Feast, Plane Shift (self only, can't travel to or from the Material Plane)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_king-fomor",
     "type": null
@@ -7501,7 +7501,7 @@
 },
 {
   "fields": {
-    "desc": "The kobolds innate spellcasting ability is Charisma (save DC 12). It can innately cast the following spells, requiring no material components: At will: mage hand, mending, 1/day each: charm person, expeditious retreat, mage armor",
+    "desc": "The kobolds innate spellcasting ability is Charisma (save DC 12). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Mage Hand, Mending\n- **1/Day Each:** Charm Person, expeditious retreat, Mage Armor",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_kobold-sorcerer-dragon-servitor",
     "type": null
@@ -7511,7 +7511,7 @@
 },
 {
   "fields": {
-    "desc": "The kobolds innate spellcasting ability is Charisma (save DC 12). It can innately cast the following spells, requiring no material components: At will: mage hand, mending, 1/day each: charm person, expeditious retreat, mage armor",
+    "desc": "The kobolds innate spellcasting ability is Charisma (save DC 12). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Mage Hand, Mending\n- **1/Day Each:** ., expeditious retreat, Mage Armor",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_kobold-sorcerer",
     "type": null
@@ -7611,7 +7611,7 @@
 },
 {
   "fields": {
-    "desc": "The lamias innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components. At will: charm person, disguise self (humanoid form), major image, misty step, 1/day each: geas, hallucinatory terrain, hypnotic pattern, scrying",
+    "desc": "The lamias innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components.\n\n- **At Will:** Charm Person, Disguise Self (humanoid form), Major Image, Misty Step\n- **1/Day Each:** Geas, Hallucinatory Terrain, Hypnotic Pattern, scrying",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_lamia",
     "type": null
@@ -7731,7 +7731,7 @@
 },
 {
   "fields": {
-    "desc": "The lich is a 16th level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20\n +12 to hit with spell attacks). The lich has the following wizard spells prepared:\n Cantrips (at will): fire bolt\n mage hand\n prestidigitation\n 1st-level (4 slots): detect magic\n shield\n silent image\n thunderwave\n 2nd-level (3 slots): blur\n detect thoughts\n locate object\n 3rd-level (3 slots): animate dead\n dispel magic\n fireball\n 4th-level (3 slots): confusion\n dimension door\n 5th-level (2 slots): geas\n scrying\n 6th-level (1 slot): create undead\n disintegrate\n 7th-level (1 slot): finger of death\n teleport\n 8th-level (1 slot): power word stun",
+    "desc": "The lich is a 16th level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20 +12 to hit with spell attacks). The lich has the following wizard spells prepared:\n\n- **Cantrips** (at will): Fire Bolt, Mage Hand, Prestidigitation\n- **1st-Level** (4 slots): Detect Magic, Shield, Silent Image, Thunderwave\n- **2nd-Level** (3 slots): Blur, Detect Thoughts, Locate Object\n- **3rd-Level** (3 slots): Animate Dead, Dispel Magic, Fireball\n- **4th-Level** (3 slots): Confusion, Dimension Door\n- **5th-Level** (2 slots): Geas, Scrying\n- **6th-Level** (1 slot): Create Undead, Disintegrate\n- **7th-Level** (1 slot): Finger of Death, Teleport, 8th-level (1 slot): Power Word Stun",
     "name": "Spellcasting",
     "parent": "a5e-mm_lich",
     "type": null
@@ -7831,7 +7831,7 @@
 },
 {
   "fields": {
-    "desc": "The mage is a 9th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 14\n +6 to hit with spell attacks). They have the following wizard spells prepared:\n Cantrips (at will): fire bolt\n light\n mage hand\n prestidigitation\n 1st-level (4 slots): detect magic\n identify\n mage armor\n shield\n 2nd-level (3 slots): alter self\n misty step\n 3rd-level (3 slots): clairvoyance\n counterspell\n fireball\n 4th-level (3 slots): dimension door\n greater invisibility\n 5th-level (1 slot): cone of cold",
+    "desc": "The mage is a 9th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 14 +6 to hit with spell attacks). They have the following wizard spells prepared:\n\n- **Cantrips** (at will): Fire Bolt, Light, Mage Hand, Prestidigitation\n- **1st-Level** (4 slots): Detect Magic, Identify, Mage Armor, Shield\n- **2nd-Level** (3 slots): Alter Self, Misty Step\n- **3rd-Level** (3 slots): Clairvoyance, Counterspell, Fireball\n- **4th-Level** (3 slots): Dimension Door, Greater Invisibility\n- **5th-Level** (1 slot): Cone of Cold",
     "name": "Spellcasting",
     "parent": "a5e-mm_mage",
     "type": null
@@ -7941,7 +7941,7 @@
 },
 {
   "fields": {
-    "desc": "The marids innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components: At will: alter self (can assume Medium or Large form), create or destroy water, detect magic, purify food and drink, 3/day each: control water, creation, tongues, water breathing, water walk, 1/day each: conjure elemental (water elemental only), plane shift (to Elemental Plane of Water only)",
+    "desc": "The marids innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Alter Self (can assume Medium or Large form), Create or Destroy Water, Detect Magic, purify food and drink,\n- **3/Day Each:** Control Water, Creation, Tongues, Water Breathing, water walk,\n- **1/Day Each:** Conjure Elemental (water elemental only), Plane Shift (to Elemental Plane of Water only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_marid-noble",
     "type": null
@@ -7961,7 +7961,7 @@
 },
 {
   "fields": {
-    "desc": "The marids innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components: At will: alter self (can assume Medium or Large form), create or destroy water, detect magic, purify food and drink, 3/day each: control water, creation, tongues, water breathing, water walk, 1/day each: conjure elemental (water elemental only), plane shift (to Elemental Plane of Water only)",
+    "desc": "The marids innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Alter Self (can assume Medium or Large form), Create or Destroy Water, Detect Magic, purify food and drink,\n- **3/Day Each:** Control Water, Creation, Tongues, Water Breathing, water walk,\n- **1/Day Each:** Conjure Elemental (water elemental only), Plane Shift (to Elemental Plane of Water only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_marid",
     "type": null
@@ -8111,7 +8111,7 @@
 },
 {
   "fields": {
-    "desc": "If it rolls a natural 1 on the save, it is petrified instantly. If it otherwise fails the save, it is restrained as it begins to be petrified. The creature repeats the saving throw at the end of its turn, ending the effect on itself on a success and becoming petrified on a failure. The petrification can be removed with greater restoration or similar powerful magic.",
+    "desc": "If it rolls a natural 1 on the save, it is petrified instantly. If it otherwise fails the save, it is restrained as it begins to be petrified. The creature repeats the saving throw at the end of its turn, ending the effect on itself on a success and becoming petrified on a failure. The petrification can be removed with Greater Restorationor similar powerful magic.",
     "name": "A creature subject to the medusas petrifying gaze makes a DC 14 Constitution saving throw",
     "parent": "a5e-mm_medusa-queen",
     "type": null
@@ -8131,7 +8131,7 @@
 },
 {
   "fields": {
-    "desc": "If it rolls a natural 1 on the save, it is petrified instantly. If it otherwise fails the save, it is restrained as it begins to be petrified. The creature repeats the saving throw at the end of its turn, ending the effect on itself on a success and becoming petrified on a failure. The petrification can be removed with greater restoration or similar powerful magic.",
+    "desc": "If it rolls a natural 1 on the save, it is petrified instantly. If it otherwise fails the save, it is restrained as it begins to be petrified. The creature repeats the saving throw at the end of its turn, ending the effect on itself on a success and becoming petrified on a failure. The petrification can be removed with Greater Restorationor similar powerful magic.",
     "name": "A creature subject to the medusas petrifying gaze makes a DC 14 Constitution saving throw",
     "parent": "a5e-mm_medusa",
     "type": null
@@ -8221,7 +8221,7 @@
 },
 {
   "fields": {
-    "desc": "The mages innate spellcasting ability is Charisma (spell save DC 12). It can innately cast the following spells, requiring no material components: At will: darkness, invisibility, 1/day: charm person",
+    "desc": "The mages innate spellcasting ability is Charisma (spell save DC 12). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Darkness, Invisibility\n- **1/Day:**  Charm Person",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_merrow-mage",
     "type": null
@@ -8321,7 +8321,7 @@
 },
 {
   "fields": {
-    "desc": "The minstrel is a 5th level spellcaster. Their spellcasting ability is Charisma (spell save DC 13\n +5 to hit with spell attacks). They have the following bard spells prepared:\n Cantrips (at will): light\n mage hand\n minor illusion\n vicious mockery\n 1st-level (4 slots): charm person\n disguise self\n healing word\n 2nd-level (3 slots): enthrall\n invisibility\n shatter\n 3rd-level (2 slots): hypnotic pattern\n major image",
+    "desc": "The minstrel is a 5th level spellcaster. Their spellcasting ability is Charisma (spell save DC 13 +5to hit with spell attacks). They have the following bard spells prepared:\n\n- **Cantrips** (at will): Light, Mage Hand, Minor Illusion, Vicious Mockery\n- **1st-Level** (4 slots): Charm Person, Disguise Self, Healing Word\n- **2nd-Level** (3 slots): enthrall, Invisibility, shatter\n- **3rd-Level** (2 slots): Hypnotic Pattern, Major Image",
     "name": "Spellcasting",
     "parent": "a5e-mm_minstrel",
     "type": null
@@ -8491,7 +8491,7 @@
 },
 {
   "fields": {
-    "desc": "The mummy lord is an 11th level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17\n +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared\n which it can cast without material components:\n Cantrips (at will): guidance\n thaumaturgy\n 1st-level (4 slots): create or destroy water\n detect magic\n 2nd-level (3 slots): augury\n gentle repose\n 3rd-level (3 slots): animate dead\n dispel magic\n 4th-level (3 slots): divination\n guardian of faith\n 5th-level (2 slots): contagion\n 6th-level (1 slot): harm",
+    "desc": "The mummy lord is an 11th level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17 +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared which it can cast without material components:\n\n- **Cantrips** (at will): Guidance, Thaumaturgy\n- **1st-Level** (4 slots): Create or Destroy Water, Detect Magic\n- **2nd-Level** (3 slots): Augury, Gentle Repose\n- **3rd-Level** (3 slots): Animate Dead, Dispel Magic\n- **4th-Level** (3 slots): Divination, Guardian of Faith\n- **5th-Level** (2 slots): Contagion\n- **6th-Level** (1 slot): Harm",
     "name": "Spellcasting",
     "parent": "a5e-mm_mummy-lord",
     "type": null
@@ -8601,7 +8601,7 @@
 },
 {
   "fields": {
-    "desc": "The mage is a 9th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 14\n +6 to hit with spell attacks). They have the following wizard spells prepared:\n Cantrips (at will): fire bolt\n light\n mage hand\n prestidigitation\n 1st-level (4 slots): detect magic\n identify\n mage armor\n shield\n 2nd-level (3 slots): alter self\n misty step\n 3rd-level (3 slots): animate dead\n counterspell\n fireball\n 4th-level (3 slots): dimension door\n greater invisibility\n 5th-level (1 slot): cone of cold",
+    "desc": "The mage is a 9th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 14 +6 to hit with spell attacks). They have the following wizard spells prepared:\n\n- **Cantrips** (at will): Fire Bolt, Light, Mage Hand, Prestidigitation\n- **1st-Level** (4 slots): Detect Magic, Identify, Mage Armor, Shield\n- **2nd-Level** (3 slots): Alter Self, Misty Step\n- **3rd-Level** (3 slots): Animate Dead, Counterspell, Fireball\n- **4th-Level** (3 slots): Dimension Door, Greater Invisibility\n- **5th-Level** (1 slot): Cone of Cold",
     "name": "Spellcasting",
     "parent": "a5e-mm_necromancer",
     "type": null
@@ -8761,7 +8761,7 @@
 },
 {
   "fields": {
-    "desc": "The ogres innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components: At will: darkness, invisibility, 1/day: charm person, cone of cold, gaseous form, hold person",
+    "desc": "The ogres innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Darkness, Invisibility\n- **1/Day:**  Charm Person, Cone of Cold, Gaseous Form, Hold Person",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_ogre-mage",
     "type": null
@@ -8801,7 +8801,7 @@
 },
 {
   "fields": {
-    "desc": "Once every 30 days, the orcish wilding minstrel can innately cast legend lore with no material component.",
+    "desc": "Once every 30 days, the orcish wilding minstrel can innately cast Legend Lore with no material component.",
     "name": "Legend lore",
     "parent": "a5e-mm_orcish-wildling-minstrel",
     "type": null
@@ -8811,7 +8811,7 @@
 },
 {
   "fields": {
-    "desc": "The minstrel is a 5th level spellcaster. Their spellcasting ability is Charisma (spell save DC 13\n +5 to hit with spell attacks). They have the following bard spells prepared:\n Cantrips (at will): light\n mage hand\n minor illusion\n vicious mockery\n 1st-level (4 slots): charm person\n disguise self\n healing word\n 2nd-level (3 slots): enthrall\n invisibility\n shatter\n 3rd-level (2 slots): hypnotic pattern\n major image",
+    "desc": "The minstrel is a 5th level spellcaster. Their spellcasting ability is Charisma (spell save DC 13 +5to hit with spell attacks). They have the following bard spells prepared:\n\n- **Cantrips** (at will): Light, Mage Hand, Minor Illusion, vicious mockery\n- **1st-Level** (4 slots): Charm Person, Disguise Self, Healing Word\n- **2nd-Level** (3 slots): enthrall, Invisibility, shatter\n- **3rd-Level** (2 slots): Hypnotic Pattern, Major Image",
     "name": "Spellcasting",
     "parent": "a5e-mm_orcish-wildling-minstrel",
     "type": null
@@ -8991,7 +8991,7 @@
 },
 {
   "fields": {
-    "desc": "The pit fiends spellcasting ability is Wisdom (spell save DC 18). It can innately cast the following spells, requiring no material components: At will: detect magic, fireball, 3/day each: hold monster, sending",
+    "desc": "The pit fiends spellcasting ability is Wisdom (spell save DC 18). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Detect Magic, Fireball\n- **3/Day Each:** Hold Monster, Sending",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_pit-fiend-general",
     "type": null
@@ -9011,7 +9011,7 @@
 },
 {
   "fields": {
-    "desc": "The pit fiends spellcasting ability is Wisdom (spell save DC 18). It can innately cast the following spells, requiring no material components: At will: detect magic, fireball, 3/day each: hold monster, sending",
+    "desc": "The pit fiends spellcasting ability is Wisdom (spell save DC 18). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Detect Magic, Fireball\n- **3/Day Each:** Hold Monster, Sending",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_pit-fiend",
     "type": null
@@ -9051,7 +9051,7 @@
 },
 {
   "fields": {
-    "desc": "The planetars spellcasting ability is Charisma (spell save DC 20). The planetar can innately cast the following spells, requiring no material components: 1/day each: commune, control weather, raise dead",
+    "desc": "The planetars spellcasting ability is Charisma (spell save DC 20). The planetar can innately cast the following spells, requiring no material components:\n- **1/Day Each:** Commune, Control Weather, Raise Dead",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_planetar",
     "type": null
@@ -9081,7 +9081,7 @@
 },
 {
   "fields": {
-    "desc": "The priest is a 5th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 13\n +5 to hit with spell attacks). They have the following cleric spells prepared:\n Cantrips (at will): light\n sacred flame\n thaumaturgy\n 1st-level (4 slots): ceremony\n detect evil and good\n guiding bolt\n healing word\n 2nd-level (3 slots): lesser restoration\n zone of truth\n 3rd-level (2 slots): dispel magic\n spirit guardians",
+    "desc": "The priest is a 5th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 13 +5to hit with spell attacks). They have the following cleric spells prepared:\n\n- **Cantrips** (at will): Light, Sacred Flame, Thaumaturgy\n- **1st-Level** (4 slots): Ceremony, Detect Evil and Good, Guiding Bolt, Healing Word\n- **2nd-Level** (3 slots): Lesser Restoration, Zone of Truth\n- **3rd-Level** (2 slots): Dispel Magic, Spirit Guardians",
     "name": "Spellcasting",
     "parent": "a5e-mm_priest",
     "type": null
@@ -9301,7 +9301,7 @@
 },
 {
   "fields": {
-    "desc": "The rakshasas innate spellcasting ability is Charisma (spell save DC 18). It can innately cast the following spells, requiring no material components: At will: detect magic, mage hand, major image, 3/day each: charm person, dominate person, fly (self only), invisibility (self only), locate person, modify memory, true seeing",
+    "desc": "The rakshasas innate spellcasting ability is Charisma (spell save DC 18). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Detect Magic, Mage Hand, Major Image\n- **3/Day Each:** Charm Person, Dominate Person, fly (self only), Invisibility (self only), locate person, Modify Memory, True Seeing",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_rakshasa",
     "type": null
@@ -9561,7 +9561,7 @@
 },
 {
   "fields": {
-    "desc": "The DC for dispel magic to destroy this creature is 19.",
+    "desc": "The DC for Dispel Magic to destroy this creature is 19.",
     "name": "Spell-created",
     "parent": "a5e-mm_rug-of-smothering",
     "type": null
@@ -9761,7 +9761,7 @@
 },
 {
   "fields": {
-    "desc": "The DC for dispel magic to disable this creature is 19. A disabled scarecrow is inanimate. After one hour, it becomes animate again unless its body has been destroyed.",
+    "desc": "The DC for Dispel Magic to disable this creature is 19. A disabled scarecrow is inanimate. After one hour, it becomes animate again unless its body has been destroyed.",
     "name": "Spell-created",
     "parent": "a5e-mm_scarecrow-harvester",
     "type": null
@@ -9801,7 +9801,7 @@
 },
 {
   "fields": {
-    "desc": "The DC for dispel magic to destroy this creature is 19.",
+    "desc": "The DC for Dispel Magic to destroy this creature is 19.",
     "name": "Spell-created",
     "parent": "a5e-mm_scarecrow",
     "type": null
@@ -9811,7 +9811,7 @@
 },
 {
   "fields": {
-    "desc": "The imperator is a 5th level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14\n +6 to hit with spell attacks). It has the following cleric and wizard spells prepared:\n Cantrips (at will): light\n sacred flame\n 1st-level (4 slots): create or destroy water\n healing word\n 2nd-level (3 slots): burning gust of wind\n lesser restoration\n 3rd-level (2 slots): major image\n venomous fireball",
+    "desc": "The imperator is a 5th level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14 +6 to hit with spell attacks). It has the following cleric and wizard spells prepared:\n\n- **Cantrips** (at will): light, Sacred Flame- **1st-Level** (4 slots): Create or Destroy Water, Healing Word\n- **2nd-Level** (3 slots): Burning Gust of Wind, Lesser Restoration\n- **3rd-Level** (2 slots): Major Image, Venomous Fireball",
     "name": "Spellcasting",
     "parent": "a5e-mm_scorpionfolk-imperator",
     "type": null
@@ -9901,7 +9901,7 @@
 },
 {
   "fields": {
-    "desc": "A creature that makes a bargain with the hag is magically cursed for 30 days. While it is cursed, the target automatically fails saving throws against the hags scrying and geas spells, and the hag can cast control weather centered on the creature.",
+    "desc": "A creature that makes a bargain with the hag is magically cursed for 30 days. While it is cursed, the target automatically fails saving throws against the hags scrying and Geas spells, and the hag can cast Control Weather centered on the creature.",
     "name": "Curse",
     "parent": "a5e-mm_sea-hag",
     "type": null
@@ -9911,7 +9911,7 @@
 },
 {
   "fields": {
-    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components: At will: dancing lights, disguise self, 1/day: control weather, geas, scrying",
+    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** dancing lights, Disguise Self\n- **1/Day:**  Control Weather, Geas, scrying",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_sea-hag",
     "type": null
@@ -10021,7 +10021,7 @@
 },
 {
   "fields": {
-    "desc": "The warriors spellcasting ability is Charisma (spell save DC 13). The warrior can innately cast the following spells, requiring no material components:\n*At Will:* _dancing lights_ \n*1/day each:* _darkness, faerie fire_",
+    "desc": "The warriors spellcasting ability is Charisma (spell save DC 13). The warrior can innately cast the following spells, requiring no material components:\n\n- *At Will:* dancing lights\n- **1/Day Each:** Darkness, Faerie Fire",
     "name": "Shadow Elf Spellcasting",
     "parent": "a5e-mm_shadow-elf-champion-warrior",
     "type": null
@@ -10031,7 +10031,7 @@
 },
 {
   "fields": {
-    "desc": "The priestcan innately cast dancing lights as a cantrip and darkness and faerie fire once each per long rest with no material components, using Wisdom as their spellcasting ability.",
+    "desc": "The priestcan innately cast dancing lights as a cantrip and Darkness and Faerie Fire once each per long rest with no material components, using Wisdom as their spellcasting ability.",
     "name": "Shadow magic",
     "parent": "a5e-mm_shadow-elf-high-priest",
     "type": null
@@ -10041,7 +10041,7 @@
 },
 {
   "fields": {
-    "desc": "The priest is an 11th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 15\n +7 to hit with spell attacks). They have the following cleric spells prepared:\n Cantrips (at will): guidance\n spare the dying\n thaumaturgy\n 1st-level (4 slots): animal friendship\n ceremony\n detect poison and disease\n 2nd-level (3 slots): augury\n lesser restoration\n web\n 3rd-level (3 slots): bestow curse\n remove curse\n 4th-level (3 slots): divination\n freedom of movement\n guardian of faith\n 5th-level (2 slots): greater restoration\n insect plague\n raise dead\n 6th-level (1 slots): word of recall",
+    "desc": "The priest is an 11th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 15 +7 to hit with spell attacks). They have the following cleric spells prepared:\n\n\n- **Cantrips** (at will): Guidance, Spare the Dying, Thaumaturgy\n- **1st-Level** (4 slots): Animal Friendship, Ceremony, Detect Poison and Disease\n- **2nd-Level** (3 slots): Augury, Lesser Restoration, Web\n- **3rd-Level** (3 slots): Bestow Curse, Remove Curse\n- **4th-Level** (3 slots): Divination, Freedom of Movement, Guardian of Faith\n- **5th-Level** (2 slots): Greater Restoration, insect plague, Raise Dead\n- **6th-Level** (1 slots): word of recall",
     "name": "Spellcasting",
     "parent": "a5e-mm_shadow-elf-high-priest",
     "type": null
@@ -10051,7 +10051,7 @@
 },
 {
   "fields": {
-    "desc": "The shadow elf magecan innately cast dancing lights as a cantrip and faerie fire and darkness once each per long rest with no material components, using Intelligence as their spellcasting ability.",
+    "desc": "The shadow elf magecan innately cast dancing lights as a cantrip and Faerie Fire and Darkness once each per long rest with no material components, using Intelligence as their spellcasting ability.",
     "name": "Innate spells",
     "parent": "a5e-mm_shadow-elf-mage",
     "type": null
@@ -10061,7 +10061,7 @@
 },
 {
   "fields": {
-    "desc": "The mage is a 9th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 14\n +6 to hit with spell attacks). They have the following wizard spells prepared:\n Cantrips (at will): fire bolt\n light\n mage hand\n prestidigitation\n 1st-level (4 slots): detect magic\n identify\n mage armor\n shield\n 2nd-level (3 slots): alter self\n misty step\n 3rd-level (3 slots): clairvoyance\n counterspell\n lightning bolt\n 4th-level (3 slots): dimension door\n greater invisibility\n 5th-level (1 slot): cloudkill",
+    "desc": "The mage is a 9th level spellcaster. Their spellcasting ability is Intelligence (spell save DC 14 +6 to hit with spell attacks). They have the following wizard spells prepared:\n\n- **Cantrips** (at will): Fire Bolt, Light, Mage Hand, Prestidigitation\n- **1st-Level** (4 slots): Detect Magic, Identify, Mage Armor, Shield\n- **2nd-Level** (3 slots): Alter Self, Misty Step\n- **3rd-Level** (3 slots): Clairvoyance, Counterspell, Lightning Bolt\n- **4th-Level** (3 slots): Dimension Door, Greater Invisibility\n- **5th-Level** (1 slot): Cloudkill",
     "name": "Spellcasting",
     "parent": "a5e-mm_shadow-elf-mage",
     "type": null
@@ -10081,7 +10081,7 @@
 },
 {
   "fields": {
-    "desc": "The driders innate spellcasting ability is Wisdom (spell save DC 14). The drider can innately cast the following spells, requiring no material components: At will: dancing lights, 1/day each: darkness, web",
+    "desc": "The driders innate spellcasting ability is Wisdom (spell save DC 14). The drider can innately cast the following spells, requiring no material components:\n\n- **At Will:** dancing lights,\n- **1/Day Each:** Darkness, Web",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_shadow-elf-spellcaster-drider",
     "type": null
@@ -10121,7 +10121,7 @@
 },
 {
   "fields": {
-    "desc": "The warriors spellcasting ability is Wisdom (spell save DC 12). The warrior can innately cast the following spells, requiring no material components:\n*At Will:* _dancing lights_ \n*1/day each:* _darkness, faerie fire_",
+    "desc": "The warriors spellcasting ability is Wisdom (spell save DC 12). The warrior can innately cast the following spells, requiring no material components:\n\n- **At Will:** Dancing Lights\n- **1/Day Each:**  Darkness, Faerie Fire",
     "name": "Shadow Elf Spellcasting",
     "parent": "a5e-mm_shadow-elf-warrior",
     "type": null
@@ -10341,7 +10341,7 @@
 },
 {
   "fields": {
-    "desc": "The lamias innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components. At will: charm person, disguise self (humanoid form), major image, misty step, 1/day each: geas, hallucinatory terrain, hypnotic pattern, scrying",
+    "desc": "The lamias innate spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring no material components.\n\n- **At Will:** Charm Person, Disguise Self (humanoid form), Major Image, Misty Step\n- **1/Day Each:** Geas, Hallucinatory Terrain, Hypnotic Pattern, Scrying",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_snake-lamia",
     "type": null
@@ -10361,7 +10361,7 @@
 },
 {
   "fields": {
-    "desc": "The solars spellcasting ability is Charisma (spell save DC 25). The solar can innately cast the following spells, requiring no material components: 1/day each: commune, control weather, resurrection",
+    "desc": "The solars spellcasting ability is Charisma (spell save DC 25). The solar can innately cast the following spells, requiring no material components:\n- **1/Day Each:** Commune, Control Weather, Resurrection",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_solar",
     "type": null
@@ -10521,7 +10521,7 @@
 },
 {
   "fields": {
-    "desc": "The sphinxs spellcasting ability is Wisdom (spell save DC 18). It can cast the following spells, requiring no material components: At will: detect evil and good, detect magic, minor illusion, spare the dying, 3/day each: dispel magic, identify, lesser restoration, remove curse, scrying, tongues, zone of truth, 1/day each: contact other plane, flame strike, freedom of movement, greater restoration, legend lore, heroes feast",
+    "desc": "The sphinxs spellcasting ability is Wisdom (spell save DC 18). It can cast the following spells, requiring no material components:\n\n- **At Will:** Detect Evil and Good, Detect Magic, Minor Illusion, Spare the Dying\n- **3/Day Each:** Dispel Magic, Identify, Lesser Restoration, Remove Curse, Scrying, Tongues, Zone of Truth\n- **1/Day Each:** contact other plane, Flame Strike, Freedom of Movement, Greater Restoration, Legend Lore, Heroes Feast",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_sphinx",
     "type": null
@@ -10591,7 +10591,7 @@
 },
 {
   "fields": {
-    "desc": "The naga is a 9th level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14). The naga has the following wizard spells prepared\n which it can cast with only vocalized components:\n Cantrips (at will): mage hand\n minor illusion\n 1st-level (4 slots): charm person\n shield\n 2nd-level (3 slots): detect thoughts\n levitate\n 3rd-level (3 slots) hypnotic pattern\n lightning bolt\n 4th-level (3 slots): arcane eye\n blight\n 5th-level (1 slots): dominate person",
+    "desc": "The naga is a 9th level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14). The naga has the following wizard spells prepared which it can cast with only vocalized components:\n\n- **Cantrips** (at will): Mage Hand, Minor Illusion\n- **1st-Level** (4 slots): Charm Person, Shield\n- **2nd-Level** (3 slots): Detect Thoughts, levitate\n- **3rd-Level** (3 slots) Hypnotic Pattern, Lightning Bolt\n- **4th-Level** (3 slots): Arcane Eye, Blight\n- **5th-Level** (1 slots): Dominate Person",
     "name": "Spellcasting",
     "parent": "a5e-mm_spirit-naga",
     "type": null
@@ -10741,7 +10741,7 @@
 },
 {
   "fields": {
-    "desc": "The giants spellcasting ability is Constitution (spell save DC 16). It can innately cast the following spells, requiring no material components: At will: stone shape, telekinesis, 3/day each: meld into stone, move earth, passwall, 1/day each: augury, scrying (underground only)",
+    "desc": "The giants spellcasting ability is Constitution (spell save DC 16). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Stone Shape, Telekinesis\n- **3/Day Each:** meld into stone, Move Earth, Passwall\n- **1/Day Each:** Augury, Scrying (underground only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_stone-giant-stonetalker",
     "type": null
@@ -10801,7 +10801,7 @@
 },
 {
   "fields": {
-    "desc": "The giants spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components: At will: detect magic, feather fall, levitate, light, 3/day each: control water, control weather, water breathing, 1/day: commune",
+    "desc": "The giants spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Detect Magic, feather fall, levitate, Light\n- **3/Day Each:** Control Water, Control Weather, Water Breathing\n- **1/Day:** Commune",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_storm-giant-monarch",
     "type": null
@@ -10821,7 +10821,7 @@
 },
 {
   "fields": {
-    "desc": "The giants spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components: At will: detect magic, feather fall, levitate, light, 3/day each: control water, control weather, water breathing, 1/day: commune",
+    "desc": "The giants spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Detect Magic, feather fall, levitate, Light\n- **3/Day Each:** Control Water, Control Weather, Water Breathing,\n- **1/Day:** Commune",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_storm-giant",
     "type": null
@@ -11011,7 +11011,7 @@
 },
 {
   "fields": {
-    "desc": "When the tarrasque is targeted by a magic missile spell, a line spell, or a spell that requires a ranged attack roll, roll a d6. On a 1 to 3, the tarrasque is unaffected. On a 4 to 6, the tarrasque is unaffected, and the spell is reflected back, targeting the caster as if it originated from the tarrasque.",
+    "desc": "When the tarrasque is targeted by a Magic Missile spell, a line spell, or a spell that requires a ranged attack roll, roll a d6. On a 1 to 3, the tarrasque is unaffected. On a 4 to 6, the tarrasque is unaffected, and the spell is reflected back, targeting the caster as if it originated from the tarrasque.",
     "name": "Reflective Carapace",
     "parent": "a5e-mm_tarrasque",
     "type": null
@@ -11071,7 +11071,7 @@
 },
 {
   "fields": {
-    "desc": "The dragon turtles spellcasting ability is Wisdom (spell save DC 17). It can innately cast the following spells, requiring no components: 3/day each: control weather, water breathing, zone of truth",
+    "desc": "The dragon turtles spellcasting ability is Wisdom (spell save DC 17). It can innately cast the following spells, requiring no components:\n- **3/Day Each:** Control Weather, Water Breathing, Zone of Truth",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_titanic-dragon-turtle",
     "type": null
@@ -11181,7 +11181,7 @@
 },
 {
   "fields": {
-    "desc": "The priest is a 5th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 13\n +5 to hit with spell attacks). They have the following cleric spells prepared:\n Cantrips (at will): sacred flame\n thaumaturgy\n minor illusion\n 1st-level (4 slots): ceremony\n detect evil and good\n healing word\n disguise self\n 2nd-level (3 slots): lesser restoration\n invisibility\n 3rd-level (2 slots): spirit guardians\n major image",
+    "desc": "The priest is a 5th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 13 +5to hit with spell attacks). They have the following cleric spells prepared:\n\n- **Cantrips** (at will): Sacred Flame, Thaumaturgy, Minor Illusion\n- **1st-Level** (4 slots): Ceremony, Detect Evil and Good, Healing Word, Disguise Self\n- **2nd-Level** (3 slots): Lesser Restoration, Invisibility\n- **3rd-Level** (2 slots): Spirit Guardians, Major Image",
     "name": "Spellcasting",
     "parent": "a5e-mm_trickster-priest",
     "type": null
@@ -11271,7 +11271,7 @@
 },
 {
   "fields": {
-    "desc": "The unicorns innate spellcasting ability is Charisma (spell save DC 16). It can innately cast the following spells, requiring no material components: At will: animal messenger, detect evil and good, druidcraft, pass without trace, scrying (locations within its domain only), 1/day: calm emotions, dispel evil and good, teleport (between locations within its domain only)",
+    "desc": "The unicorns innate spellcasting ability is Charisma (spell save DC 16). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Animal Messenger, Detect Evil and Good, Druidcraft, Pass Without Trace, Scrying (locations within its domain only),\n- **1/Day:**  Calm Emotions, dispel evil and good, Teleport (between locations within its domain only)",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_unicorn",
     "type": null
@@ -11331,7 +11331,7 @@
 },
 {
   "fields": {
-    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a bless, hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
+    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a Bless, Hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
     "name": "Resting Place",
     "parent": "a5e-mm_vampire-assassin",
     "type": null
@@ -11401,7 +11401,7 @@
 },
 {
   "fields": {
-    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a bless, hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
+    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a Bless, Hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
     "name": "Resting Place",
     "parent": "a5e-mm_vampire-mage",
     "type": null
@@ -11411,7 +11411,7 @@
 },
 {
   "fields": {
-    "desc": "The vampire is a 7th level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15). It has the following wizard spells prepared:\n Cantrips (at will): mage hand\n minor illusion\n 1st-level (4 slots): disguise self\n shield\n 2nd-level (3 slots): darkness\n misty step\n 3rd-level (3 slots): animate dead\n fireball\n 4th-level (1 slot): blight",
+    "desc": "The vampire is a 7th level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15). It has the following wizard spells prepared:\n\n- **Cantrips** (at will): Mage Hand, Minor Illusion\n- **1st-Level** (4 slots): Disguise Self, Shield\n- **2nd-Level** (3 slots): Darkness, Misty Step\n- **3rd-Level** (3 slots): Animate Dead, Fireball\n- **4th-Level** (1 slot): Blight",
     "name": "Spellcasting",
     "parent": "a5e-mm_vampire-mage",
     "type": null
@@ -11501,7 +11501,7 @@
 },
 {
   "fields": {
-    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a bless, hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
+    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a Bless, Hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
     "name": "Resting Place",
     "parent": "a5e-mm_vampire-warrior",
     "type": null
@@ -11561,7 +11561,7 @@
 },
 {
   "fields": {
-    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a bless, hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
+    "desc": "Every vampires lair contains a resting place, usually a coffin or sarcophagus, where the vampire must rest for at least an hour each day to recuperate its powers. This resting place is sprinkled with soil from its mortal homeland. If this soil is scattered or is subjected to a Bless, Hallow, or similar spell, the vampire is destroyed when reduced to 0 hit points.",
     "name": "Resting Place",
     "parent": "a5e-mm_vampire",
     "type": null
@@ -11631,7 +11631,7 @@
 },
 {
   "fields": {
-    "desc": "If defeated in combat, the ghost returns in 24 hours. It can be put to rest permanently only by finding and casting remove curse on its remains or by resolving the unfinished business that keeps it from journeying to the afterlife.",
+    "desc": "If defeated in combat, the ghost returns in 24 hours. It can be put to rest permanently only by finding and casting Remove Curse on its remains or by resolving the unfinished business that keeps it from journeying to the afterlife.",
     "name": "Unquiet Spirit",
     "parent": "a5e-mm_vengeful-ghost",
     "type": null
@@ -11701,7 +11701,7 @@
 },
 {
   "fields": {
-    "desc": "The DC for dispel magic to destroy this creature is 19.",
+    "desc": "The DC for Dispel Magic to destroy this creature is 19.",
     "name": "Spell-created",
     "parent": "a5e-mm_walking-statue",
     "type": null
@@ -11731,7 +11731,7 @@
 },
 {
   "fields": {
-    "desc": "The priest is a 5th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 13\n +5 to hit with spell attacks). They have the following cleric spells prepared:\n Cantrips (at will): guidance\n sacred flame\n thaumaturgy\n 1st-level (4 slots): ceremony\n detect evil and good\n guiding bolt\nbless\n 2nd-level (3 slots): lesser restoration\narcane eye\n 3rd-level (2 slots): dispel magic\n spirit guardians",
+    "desc": "The priest is a 5th level spellcaster. Their spellcasting ability is Wisdom (spell save DC 13 +5to hit with spell attacks). They have the following cleric spells prepared:\n\n- **Cantrips** (at will): Guidance, Sacred Flame, Thaumaturgy\n- **1st-Level** (4 slots): Ceremony, Detect Evil and Good, Guiding Bolt, Bless\n- **2nd-Level** (3 slots): Lesser Restoration, Arcane Eye\n- **3rd-Level** (2 slots): Dispel Magic, Spirit Guardians",
     "name": "Spellcasting",
     "parent": "a5e-mm_warhordling-orc-eye",
     "type": null
@@ -11741,7 +11741,7 @@
 },
 {
   "fields": {
-    "desc": "The eye has advantage on attack rolls made against targets they can see with arcane eye.",
+    "desc": "The eye has advantage on attack rolls made against targets they can see with Arcane Eye.",
     "name": "Warhordling Orc Eye Spellcasting",
     "parent": "a5e-mm_warhordling-orc-eye",
     "type": null
@@ -11791,7 +11791,7 @@
 },
 {
   "fields": {
-    "desc": "If defeated in combat, the banshee returns on the anniversary of its death. It can be permanently put to rest only by finding and casting remove curse on its grave or by righting whatever wrong was done to it.",
+    "desc": "If defeated in combat, the banshee returns on the anniversary of its death. It can be permanently put to rest only by finding and casting Remove Curse on its grave or by righting whatever wrong was done to it.",
     "name": "Unquiet Spirit",
     "parent": "a5e-mm_warlords-ghost",
     "type": null
@@ -12061,7 +12061,7 @@
 },
 {
   "fields": {
-    "desc": "A creature that accepts a gift from the hag is magically cursed for 30 days. While it is cursed, the target automatically fails saving throws against the hags charm person, geas, and scrying spells, and the hag can cast control weather centered on the creature.",
+    "desc": "A creature that accepts a gift from the hag is magically cursed for 30 days. While it is cursed, the target automatically fails saving throws against the hags Charm Person, Geas, and Scrying spells, and the hag can cast Control Weather centered on the creature.",
     "name": "Curse",
     "parent": "a5e-mm_winter-hag",
     "type": null
@@ -12081,7 +12081,7 @@
 },
 {
   "fields": {
-    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components: At will: charm person, dancing lights, invisibility, minor illusion, passwall (ice only), 1/day: control weather (extreme cold), geas, scrying",
+    "desc": "The hags innate spellcasting ability is Charisma (spell save DC 15). It can innately cast the following spells, requiring no material components:\n\n- **At Will:** Charm Person, dancing lights, Invisibility, Minor Illusion, Passwall (ice only)\n- **1/Day:** Control Weather (extreme cold), Geas, Scrying",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_winter-hag",
     "type": null
@@ -12391,7 +12391,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components. 3/day each:calm emotions, charm person",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 19). It can innately cast the following spells, requiring no material components.\n\n- **3/Day Each:** Calm Emotions, Charm Person",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-amethyst-dragon",
     "type": null
@@ -12421,7 +12421,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 14). It can innately cast the following spells, requiring no material components. 3/day each:fog cloud, pass without trace",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 14). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Fog Cloud, Pass Without Trace",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-black-dragon",
     "type": null
@@ -12461,7 +12461,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components. 3/day each:blur, silent image",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Blur, Silent Image",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-blue-dragon",
     "type": null
@@ -12471,7 +12471,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 14). It can innately cast the following spells, requiring no material components. 3/day each:comprehend languages,",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 14). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**comprehend languages,",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-brass-dragon",
     "type": null
@@ -12501,7 +12501,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components. 3/day each:fog cloud, speak with animals",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Fog Cloud, Speak with Animals",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-bronze-dragon",
     "type": null
@@ -12531,7 +12531,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components. 3/day each:hideous laughter, suggestion",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Hideous Laughter, Suggestion",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-copper-dragon",
     "type": null
@@ -12571,7 +12571,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 12). It can innately cast the following spells, requiring no material components. 3/day each:locate animals or plants, spike growth",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 12). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Locate Animals or Plants, Spike Growth",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-earth-dragon",
     "type": null
@@ -12591,7 +12591,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components. 3/day each:hideous laughter, suggestion",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Hideous Laughter, Suggestion",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-emerald-dragon",
     "type": null
@@ -12601,7 +12601,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components. 3/day each:bless, healing word",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Bless, Healing Word",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-gold-dragon",
     "type": null
@@ -12631,7 +12631,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 14). It can innately cast the following spells, requiring no material components. 3/day each:animal messenger, tongues",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 14). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:** Animal Messenger, Tongues",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-green-dragon",
     "type": null
@@ -12671,7 +12671,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 16). It can innately cast the following spells, requiring no material components. 3/day each:command, hold person",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 16). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Command, Hold Person",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-red-dragon",
     "type": null
@@ -12731,7 +12731,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 13). It can innately cast the following spells, requiring no material components. 3/day each:create or destroy water, fog cloud",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 13). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Create or Destroy Water, Fog Cloud",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-river-dragon",
     "type": null
@@ -12761,7 +12761,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components. 3/day each:comprehend languages, detect thoughts",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 15). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**comprehend languages, Detect Thoughts",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-sapphire-dragon",
     "type": null
@@ -12801,7 +12801,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 16). It can innately cast the following spells, requiring no material components. 3/day each:darkness, detect evil and good",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 16). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Darkness, Detect Evil and Good",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-shadow-dragon",
     "type": null
@@ -12821,7 +12821,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components. 3/day each:charm person, faerie fire",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 17). It can innately cast the following spells, requiring no material components.\n\n- **3/Day Each:** Charm Person, Faerie Fire",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-silver-dragon",
     "type": null
@@ -12841,7 +12841,7 @@
 },
 {
   "fields": {
-    "desc": "The dragons spellcasting ability is Charisma (save DC 13). It can innately cast the following spells, requiring no material components. 3/day each:animal friendship, sleet storm",
+    "desc": "The dragons spellcasting ability is Charisma (save DC 13). It can innately cast the following spells, requiring no material components.\n- **3/Day Each:**Animal Friendship, Sleet Storm",
     "name": "Innate Spellcasting",
     "parent": "a5e-mm_young-white-dragon",
     "type": null

--- a/data/v2/green-ronin/tdcs/CreatureTrait.json
+++ b/data/v2/green-ronin/tdcs/CreatureTrait.json
@@ -11,7 +11,7 @@
 },
 {
   "fields": {
-    "desc": "The firetamer is a 9th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). It has the following druid spells prepared:\n\n* Cantrips (at will): druidcraft, mending, produce flame\n* 1st level (4 slots): cure wounds, faerie fire, longstrider, jump\n* 2nd level (3 slots): flame blade, heat metal, lesser restoration\n* 3rd level (3 slots): daylight, dispel magic, protection from energy\n* 4th level (3 slots): blight, freedom of movement, wall of fire 5th level (1 slot): conjure elemental",
+    "desc": "The firetamer is a 9th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). It has the following druid spells prepared:\n\n- **Cantrips** (at will): druidcraft, mending, produce flame\n- **1st Level** (4 slots): cure wounds, faerie fire, longstrider, jump\n- **2nd Level** (3 slots): flame blade, heat metal, lesser restoration\n- **3rd Level** (3 slots): daylight, dispel magic, protection from energy\n- **4th Level** (3 slots): blight, freedom of movement, wall of fire 5th level (1 slot): conjure elemental",
     "name": "Spellcasting",
     "parent": "tdcs_firetamer",
     "type": null
@@ -51,7 +51,7 @@
 },
 {
   "fields": {
-    "desc": "The skydancer is a 3rd-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following druid spells prepared:\n\n* Cantrips (at will): guidance, shillelagh\n* 1st level (4 slots): fog cloud, entangle, jump\n* 2nd level (2 slots): gust of wind, skywrite",
+    "desc": "The skydancer is a 3rd-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following druid spells prepared:\n\n- **Cantrips** (at will): guidance, shillelagh\n- **1st Level** (4 slots): fog cloud, entangle, jump\n- **2nd Level** (2 slots): gust of wind, skywrite",
     "name": "Spellcasting",
     "parent": "tdcs_skydancer",
     "type": null
@@ -61,7 +61,7 @@
 },
 {
   "fields": {
-    "desc": "The stoneguard is a 3rd-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following druid spells prepared:\n\n* Cantrips (at will): druidcraft, resistance\n* 1st level (4 slots): goodberry, speak with animals, thunderwave\n* 2nd level (2 slots): hold person, spike growth",
+    "desc": "The stoneguard is a 3rd-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following druid spells prepared:\n\n- **Cantrips** (at will): druidcraft, resistance\n- **1st Level** (4 slots): goodberry, speak with animals, thunderwave\n- **2nd Level** (2 slots): hold person, spike growth",
     "name": "Spellcasting",
     "parent": "tdcs_stoneguard",
     "type": null
@@ -101,7 +101,7 @@
 },
 {
   "fields": {
-    "desc": "The waverider is a 7th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following druid spells prepared:\n\n* Cantrips (at will): druidcraft, poison spray, resistance\n* 1st level (4 slots): cure wounds, create or destroy water, healing word\n* 2nd level (3 slots): animal messenger, enhance ability, lesser restoration\n* 3rd level (3 slots): conjure animals (aquatic beasts only), water walk, water breathing\n* 4th level (1 slots): control water",
+    "desc": "The waverider is a 7th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following druid spells prepared:\n\n- **Cantrips** (at will): druidcraft, poison spray, resistance\n- **1st Level** (4 slots): cure wounds, create or destroy water, healing word\n- **2nd Level** (3 slots): animal messenger, enhance ability, lesser restoration\n- **3rd Level** (3 slots): conjure animals (aquatic beasts only), water walk, water breathing\n- **4th Level** (1 slots): control water",
     "name": "Spellcasting",
     "parent": "tdcs_waverider",
     "type": null

--- a/data/v2/kobold-press/bfrd/CreatureAction.json
+++ b/data/v2/kobold-press/bfrd/CreatureAction.json
@@ -152,7 +152,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The acolyte casts one of the following spells using WIS as the spellcasting ability (spell save DC 13).<br>At will: _light_, _thaumaturgy_<br>3/day each: _bless_, _cure wounds_, _sanctuary_",
+    "desc": "The acolyte casts one of the following spells using WIS as the spellcasting ability (spell save DC 13).\n\n- **At Will:** _light_, _thaumaturgy_\n- **3/Day Each:** _bless_, _cure wounds_, _sanctuary_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -2252,7 +2252,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The ambush hag casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 16):<br>At will: _message_, _minor illusion_, _prestidigitation_<br>3/day each: _blur_, _charm_, _hallucinatory terrain_ (as an action)<br>1/day each: _hypnotic pattern_, _major image_, _seeming_",
+    "desc": "The ambush hag casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 16):\n\n- **At Will:** _message_, _minor illusion_, _prestidigitation_\n- **3/Day Each:** _blur_, _charm_, _hallucinatory terrain_ (as an action)\n- **1/Day Each:** _hypnotic pattern_, _major image_, _seeming_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -4322,7 +4322,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The sphinx casts one of the following spells, requiring no material components and using WIS as the spellcasting ability (spell save DC 18).<br>At will: _command_, _detect evil and good_, _thaumaturgy_<br>3/day each: _dispel magic_, _restoration_, _tongues_, _zone of truth_<br>2/day each: _freedom of movement_, _greater restoration_<br>1/day: _heal_",
+    "desc": "The sphinx casts one of the following spells, requiring no material components and using WIS as the spellcasting ability (spell save DC 18).\n\n- **At Will:** _command_, _detect evil and good_, _thaumaturgy_\n- **3/Day Each:** _dispel magic_, _restoration_, _tongues_, _zone of truth_\n- **2/Day Each:** _freedom of movement_, _greater restoration_<br>1/day: _heal_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -4592,7 +4592,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The archdruid casts one of the following spells, using WIS as the spellcasting ability (spell save DC 17).<br>At will: _animal friendship_, _druidcraft_, _entangle_, _speak with animals_<br>3/day each: _heat metal_, _spike growth_, _plant growth_, _speak with plants_<br>1/day each: _polymorph_, _insect plague_",
+    "desc": "The archdruid casts one of the following spells, using WIS as the spellcasting ability (spell save DC 17).\n\n- **At Will:** _animal friendship_, _druidcraft_, _entangle_, _speak with animals_\n- **3/Day Each:** _heat metal_, _spike growth_, _plant growth_, _speak with plants_\n- **1/Day Each:** _polymorph_, _insect plague_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -4697,7 +4697,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The archmage casts one of the following spells, using INT as the spellcasting ability (spell save DC 17).<br>At will: _detect magic_, _disguise self_, _mage hand_, _prestidigitation_<br>3/day each: _charm_, _dispel magic_, _fly_, _invisibility_ (self only), _mirror image_<br>1/day each: _dimension door_, _greater hold_, _wall of force_",
+    "desc": "The archmage casts one of the following spells, using INT as the spellcasting ability (spell save DC 17).\n\n- **At Will:** _detect magic_, _disguise self_, _mage hand_, _prestidigitation_\n- **3/Day Each:** _charm_, _dispel magic_, _fly_, _invisibility_ (self only), _mirror image_\n- **1/Day Each:** _dimension door_, _greater hold_, _wall of force_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -5417,7 +5417,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The bard casts one of the following spells, using CHA as the spellcasting ability (spell save DC 15).<br>At will: dancing lights, mage hand, message<br>3/day each: _faerie fire_, _hold_, _suggestion_<br>1/day each: _confusion_, _greater invisibility_",
+    "desc": "The bard casts one of the following spells, using CHA as the spellcasting ability (spell save DC 15).\n\n- **At Will:** dancing lights, mage hand, message\n- **3/Day Each:** _faerie fire_, _hold_, _suggestion_\n- **1/Day Each:** _confusion_, _greater invisibility_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -7547,7 +7547,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The fanatic casts one of the following spells, using WIS as the spellcasting ability (spell save DC 13).<br>At will: _light_, _thaumaturgy_<br>3/day each: _bane_, _command_<br>2/day: _hold_",
+    "desc": "The fanatic casts one of the following spells, using WIS as the spellcasting ability (spell save DC 13).\n\n- **At Will:** _light_, _thaumaturgy_\n- **3/Day Each:** _bane_, _command_<br>2/day: _hold_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -8432,7 +8432,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The druid casts one of the following spells, using WIS as the spellcasting ability (spell save DC 13).<br>At will: druidcraft, speak with animals<br>3/day each: _entangle_, _cure wounds_, _thunderwave_<br>2/day each: _barkskin_, _spike growth_",
+    "desc": "The druid casts one of the following spells, using WIS as the spellcasting ability (spell save DC 13).\n\n- **At Will:** druidcraft, speak with animals\n- **3/Day Each:** _entangle_, _cure wounds_, _thunderwave_\n- **2/Day Each:** _barkskin_, _spike growth_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -10892,7 +10892,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The hag casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 14).<br>At will: _dancing lights_, _minor illusion_<br>1/day: _bestow curse_",
+    "desc": "The hag casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 14).\n\n- **At Will:** _dancing lights_, _minor illusion_<br>1/day: _bestow curse_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -11132,7 +11132,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The guardian naga casts one of the following spells, requiring only verbal components and using WIS as the spellcasting ability (spell save DC 16).<br>At will: _augury_ (as an action), _command_, _mending_, _thaumaturgy_<br>3/day each: _bestow curse_, _cure wounds_<br>2/day each: _freedom of movement_, _hold_<br>1/day: _geas_ (as an action)",
+    "desc": "The guardian naga casts one of the following spells, requiring only verbal components and using WIS as the spellcasting ability (spell save DC 16).\n\n- **At Will:** _augury_ (as an action), _command_, _mending_, _thaumaturgy_\n- **3/Day Each:** _bestow curse_, _cure wounds_\n- **2/Day Each:** _freedom of movement_, _hold_<br>1/day: _geas_ (as an action)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -11282,7 +11282,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The sphinx casts one of the following spells, requiring no spell components and using CHA as the spellcasting ability (spell save DC 17).<br>At will: _detect magic_, _minor illusion_, _prestidigitation_<br>3/day each: _augury_ (as an action), _major image_, _suggestion_, _tongues_<br>1/day: h*allucinatory terrain* (as an action)",
+    "desc": "The sphinx casts one of the following spells, requiring no spell components and using CHA as the spellcasting ability (spell save DC 17).\n\n- **At Will:** _detect magic_, _minor illusion_, _prestidigitation_\n- **3/Day Each:** _augury_ (as an action), _major image_, _suggestion_, _tongues_<br>1/day: h*allucinatory terrain* (as an action)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -13082,7 +13082,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The kobold witch casts one of the following spells, using CHA as the spellcasting ability (spell save DC 15).<br>At will: _disguise self_, _druidcraft_, _guidance_<br>2/day each: _command_, _ray of enfeeblement_<br>1/day: _bestow curse_",
+    "desc": "The kobold witch casts one of the following spells, using CHA as the spellcasting ability (spell save DC 15).\n\n- **At Will:** _disguise self_, _druidcraft_, _guidance_\n- **2/Day Each:** _command_, _ray of enfeeblement_<br>1/day: _bestow curse_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -13382,7 +13382,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The lamia casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 13).<br>At will: _minor illusion_, _silent image_, _suggestion_<br>3/day each: _charm_, _command_, _major image_<br>1/day: _compulsion_",
+    "desc": "The lamia casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 13).\n\n- **At Will:** _minor illusion_, _silent image_, _suggestion_\n- **3/Day Each:** _charm_, _command_, _major image_<br>1/day: _compulsion_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -13622,7 +13622,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The lich casts one of the following spells, using INT as the spellcasting ability (spell save DC 20).<br>At will: _detect magic_, _disguise self_, _mage hand_, _message_, _prestidigitation_<br>3/day each: _charm_, _detect thoughts_, _dispel magic_, _invisibility_ (self only), _mirror image_<br>2/day each: _bestow curse_, _cloudkill_, _dimension door_, _greater hold_<br>1/day each: _plane shift_ (self only), _power word stun_, _wall of force_",
+    "desc": "The lich casts one of the following spells, using INT as the spellcasting ability (spell save DC 20).\n\n- **At Will:** _detect magic_, _disguise self_, _mage hand_, _message_, _prestidigitation_\n- **3/Day Each:** _charm_, _detect thoughts_, _dispel magic_, _invisibility_ (self only), _mirror image_\n- **2/Day Each:** _bestow curse_, _cloudkill_, _dimension door_, _greater hold_\n- **1/Day Each:** _plane shift_ (self only), _power word stun_, _wall of force_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -13997,7 +13997,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The lizardfolk shaman casts one of the following spells, using WIS as the spellcasting ability (spell save DC 13).<br>At will: _druidcraft_, _guidance_, _mending_<br>2/day each: _cure wounds_, _entangle_, _grease_<br>1/day: _ray of enfeeblement_",
+    "desc": "The lizardfolk shaman casts one of the following spells, using WIS as the spellcasting ability (spell save DC 13).\n\n- **At Will:** _druidcraft_, _guidance_, _mending_\n- **2/Day Each:** _cure wounds_, _entangle_, _grease_<br>1/day: _ray of enfeeblement_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -14132,7 +14132,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mage apprentice casts one of the following spells, using INT as the spellcasting ability (spell save DC 12).<br>At will: _mage hand_, _minor illusion_<br>1/day each: _color spray_, _mage armor_, _sleep_",
+    "desc": "The mage apprentice casts one of the following spells, using INT as the spellcasting ability (spell save DC 12).\n\n- **At Will:** _mage hand_, _minor illusion_\n- **1/Day Each:** _color spray_, _mage armor_, _sleep_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -14192,7 +14192,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mage casts one of the following spells, using INT as the spellcasting ability (spell save DC 14).<br>At will: _detect magic_, _light_, _mage hand_, _prestidigitation_<br>3/day each: _fly_, _mage armor_, _mirror image_<br>2/day each: _fireball_, _haste_, _slow_<br>1/day each: _cone of cold_, _greater invisibility_",
+    "desc": "The mage casts one of the following spells, using INT as the spellcasting ability (spell save DC 14).\n\n- **At Will:** _detect magic_, _light_, _mage hand_, _prestidigitation_\n- **3/Day Each:** _fly_, _mage armor_, _mirror image_\n- **2/Day Each:** _fireball_, _haste_, _slow_\n- **1/Day Each:** _cone of cold_, _greater invisibility_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -15467,7 +15467,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mummy lord casts one of the following spells, using WIS as the spellcasting ability (spell save DC 17).<br>At will: _command_, _guidance_, _thaumaturgy_<br>3/day each: _dispel magic_, _hold_, _silence_<br>1/day each: _contagion_, _insect plague_",
+    "desc": "The mummy lord casts one of the following spells, using WIS as the spellcasting ability (spell save DC 17).\n\n- **At Will:** _command_, _guidance_, _thaumaturgy_\n- **3/Day Each:** _dispel magic_, _hold_, _silence_\n- **1/Day Each:** _contagion_, _insect plague_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -15887,7 +15887,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The hag casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 14).<br>At will: _ray of enfeeblement_, _silent image_<br>2/day each: _detect thoughts_, _plane shift_ (self only), _sleep_",
+    "desc": "The hag casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 14).\n\n- **At Will:** _ray of enfeeblement_, _silent image_\n- **2/Day Each:** _detect thoughts_, _plane shift_ (self only), _sleep_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -16292,7 +16292,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The oni casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 14).<br>At will: _darkness_, _invisibility_ (self only)<br>1/day each: _charm_, _gaseous form_, _sleep_",
+    "desc": "The oni casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 14).\n\n- **At Will:** _darkness_, _invisibility_ (self only)\n- **1/Day Each:** _charm_, _gaseous form_, _sleep_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -17012,7 +17012,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The planetar casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 19).<br>At will: _command_, _invisibility_ (self only)<br>3/day each: _daylight_, _raise dead_ (as an action)",
+    "desc": "The planetar casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 19).\n\n- **At Will:** _command_, _invisibility_ (self only)\n- **3/Day Each:** _daylight_, _raise dead_ (as an action)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -17132,7 +17132,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The priest casts one of the following spells, using WIS as the spellcasting ability (spell save DC 13).<br>At will: _guidance_, _light_, _thaumaturgy_<br>2/day each: _bane_, _bless_, _cure wounds_<br>1/day each: _dispel magic_, _restoration_",
+    "desc": "The priest casts one of the following spells, using WIS as the spellcasting ability (spell save DC 13).\n\n- **At Will:** _guidance_, _light_, _thaumaturgy_\n- **2/Day Each:** _bane_, _bless_, _cure wounds_\n- **1/Day Each:** _dispel magic_, _restoration_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -17447,7 +17447,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The rakshasa casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 18).<br>At will: _detect thoughts_, _mage hand_, _minor illusion_<br>3/day each: _major image_, _suggestion_<br>1/day: _dominate_",
+    "desc": "The rakshasa casts one of the following spells, requiring no material components and using CHA as the spellcasting ability (spell save DC 18).\n\n- **At Will:** _detect thoughts_, _mage hand_, _minor illusion_\n- **3/Day Each:** _major image_, _suggestion_<br>1/day: _dominate_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -19412,7 +19412,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The solar casts one of the following spells, requiring no material components and using WIS as the spellcasting ability (spell save DC 22).<br>At will: _command_, _invisibility_ (self only)<br>3/day each: _greater restoration_, _resurrection_ (as an action)<br>1/day: _holy aura_",
+    "desc": "The solar casts one of the following spells, requiring no material components and using WIS as the spellcasting ability (spell save DC 22).\n\n- **At Will:** _command_, _invisibility_ (self only)\n- **3/Day Each:** _greater restoration_, _resurrection_ (as an action)<br>1/day: _holy aura_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -19607,7 +19607,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The spirit naga casts one of the following spells, requiring only verbal components and using CHA as the spellcasting ability (spell save DC 14).<br>At will: _command_, _mage hand_, _minor illusion_<br>3/day each: _augury_ (as an action), _charm_, _sleep_<br>2/day each: _bestow curse_, _hold_<br>1/day: _dominate_",
+    "desc": "The spirit naga casts one of the following spells, requiring only verbal components and using CHA as the spellcasting ability (spell save DC 14).\n\n- **At Will:** _command_, _mage hand_, _minor illusion_\n- **3/Day Each:** _augury_ (as an action), _charm_, _sleep_\n- **2/Day Each:** _bestow curse_, _hold_<br>1/day: _dominate_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -21632,7 +21632,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The lich casts one of the following spells, using CHA as the spellcasting ability (spell save DC 17).<br>At will: _disguise self_, _mage hand_, _message_, _prestidigitation_<br>3/day each: _charm_, _hideous laughter_, _hold_, _invisibility_ (self only)<br>2/day each: _dispel magic_, _fear_, _dimension door_<br>1/day each: _irresistible dance_, _programmed illusion_, _seeming_",
+    "desc": "The lich casts one of the following spells, using CHA as the spellcasting ability (spell save DC 17).\n\n- **At Will:** _disguise self_, _mage hand_, _message_, _prestidigitation_\n- **3/Day Each:** _charm_, _hideous laughter_, _hold_, _invisibility_ (self only)\n- **2/Day Each:** _dispel magic_, _fear_, _dimension door_\n- **1/Day Each:** _irresistible dance_, _programmed illusion_, _seeming_",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",

--- a/data/v2/kobold-press/ccdx/CreatureTrait.json
+++ b/data/v2/kobold-press/ccdx/CreatureTrait.json
@@ -1251,7 +1251,7 @@
 },
 {
   "fields": {
-    "desc": "The priestess is a 6th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priestess has the following cleric spells prepared:\nCantrips (at will): guidance, mending, resistance, sacred flame\n1st level (4 slots): bane, command, cure wounds, detect magic\n2nd level (3 slots): augury, spiritual weapon\n3rd level (3 slots): animate dead, bestow curse, spirit guardians",
+    "desc": "The priestess is a 6th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priestess has the following cleric spells prepared:\n\n- **Cantrips** (at will): guidance, mending, resistance, sacred flame\n- **1st Level** (4 slots): bane, command, cure wounds, detect magic\n- **2nd Level** (3 slots): augury, spiritual weapon\n- **3rd Level** (3 slots): animate dead, bestow curse, spirit guardians",
     "name": "Spellcasting",
     "parent": "ccdx_black-sun-priestess",
     "type": null
@@ -2021,7 +2021,7 @@
 },
 {
   "fields": {
-    "desc": "The cueyatl moon priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following cleric spells prepared: \nCantrips (at will): guidance, resistance, sacred flame, spare the dying\n1st level (4 slots): bane, cure wounds, protection from evil and good\n2nd level (3 slots): hold person, silence, spiritual weapon\n3rd level (2 slots): bestow curse, spirit guardians",
+    "desc": "The cueyatl moon priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following cleric spells prepared: \n\n- **Cantrips** (at will): guidance, resistance, sacred flame, spare the dying\n- **1st Level** (4 slots): bane, cure wounds, protection from evil and good\n- **2nd Level** (3 slots): hold person, silence, spiritual weapon\n- **3rd Level** (2 slots): bestow curse, spirit guardians",
     "name": "Spellcasting",
     "parent": "ccdx_cueyatl-moon-priest",
     "type": null
@@ -2081,7 +2081,7 @@
 },
 {
   "fields": {
-    "desc": "The cueyatl sea priest is a 2nd-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). It has the following druid spells prepared: \nCantrips (at will): guidance, poison spray\n1st level (3 slots): animal friendship, create or destroy water, fog cloud, speak with animals",
+    "desc": "The cueyatl sea priest is a 2nd-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). It has the following druid spells prepared: \n\n- **Cantrips** (at will): guidance, poison spray\n- **1st Level** (3 slots): animal friendship, create or destroy water, fog cloud, speak with animals",
     "name": "Spellcasting",
     "parent": "ccdx_cueyatl-sea-priest",
     "type": null
@@ -2201,7 +2201,7 @@
 },
 {
   "fields": {
-    "desc": "The darakhul high priestess is a 15th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has the following cleric spells prepared: \nCantrips (at will): guidance, mending, resistance, sacred flame, spare the dying, thaumaturgy\n1st level (4 slots): bane, command, inflict wounds, protection from evil and good, shield of faith\n2nd level (3 slots): blindness/deafness, hold person, spiritual weapon\n3rd level (3 slots): animate dead, bestow curse, protection from energy, spirit guardians\n4th level (3 slots): banishment, stone shape\n5th level (2 slot): contagion, insect plague\n6th level (1 slot): create undead\n7th level (1 slot): regenerate\n8th level (1 slot): antimagic field",
+    "desc": "The darakhul high priestess is a 15th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has the following cleric spells prepared: \n\n- **Cantrips** (at will): guidance, mending, resistance, sacred flame, spare the dying, thaumaturgy\n- **1st Level** (4 slots): bane, command, inflict wounds, protection from evil and good, shield of faith\n- **2nd Level** (3 slots): blindness/deafness, hold person, spiritual weapon\n- **3rd Level** (3 slots): animate dead, bestow curse, protection from energy, spirit guardians\n- **4th Level** (3 slots): banishment, stone shape\n- **5th Level** (2 slot): contagion, insect plague\n- **6th Level** (1 slot): create undead\n- **7th Level** (1 slot): regenerate\n- **8th Level** (1 slot): antimagic field",
     "name": "Spellcasting",
     "parent": "ccdx_darakhul-high-priestess",
     "type": null
@@ -2261,7 +2261,7 @@
 },
 {
   "fields": {
-    "desc": "The darakhul shadowmancer is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). It has the following wizard spells prepared: \nCantrips (at will): acid splash, chill touch, mage hand, prestidigitation\n1st level (4 slots): mage armor, ray of sickness, silent image\n2nd level (3 slots): misty step, scorching ray, see invisibility\n3rd level (3 slots): animate dead, dispel magic, stinking cloud\n4th level (2 slots): arcane eye, black tentacles, confusion\n5th level (1 slot): teleportation circle",
+    "desc": "The darakhul shadowmancer is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). It has the following wizard spells prepared: \n\n- **Cantrips** (at will): acid splash, chill touch, mage hand, prestidigitation\n- **1st Level** (4 slots): mage armor, ray of sickness, silent image\n- **2nd Level** (3 slots): misty step, scorching ray, see invisibility\n- **3rd Level** (3 slots): animate dead, dispel magic, stinking cloud\n- **4th Level** (2 slots): arcane eye, black tentacles, confusion\n- **5th Level** (1 slot): teleportation circle",
     "name": "Spellcasting",
     "parent": "ccdx_darakhul-shadowmancer",
     "type": null
@@ -3091,7 +3091,7 @@
 },
 {
   "fields": {
-    "desc": "The enchanter is a 13th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The enchanter has the following wizard spells prepared: \nCantrips (at will): dancing lights, friends, mage hand, message, prestidigitation\n1st level (4 slots): charm person*, hideous laughter*, magic missile\n2nd level (3 slots): hold person*, invisibility, suggestion*\n3rd level (3 slots): hypnotic pattern, lightning bolt\n4th level (3 slots): confusion*, conjure minor elementals\n5th level (2 slots): dominate person*, hold monster*, mislead, modify memory*\n6th level (1 slots): irresistible dance*, chain lightning\n7th level (1 slot): prismatic spray*\nEnchantment spell of 1st level or higher",
+    "desc": "The enchanter is a 13th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The enchanter has the following wizard spells prepared: \n\n- **Cantrips** (at will): dancing lights, friends, mage hand, message, prestidigitation\n- **1st Level** (4 slots): charm person*, hideous laughter*, magic missile\n- **2nd Level** (3 slots): hold person*, invisibility, suggestion*\n- **3rd Level** (3 slots): hypnotic pattern, lightning bolt\n- **4th Level** (3 slots): confusion*, conjure minor elementals\n- **5th Level** (2 slots): dominate person*, hold monster*, mislead, modify memory*\n- **6th Level** (1 slots): irresistible dance*, chain lightning\n- **7th Level** (1 slot): prismatic spray*\nEnchantment spell of 1st level or higher",
     "name": "Spellcasting",
     "parent": "ccdx_enchanter",
     "type": null
@@ -4541,7 +4541,7 @@
 },
 {
   "fields": {
-    "desc": "The lich is an 9th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The lich has the following cleric spells prepared:\nCantrips (at will): guidance, mending, sacred flame, thaumaturgy\n1st level (4 slots): command, detect magic, protection from evil and good, sanctuary\n2nd level (3 slots): blindness/deafness, hold person, silence\n3rd level (3 slots): animate dead, dispel magic, spirit guardians\n4th level (3 slots): banishment, freedom of movement, guardian of faith\n5th level (1 slot): flame strike",
+    "desc": "The lich is an 9th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The lich has the following cleric spells prepared:\n\n- **Cantrips** (at will): guidance, mending, sacred flame, thaumaturgy\n- **1st Level** (4 slots): command, detect magic, protection from evil and good, sanctuary\n- **2nd Level** (3 slots): blindness/deafness, hold person, silence\n- **3rd Level** (3 slots): animate dead, dispel magic, spirit guardians\n- **4th Level** (3 slots): banishment, freedom of movement, guardian of faith\n- **5th Level** (1 slot): flame strike",
     "name": "Spellcasting",
     "parent": "ccdx_hierophant-lich",
     "type": null
@@ -5221,7 +5221,7 @@
 },
 {
   "fields": {
-    "desc": "The king kobold is a 4th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). It has the following wizard spells prepared: \nCantrips (at will): fire bolt, mage hand, minor illusion, poison spray\n1st level (4 slots): alarm, grease, mage armor\n2nd level (3 slots): alter self, hold person, invisibility",
+    "desc": "The king kobold is a 4th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). It has the following wizard spells prepared: \n\n- **Cantrips** (at will): fire bolt, mage hand, minor illusion, poison spray\n- **1st Level** (4 slots): alarm, grease, mage armor\n- **2nd Level** (3 slots): alter self, hold person, invisibility",
     "name": "Spellcasting",
     "parent": "ccdx_king-kobold",
     "type": null
@@ -6311,7 +6311,7 @@
 },
 {
   "fields": {
-    "desc": "The necrophage ghast is a 5th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The necrophage ghast has the following wizard spells prepared: \nCantrips (at will): friends, mage hand, poison spray, prestidigitation\n1st level (4 slots): charm person, false life, magic missile, ray of sickness\n2nd level (3 slots): hold person, invisibility\n3rd level (2 slots): animate dead, hypnotic pattern",
+    "desc": "The necrophage ghast is a 5th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The necrophage ghast has the following wizard spells prepared: \n\n- **Cantrips** (at will): friends, mage hand, poison spray, prestidigitation\n- **1st Level** (4 slots): charm person, false life, magic missile, ray of sickness\n- **2nd Level** (3 slots): hold person, invisibility\n- **3rd Level** (2 slots): animate dead, hypnotic pattern",
     "name": "Spellcasting",
     "parent": "ccdx_necrophage-ghast",
     "type": null
@@ -6631,7 +6631,7 @@
 },
 {
   "fields": {
-    "desc": "The ouroban is a 14th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 16, +8 to hit with spell attacks). It has the following paladin spells prepared:\n1st level (4 slots): command, cure wounds, detect evil and good, detect magic, divine favor (fire damage instead of radiant)\n2nd level (3 slots): branding smite, lesser restoration, zone of truth\n3rd level (3 slots): dispel magic, elemental weapon\n4th level (1 slot): banishment",
+    "desc": "The ouroban is a 14th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 16, +8 to hit with spell attacks). It has the following paladin spells prepared:\n\n- **1st Level** (4 slots): command, cure wounds, detect evil and good, detect magic, divine favor (fire damage instead of radiant)\n- **2nd Level** (3 slots): branding smite, lesser restoration, zone of truth\n- **3rd Level** (3 slots): dispel magic, elemental weapon\n- **4th Level** (1 slot): banishment",
     "name": "Spellcasting",
     "parent": "ccdx_ouroban",
     "type": null
@@ -6861,7 +6861,7 @@
 },
 {
   "fields": {
-    "desc": "The pattern dancer is a 5th-levelspellcaster. Its spellcasting ability is Charisma (spell save DC 13, +5 to hit with spell attacks). It has the following wizard spells prepared:\nCantrips (at will): dancing lights, friends, minor illusion, poison spray\n1st level (4 slots): color spray, disguise self, magic missile, shield\n2nd level (3 slots): blur, mirror image\n3rd level (2 slots): major image, nondetection",
+    "desc": "The pattern dancer is a 5th-levelspellcaster. Its spellcasting ability is Charisma (spell save DC 13, +5 to hit with spell attacks). It has the following wizard spells prepared:\n\n- **Cantrips** (at will): dancing lights, friends, minor illusion, poison spray\n- **1st Level** (4 slots): color spray, disguise self, magic missile, shield\n- **2nd Level** (3 slots): blur, mirror image\n- **3rd Level** (2 slots): major image, nondetection",
     "name": "Spellcasting",
     "parent": "ccdx_pattern-dancer",
     "type": null
@@ -7271,7 +7271,7 @@
 },
 {
   "fields": {
-    "desc": "The ramag portal master is a 7th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). It has the following wizard spells prepared:\nCantrips (at will): fire bolt, light, prestidigitation, shocking grasp\n1st level (4 slots): burning hands, mage armor, magic missile\n2nd level (3 slots): arcane lock, hold person, levitate, misty step\n3rd level (3 slots): counterspell, dispel magic, fireball\n4th level (1 slot): banishment",
+    "desc": "The ramag portal master is a 7th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). It has the following wizard spells prepared:\n\n- **Cantrips** (at will): fire bolt, light, prestidigitation, shocking grasp\n- **1st Level** (4 slots): burning hands, mage armor, magic missile\n- **2nd Level** (3 slots): arcane lock, hold person, levitate, misty step\n- **3rd Level** (3 slots): counterspell, dispel magic, fireball\n- **4th Level** (1 slot): banishment",
     "name": "Spellcasting",
     "parent": "ccdx_ramag-portal-master",
     "type": null
@@ -7681,7 +7681,7 @@
 },
 {
   "fields": {
-    "desc": "The servant of the vine is an 11th-level spellcaster. Its primary spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following cleric spells prepared:\nCantrips (at will): guidance, light, sacred flame, thaumaturgy\n1st level (4 slots): bless, create or destroy water (creates or destroys wine; wine created this way evaporates after 1 day), cure wounds, sanctuary\n2nd level (3 slots): hold person, lesser restoration, protection from poison\n3rd level (3 slots): bestow curse, dispel magic\n4th level (3 slots): guardian of faith, freedom of movement\n5th level (2 slots): contagion\n6th level (1 slot): harm, heal",
+    "desc": "The servant of the vine is an 11th-level spellcaster. Its primary spellcasting ability is Wisdom (spell save DC 14, +6 to hit with spell attacks). It has the following cleric spells prepared:\n\n- **Cantrips** (at will): guidance, light, sacred flame, thaumaturgy\n- **1st Level** (4 slots): bless, create or destroy water (creates or destroys wine; wine created this way evaporates after 1 day), cure wounds, sanctuary\n- **2nd Level** (3 slots): hold person, lesser restoration, protection from poison\n- **3rd Level** (3 slots): bestow curse, dispel magic\n- **4th Level** (3 slots): guardian of faith, freedom of movement\n- **5th Level** (2 slots): contagion\n- **6th Level** (1 slot): harm, heal",
     "name": "Spellcasting",
     "parent": "ccdx_servant-of-the-vine",
     "type": null
@@ -8781,7 +8781,7 @@
 },
 {
   "fields": {
-    "desc": "The trollkin shaman is an 8th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). It has the following druid spells prepared: \nCantrips (at will): druidcraft, produce flame, shillelagh\n1st level (4 slots): cure wounds, entangle, faerie fire, thunderwave\n2nd level (3 slots): flaming sphere, hold person\n3rd level (3 slots): dispel magic, meld into stone, sleet storm\n4th level (2 slots): dominate beast, grasping vine",
+    "desc": "The trollkin shaman is an 8th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). It has the following druid spells prepared: \n\n- **Cantrips** (at will): druidcraft, produce flame, shillelagh\n- **1st Level** (4 slots): cure wounds, entangle, faerie fire, thunderwave\n- **2nd Level** (3 slots): flaming sphere, hold person\n- **3rd Level** (3 slots): dispel magic, meld into stone, sleet storm\n- **4th Level** (2 slots): dominate beast, grasping vine",
     "name": "Spellcasting",
     "parent": "ccdx_trollkin-shaman",
     "type": null
@@ -9091,7 +9091,7 @@
 },
 {
   "fields": {
-    "desc": "The vampire priestess is a 9th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has the following cleric spells prepared:\nCantrips (at will): light, guidance, poison spray, thaumaturgy\n1st level (4 slots): bane, command, inflict wounds, ray of sickness\n2nd level (3 slots): blindness/deafness, silence, spiritual weapon\n3rd level (3 slots): bestow curse, dispel magic, spirit guardians\n4th level (3 slots): banishment, freedom of movement\n5th level (1 slot): contagion, flame strike",
+    "desc": "The vampire priestess is a 9th-level spellcaster. Her spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). She has the following cleric spells prepared:\n\n- **Cantrips** (at will): light, guidance, poison spray, thaumaturgy\n- **1st Level** (4 slots): bane, command, inflict wounds, ray of sickness\n- **2nd Level** (3 slots): blindness/deafness, silence, spiritual weapon\n- **3rd Level** (3 slots): bestow curse, dispel magic, spirit guardians\n- **4th Level** (3 slots): banishment, freedom of movement\n- **5th Level** (1 slot): contagion, flame strike",
     "name": "Spellcasting",
     "parent": "ccdx_vampire-priestess",
     "type": null
@@ -9281,7 +9281,7 @@
 },
 {
   "fields": {
-    "desc": "The void giant is an 11th-level spellcaster. Its spellcasting ability is Intelligence (save DC 16, +8 to hit with spell attacks). The void giant has the following wizard spells prepared: \nCantrips (at will): chill touch, light, mending, shocking grasp\n1st level (4 slots): comprehend languages, magic missile, shield\n2nd level (3 slots): crown of madness, mirror image, scorching ray\n3rd level (3 slots): counterspell, fly, lightning bolt\n4th level (3 slots): confusion, ice storm, phantasmal killer\n5th level (2 slots): cone of cold, dominate person\n6th level (1 slot): disintegrate",
+    "desc": "The void giant is an 11th-level spellcaster. Its spellcasting ability is Intelligence (save DC 16, +8 to hit with spell attacks). The void giant has the following wizard spells prepared: \n\n- **Cantrips** (at will): chill touch, light, mending, shocking grasp\n- **1st Level** (4 slots): comprehend languages, magic missile, shield\n- **2nd Level** (3 slots): crown of madness, mirror image, scorching ray\n- **3rd Level** (3 slots): counterspell, fly, lightning bolt\n- **4th Level** (3 slots): confusion, ice storm, phantasmal killer\n- **5th Level** (2 slots): cone of cold, dominate person\n- **6th Level** (1 slot): disintegrate",
     "name": "Spellcasting",
     "parent": "ccdx_void-giant",
     "type": null
@@ -9751,7 +9751,7 @@
 },
 {
   "fields": {
-    "desc": "The witch queen is an 8th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). She has the following wizard spells prepared: \nCantrips (at will): acid splash, mage hand, message, ray of frost\n1st level (4 slots): burning hands, magic missile, sleep\n2nd level (3 slots): invisibility, spider climb, suggestion\n3rd level (3 slots): blink, fear, lightning bolt\n4th level (2 slots): blight, confusion",
+    "desc": "The witch queen is an 8th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). She has the following wizard spells prepared: \n\n- **Cantrips** (at will): acid splash, mage hand, message, ray of frost\n- **1st Level** (4 slots): burning hands, magic missile, sleep\n- **2nd Level** (3 slots): invisibility, spider climb, suggestion\n- **3rd Level** (3 slots): blink, fear, lightning bolt\n- **4th Level** (2 slots): blight, confusion",
     "name": "Spellcasting",
     "parent": "ccdx_witch-queen",
     "type": null
@@ -9781,7 +9781,7 @@
 },
 {
   "fields": {
-    "desc": "The wizard kobold is an 8th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). It has the following wizard spells prepared:\nCantrips (at will): fire bolt, minor illusion, poison spray, prestidigitation\n1st level (4 slots): burning hands, mage armor, magic missile, shield\n2nd level (3 slots): hold person, mirror image, misty step\n3rd level (3 slots): blink, counterspell, fireball\n4th level (2 slots): fire shield",
+    "desc": "The wizard kobold is an 8th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). It has the following wizard spells prepared:\n\n- **Cantrips** (at will): fire bolt, minor illusion, poison spray, prestidigitation\n- **1st Level** (4 slots): burning hands, mage armor, magic missile, shield\n- **2nd Level** (3 slots): hold person, mirror image, misty step\n- **3rd Level** (3 slots): blink, counterspell, fireball\n- **4th Level** (2 slots): fire shield",
     "name": "Spellcasting",
     "parent": "ccdx_wizard-kobold",
     "type": null

--- a/data/v2/kobold-press/tob-2023/CreatureAction.json
+++ b/data/v2/kobold-press/tob-2023/CreatureAction.json
@@ -1172,7 +1172,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "Akyishigal casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: detect evil and good, pass without trace\n3/day: dispel magic, giant insect, insect plague\n1/day: contagion (filth fever only)",
+    "desc": "Akyishigal casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** detect evil and good, pass without trace\n3/day: dispel magic, giant insect, insect plague\n1/day: contagion (filth fever only)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -1232,7 +1232,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The al-aeshma casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: detect magic\n3/day each: create or destroy water (destroy only), wind walk (as an action)\n1/day each: gaseous form, invisibility",
+    "desc": "The al-aeshma casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** detect magic\n- **3/Day Each:** create or destroy water (destroy only), wind walk (as an action)\n- **1/Day Each:** gaseous form, invisibility",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -1517,7 +1517,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The algorith casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16): \nAt will: bless, detect magic, dimension door, dispel magic\n1/day each: commune (as an action), wall of force",
+    "desc": "The algorith casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16): \n\n- **At Will:** bless, detect magic, dimension door, dispel magic\n- **1/Day Each:** commune (as an action), wall of force",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -1562,7 +1562,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The grovekeeper casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13):\nAt will: animal friendship, animal messenger, druidcraft\n1/day each: cure wounds, faerie fire, lesser restoration",
+    "desc": "The grovekeeper casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13):\n\n- **At Will:** animal friendship, animal messenger, druidcraft\n- **1/Day Each:** cure wounds, faerie fire, lesser restoration",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -3107,7 +3107,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The aridni casts one of the following spells, using Charisma as the spellcasting ability (spell save DC 14):\nAt will: dancing lights, detect magic, invisibility\n3/day each: charm person, faerie fire\n1/day: spike growth",
+    "desc": "The aridni casts one of the following spells, using Charisma as the spellcasting ability (spell save DC 14):\n\n- **At Will:** dancing lights, detect magic, invisibility\n- **3/Day Each:** charm person, faerie fire\n1/day: spike growth",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -3527,7 +3527,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The horseman casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\n3/day: phantom steed (as an action)\n2/day each: darkness (black night horseman only), daylight (bright day and red sun horsemen only), dimension door, fire shield\n1/day: plane shift (self and mount only)",
+    "desc": "The horseman casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\n3/day: phantom steed (as an action)\n- **2/Day Each:** darkness (black night horseman only), daylight (bright day and red sun horsemen only), dimension door, fire shield\n1/day: plane shift (self and mount only)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -3767,7 +3767,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The temple cat casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\nAt will: guidance\n3/day each: charm person, cure wounds\n1/day: enhance ability (only Cat's Grace)",
+    "desc": "The temple cat casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\n\n- **At Will:** guidance\n- **3/Day Each:** charm person, cure wounds\n1/day: enhance ability (only Cat's Grace)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -4517,7 +4517,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The blood hag casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 17):\nAt will: disguise self, knock, tongues\n3/day each: modify memory, pass without trace",
+    "desc": "The blood hag casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 17):\n\n- **At Will:** disguise self, knock, tongues\n- **3/Day Each:** modify memory, pass without trace",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -4547,7 +4547,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "(True Form Only)The boloti casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 11):\nAt will: water breathing, water walk\n3/day each: create or destroy water, fog cloud, sleep\n1/day: control water",
+    "desc": "(True Form Only)The boloti casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 11):\n\n- **At Will:** water breathing, water walk\n- **3/Day Each:** create or destroy water, fog cloud, sleep\n1/day: control water",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -4787,7 +4787,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "(Coalesced Form Only)The bonepowder ghoul casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\nAt will: dispel magic, mage hand, ray of enfeeblement\n3/day each: blindness/deafness, fear\n1/day: phantasmal killer",
+    "desc": "(Coalesced Form Only)The bonepowder ghoul casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\n\n- **At Will:** dispel magic, mage hand, ray of enfeeblement\n- **3/Day Each:** blindness/deafness, fear\n1/day: phantasmal killer",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -5042,7 +5042,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The buraq casts one of the following spells, requiring no components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: comprehend languages, detect evil and good, holy aura, pass without trace\n3/day each: haste, longstrider\n1/day each: plane shift, wind walk\nTeleport (1/Day)The buraq magically teleports itself and its rider, along with any equipment it is wearing or carrying, to a location the buraq is familiar with, up to 1 mile away.",
+    "desc": "The buraq casts one of the following spells, requiring no components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** comprehend languages, detect evil and good, holy aura, pass without trace\n- **3/Day Each:** haste, longstrider\n- **1/Day Each:** plane shift, wind walk\nTeleport (1/Day)The buraq magically teleports itself and its rider, along with any equipment it is wearing or carrying, to a location the buraq is familiar with, up to 1 mile away.",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -5402,7 +5402,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "Camazotz casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 22):\nAt will: darkness, detect evil and good, dispel magic\n3/day each: dominate person, haste\n1/day: incendiary cloud",
+    "desc": "Camazotz casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 22):\n\n- **At Will:** darkness, detect evil and good, dispel magic\n- **3/Day Each:** dominate person, haste\n1/day: incendiary cloud",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -5537,7 +5537,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The cambium casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: alter self, detect thoughts, spare the dying\n3/day each: hold person, protection from poison, heal\n1/day: plane shift (self only)",
+    "desc": "The cambium casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** alter self, detect thoughts, spare the dying\n- **3/Day Each:** hold person, protection from poison, heal\n1/day: plane shift (self only)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -5867,7 +5867,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The chelicerae casts one of the following spells, requiring no material or verbal components and using Intelligence as the spellcasting ability (spell save DC 15):\nAt will: mage hand, minor illusion\n1/day each: haste, hold person, invisibility, phantasmal killer",
+    "desc": "The chelicerae casts one of the following spells, requiring no material or verbal components and using Intelligence as the spellcasting ability (spell save DC 15):\n\n- **At Will:** mage hand, minor illusion\n- **1/Day Each:** haste, hold person, invisibility, phantasmal killer",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -5912,7 +5912,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The chernomoi casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 13):\nAt will: detect magic, mage hand, mending, message, prestidigitation\n1/day each: detect poison and disease, dimension door",
+    "desc": "The chernomoi casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 13):\n\n- **At Will:** detect magic, mage hand, mending, message, prestidigitation\n- **1/Day Each:** detect poison and disease, dimension door",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -6122,7 +6122,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The chort devil casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: charm person, illusory script (as an action)\n3/day each: dispel magic, modify memory\n1/day: haste",
+    "desc": "The chort devil casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** charm person, illusory script (as an action)\n- **3/Day Each:** dispel magic, modify memory\n1/day: haste",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -6782,7 +6782,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The clurichaun casts one of the following spells, requiring alcohol as the only material component and using Charisma as the spellcasting ability (spell save DC 13):\nAt will: mending, purify food and drink\n1/day each: blur, heroism, suggestion",
+    "desc": "The clurichaun casts one of the following spells, requiring alcohol as the only material component and using Charisma as the spellcasting ability (spell save DC 13):\n\n- **At Will:** mending, purify food and drink\n- **1/Day Each:** blur, heroism, suggestion",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -7397,7 +7397,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dau casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 13):\nAt will: detect thoughts, minor illusion\n3/day each: invisibility, major image\n1/day each: programmed illusion, project image",
+    "desc": "The dau casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 13):\n\n- **At Will:** detect thoughts, minor illusion\n- **3/Day Each:** invisibility, major image\n- **1/Day Each:** programmed illusion, project image",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -7682,7 +7682,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The deep one archimandrite casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\nAt will: bless, guidance, suggestion, thaumaturgy\n3/day each: charm person, command, sleep\n1/day each: augury, lightning bolt, spirit guardians",
+    "desc": "The deep one archimandrite casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\n\n- **At Will:** bless, guidance, suggestion, thaumaturgy\n- **3/Day Each:** charm person, command, sleep\n- **1/Day Each:** augury, lightning bolt, spirit guardians",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -7757,7 +7757,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The deep one priest casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 13):\nAt will: guidance, thaumaturgy\n3/day each: command, sleep\n1/day each: spirit guardians",
+    "desc": "The deep one priest casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 13):\n\n- **At Will:** guidance, thaumaturgy\n- **3/Day Each:** command, sleep\n- **1/Day Each:** spirit guardians",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -7952,7 +7952,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The devilbound gnome casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: detect magic, minor illusion, prestidigitation\n3/day each: command, dimension door, invisibility\n1/day each: fly, haste, wall of fire",
+    "desc": "The devilbound gnome casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** detect magic, minor illusion, prestidigitation\n- **3/Day Each:** command, dimension door, invisibility\n- **1/Day Each:** fly, haste, wall of fire",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -8237,7 +8237,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The domovoi casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 13):\nAt will: alter self\n3/day each: darkness, haste",
+    "desc": "The domovoi casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 13):\n\n- **At Will:** alter self\n- **3/Day Each:** darkness, haste",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -8927,7 +8927,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dryad casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: druidcraft\n3/day each: charm person, entangle, invisibility\n1/day each: barkskin, spike growth, suggestion",
+    "desc": "The dryad casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** druidcraft\n- **3/Day Each:** charm person, entangle, invisibility\n- **1/Day Each:** barkskin, spike growth, suggestion",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -9032,7 +9032,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dwarven ringmage casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 15):\nAt will: color spray, mage hand, true strike\n3/day each: expeditious retreat, fly, haste\n1/day each: greater invisibility, wall of stone",
+    "desc": "The dwarven ringmage casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 15):\n\n- **At Will:** color spray, mage hand, true strike\n- **3/Day Each:** expeditious retreat, fly, haste\n- **1/Day Each:** greater invisibility, wall of stone",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -9587,7 +9587,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The Emerald Order cult leader casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 16):\nAt will: command, light, thaumaturgy\n3/day each: detect thoughts, dimension door, silence, slow\n1/day each: divination, freedom of movement",
+    "desc": "The Emerald Order cult leader casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 16):\n\n- **At Will:** command, light, thaumaturgy\n- **3/Day Each:** detect thoughts, dimension door, silence, slow\n- **1/Day Each:** divination, freedom of movement",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -9737,7 +9737,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The enchantress casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\nAt will: command, message\n3/day: charm person, enthrall, fear, hold person, hypnotic pattern\n1/day: confusion, dominate person, greater invisibility, hold monster, phantasmal killer",
+    "desc": "The enchantress casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\n\n- **At Will:** command, message\n3/day: charm person, enthrall, fear, hold person, hypnotic pattern\n1/day: confusion, dominate person, greater invisibility, hold monster, phantasmal killer",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -10097,7 +10097,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The fear smith casts one of the following spells, requiring no verbal or material components and using Charisma as the spellcasting ability (spell save DC 16):\nAt will: detect thoughts, fear\n2/day each: charm person, command",
+    "desc": "The fear smith casts one of the following spells, requiring no verbal or material components and using Charisma as the spellcasting ability (spell save DC 16):\n\n- **At Will:** detect thoughts, fear\n- **2/Day Each:** charm person, command",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -10382,7 +10382,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The angel casts one of the following spells, requiring no material components and using Charisma as its spellcasting ability (spell save DC 15):\nAt will: detect evil and good, purify food and drink, spare the dying\n3/day each: bless, cure wounds, daylight",
+    "desc": "The angel casts one of the following spells, requiring no material components and using Charisma as its spellcasting ability (spell save DC 15):\n\n- **At Will:** detect evil and good, purify food and drink, spare the dying\n- **3/Day Each:** bless, cure wounds, daylight",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -10727,7 +10727,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The folk of Leng casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\nAt will: message, minor illusion\n3/day each: disguise self, suggestion",
+    "desc": "The folk of Leng casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\n\n- **At Will:** message, minor illusion\n- **3/Day Each:** disguise self, suggestion",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -11432,7 +11432,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The gilded devil casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 15):\nAt will: alter self, detect thoughts, suggestion\n3/day each: charm person, scrying",
+    "desc": "The gilded devil casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 15):\n\n- **At Will:** alter self, detect thoughts, suggestion\n- **3/Day Each:** charm person, scrying",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -11807,7 +11807,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The greyfur casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 13):\nAt will: light, mage hand, prestidigitation\n3/day each: color spray, sleep",
+    "desc": "The greyfur casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 13):\n\n- **At Will:** light, mage hand, prestidigitation\n- **3/Day Each:** color spray, sleep",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -11867,7 +11867,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The grim jester casts one of the following spells, requiring no components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: disguise self, grease\n3/day each: magic mouth (as an action), mirror image\n1/day each: mislead, seeming",
+    "desc": "The grim jester casts one of the following spells, requiring no components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** disguise self, grease\n- **3/Day Each:** magic mouth (as an action), mirror image\n- **1/Day Each:** mislead, seeming",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -12122,7 +12122,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The sphinx casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 17):\nAt will: comprehend languages, detect magic, mage hand\n3/day each: blur, dispel magic, locate object\n1/day each: major image, greater invisibility",
+    "desc": "The sphinx casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 17):\n\n- **At Will:** comprehend languages, detect magic, mage hand\n- **3/Day Each:** blur, dispel magic, locate object\n- **1/Day Each:** major image, greater invisibility",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -12212,7 +12212,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The haugbui casts one of the following spells, requiring no components and using Wisdom as the spellcasting ability (spell save DC 18):\nAt will: dancing lights, mending, purify food and drink, spare the dying\n3/day each: gust of wind, telekinesis\n1/day each: dispel magic, remove curse",
+    "desc": "The haugbui casts one of the following spells, requiring no components and using Wisdom as the spellcasting ability (spell save DC 18):\n\n- **At Will:** dancing lights, mending, purify food and drink, spare the dying\n- **3/Day Each:** gust of wind, telekinesis\n- **1/Day Each:** dispel magic, remove curse",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -12872,7 +12872,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The hundun casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 17):\nAt will: create or destroy water, dancing lights, minor illusion, prestidigitation\n3/day each: black tentacles, fabricate (as an action), irresistible dance\n1/day each: creation (as an action), plant growth",
+    "desc": "The hundun casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 17):\n\n- **At Will:** create or destroy water, dancing lights, minor illusion, prestidigitation\n- **3/Day Each:** black tentacles, fabricate (as an action), irresistible dance\n- **1/Day Each:** creation (as an action), plant growth",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -13352,7 +13352,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The ink devil casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\nAt will: detect magic, illusory script (as an action)\n1/day: glyph of warding",
+    "desc": "The ink devil casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\n\n- **At Will:** detect magic, illusory script (as an action)\n1/day: glyph of warding",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -13667,7 +13667,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The jotun casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 20):\nAt will: earthquake, speak with animals\n3/day: bestow curse, gust of wind\n1/day: divination",
+    "desc": "The jotun casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 20):\n\n- **At Will:** earthquake, speak with animals\n3/day: bestow curse, gust of wind\n1/day: divination",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -13862,7 +13862,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The kishi casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\nAt will: detect evil and good, detect magic, suggestion\n3/day: glibness\n1/day: dominate person",
+    "desc": "The kishi casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** detect evil and good, detect magic, suggestion\n3/day: glibness\n1/day: dominate person",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -15032,7 +15032,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The lunar devil casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\nAt will: fly, major image\n3/day: greater invisibility\n1/day: wall of ice",
+    "desc": "The lunar devil casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\n\n- **At Will:** fly, major image\n3/day: greater invisibility\n1/day: wall of ice",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -15167,7 +15167,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mallqui casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 15):\nAt will: druidcraft\n3/day each: create or destroy water, entangle\n1/day each: locate animals or plants, wind wall",
+    "desc": "The mallqui casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 15):\n\n- **At Will:** druidcraft\n- **3/Day Each:** create or destroy water, entangle\n- **1/Day Each:** locate animals or plants, wind wall",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -15482,7 +15482,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mavka casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\nAt will: create or destroy water, dancing lights\n3/day each: darkness, hold person, silence\n1/day each: bestow curse, dispel magic",
+    "desc": "The mavka casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\n\n- **At Will:** create or destroy water, dancing lights\n- **3/Day Each:** darkness, hold person, silence\n- **1/Day Each:** bestow curse, dispel magic",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -15647,7 +15647,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "Mechuiti casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 22):\nAt will: dispel magic, hold monster, wall of fire\n3/day each: fire storm, power word stun",
+    "desc": "Mechuiti casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 22):\n\n- **At Will:** dispel magic, hold monster, wall of fire\n- **3/Day Each:** fire storm, power word stun",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -15902,7 +15902,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mirager casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\n3/day: charm person\n1/day each: hallucinatory terrain (as an action), suggestion",
+    "desc": "The mirager casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\n3/day: charm person\n- **1/Day Each:** hallucinatory terrain (as an action), suggestion",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -16037,7 +16037,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mirror hag casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\nAt will: disguise self, ray of enfeeblement\n1/day each: dispel magic, locate creature",
+    "desc": "The mirror hag casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\n\n- **At Will:** disguise self, ray of enfeeblement\n- **1/Day Each:** dispel magic, locate creature",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -16337,7 +16337,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The Moonlit King casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (save DC 19):\nAt will: continual flame, invisibility (self only), moonbeam, zone of truth\n3/day each: dispel evil and good, dispel magic, major image\n1/day each: heal, project image",
+    "desc": "The Moonlit King casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (save DC 19):\n\n- **At Will:** continual flame, invisibility (self only), moonbeam, zone of truth\n- **3/Day Each:** dispel evil and good, dispel magic, major image\n- **1/Day Each:** heal, project image",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -16712,7 +16712,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The naina casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\nAt will: charm person, dancing lights, silent image\n3/day each: dispel magic, hypnotic pattern, invisibility\n1/day each: dimension door, dominate person",
+    "desc": "The naina casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\n\n- **At Will:** charm person, dancing lights, silent image\n- **3/Day Each:** dispel magic, hypnotic pattern, invisibility\n- **1/Day Each:** dimension door, dominate person",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -17612,7 +17612,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The orobas casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 18):\nAt will: augury, detect thoughts, guidance\n3/day each: locate creature, nondetection\n1/day each: contact other plane (as an action), legend lore (as an action)",
+    "desc": "The orobas casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 18):\n\n- **At Will:** augury, detect thoughts, guidance\n- **3/Day Each:** locate creature, nondetection\n- **1/Day Each:** contact other plane (as an action), legend lore (as an action)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -18347,7 +18347,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "Qorgeth casts one of the following spells, requiring no material or somatic components and using Charisma as the spellcasting ability (spell save DC 19):\nAt will: black tentacles, detect magic\n3/day each: dispel magic, insect plague (biting worms)\n1/day each: earthquake, teleport (self only)",
+    "desc": "Qorgeth casts one of the following spells, requiring no material or somatic components and using Charisma as the spellcasting ability (spell save DC 19):\n\n- **At Will:** black tentacles, detect magic\n- **3/Day Each:** dispel magic, insect plague (biting worms)\n- **1/Day Each:** earthquake, teleport (self only)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -18482,7 +18482,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The Queen of Night and Magic casts one of the following spells, using Charisma as the spellcasting ability (spell save DC 23):\nAt will: command, dancing lights, darkness, mage hand, suggestion\n3/day each: confusion, fear, greater invisibility, mirror image\n1/day each: dominate monster, plane shift, power word stun",
+    "desc": "The Queen of Night and Magic casts one of the following spells, using Charisma as the spellcasting ability (spell save DC 23):\n\n- **At Will:** command, dancing lights, darkness, mage hand, suggestion\n- **3/Day Each:** confusion, fear, greater invisibility, mirror image\n- **1/Day Each:** dominate monster, plane shift, power word stun",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -18632,7 +18632,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The Queen of Witches casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (save DC 20):\nAt will: faerie fire, silent image, tongues\n3/day each: dispel magic, hypnotic pattern, teleportation circle (as an action)\n2/day each: bestow curse, mass suggestion, flesh to stone\n1/day each: power word kill, sleep (as a 9th level spell), true polymorph",
+    "desc": "The Queen of Witches casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (save DC 20):\n\n- **At Will:** faerie fire, silent image, tongues\n- **3/Day Each:** dispel magic, hypnotic pattern, teleportation circle (as an action)\n- **2/Day Each:** bestow curse, mass suggestion, flesh to stone\n- **1/Day Each:** power word kill, sleep (as a 9th level spell), true polymorph",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -19007,7 +19007,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The ratatosk casts one of the following spells, requiring no material or somatic components and using Charisma as the spellcasting ability (save DC 14):\nAt will: animal messenger, message\n3/day each: sending, suggestion\n1/day: commune (as an action)",
+    "desc": "The ratatosk casts one of the following spells, requiring no material or somatic components and using Charisma as the spellcasting ability (save DC 14):\n\n- **At Will:** animal messenger, message\n- **3/Day Each:** sending, suggestion\n1/day: commune (as an action)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -19517,7 +19517,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The red hag casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 16):\nAt will: animal friendship, druidcraft, entangle\n3/day: cure wounds, dispel magic, lesser restoration\n1/day: control water, freedom of movement",
+    "desc": "The red hag casts one of the following spells, requiring no material components and using Wisdom as the spellcasting ability (spell save DC 16):\n\n- **At Will:** animal friendship, druidcraft, entangle\n3/day: cure wounds, dispel magic, lesser restoration\n1/day: control water, freedom of movement",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -19907,7 +19907,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The River King casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (save DC 16):\nAt will: create or destroy water, water breathing\n3/day each: freedom of movement, control water\n1/day: control weather (as an action)",
+    "desc": "The River King casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (save DC 16):\n\n- **At Will:** create or destroy water, water breathing\n- **3/Day Each:** freedom of movement, control water\n1/day: control weather (as an action)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -20072,7 +20072,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The rubezahl casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\nAt will: disguise self, fog cloud\n3/day each: gust of wind, sleet storm\n1/day: control weather (as an action)",
+    "desc": "The rubezahl casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 16):\n\n- **At Will:** disguise self, fog cloud\n- **3/Day Each:** gust of wind, sleet storm\n1/day: control weather (as an action)",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -20132,7 +20132,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The gremlin casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 11):\nAt will: prestidigitation\n3/day: command",
+    "desc": "The gremlin casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 11):\n\n- **At Will:** prestidigitation\n3/day: command",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -20372,7 +20372,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The sand hag casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\nAt will: silent image\n3/day each: hallucinatory terrain (as an action), major image",
+    "desc": "The sand hag casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\n\n- **At Will:** silent image\n- **3/Day Each:** hallucinatory terrain (as an action), major image",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -20897,7 +20897,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The scheznyki casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\nAt will: dancing lights, faerie fire\n3/day each: locate object, hideous laughter, ray of enfeeblement\n1/day each: dispel magic, hold person",
+    "desc": "The scheznyki casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 14):\n\n- **At Will:** dancing lights, faerie fire\n- **3/Day Each:** locate object, hideous laughter, ray of enfeeblement\n- **1/Day Each:** dispel magic, hold person",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -22307,7 +22307,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The arcane guardian casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\nAt will: dancing lights, fog cloud, minor illusion\n3/day each: fear, slow\n1/day each: arcane hand",
+    "desc": "The arcane guardian casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save DC 15):\n\n- **At Will:** dancing lights, fog cloud, minor illusion\n- **3/Day Each:** fear, slow\n- **1/Day Each:** arcane hand",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",
@@ -22367,7 +22367,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The spider of Leng casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 15):\nAt will: comprehend languages, detect magic\n3/day each: confusion, silence\n1/day each: arcane eye, hypnotic pattern",
+    "desc": "The spider of Leng casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save DC 15):\n\n- **At Will:** comprehend languages, detect magic\n- **3/Day Each:** confusion, silence\n- **1/Day Each:** arcane eye, hypnotic pattern",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",

--- a/data/v2/kobold-press/tob/CreatureTrait.json
+++ b/data/v2/kobold-press/tob/CreatureTrait.json
@@ -191,7 +191,7 @@
 },
 {
   "fields": {
-    "desc": "the dragon is a 6th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The dragon has the following wizard spells prepared:\n\ncantrips (at will): acid splash, light, mage hand, prestidigitation\n\n1st level (4 slots): charm person, expeditious retreat, magic missile, unseen servant\n\n2nd level (3 slots): blur, hold person, see invisibility\n\n3rd level (3 slots): haste, lightning bolt, protection from energy",
+    "desc": "the dragon is a 6th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The dragon has the following wizard spells prepared:\n\n- **Cantrips (at will)**: acid splash, light, mage hand, prestidigitation\n- **1st Level** (4 slots): charm person, expeditious retreat, magic missile, unseen servant\n- **2nd Level** (3 slots): blur, hold person, see invisibility\n- **3rd Level** (3 slots): haste, lightning bolt, protection from energy",
     "name": "Spellcasting",
     "parent": "tob_adult-mithral-dragon",
     "type": null
@@ -471,7 +471,7 @@
 },
 {
   "fields": {
-    "desc": "the grovekeeper is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). It has the following druid spells prepared:\n\ncantrips (at will): druidcraft, guidance, produce flame, shillelagh\n\n1st (4 slots): animal friendship, cure wounds, faerie fire\n\n2nd (3 slots): animal messenger, heat metal, lesser restoration\n\n3rd (2 slots): call lightning, dispel magic",
+    "desc": "the grovekeeper is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). It has the following druid spells prepared:\n\n- **Cantrips (at will)**: druidcraft, guidance, produce flame, shillelagh\n\n1st (4 slots): animal friendship, cure wounds, faerie fire\n\n2nd (3 slots): animal messenger, heat metal, lesser restoration\n\n3rd (2 slots): call lightning, dispel magic",
     "name": "Spellcasting",
     "parent": "tob_alseid-grovekeeper",
     "type": null
@@ -591,7 +591,7 @@
 },
 {
   "fields": {
-    "desc": "the dragon is a 15th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 21, +13 to hit with spell attacks). It requires no material components to cast its spells. The dragon has the following wizard spells prepared:\n\ncantrips (at will): acid splash, light, mage hand, minor illusion, prestidigitation\n\n1st level (4 slots): charm person, expeditious retreat, magic missile, unseen servant\n\n2nd level (3 slots): blur, hold person, see invisibility\n\n3rd level (3 slots): haste, lightning bolt, protection from energy\n\n4th level (3 slots): dimension door, stoneskin, wall of fire\n\n5th level (2 slots): polymorph, teleportation circle\n\n6th level (1 slot): guards and wards\n\n7th level (1 slot): forcecage\n\n8th level (1 slot): antimagic field",
+    "desc": "the dragon is a 15th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 21, +13 to hit with spell attacks). It requires no material components to cast its spells. The dragon has the following wizard spells prepared:\n\n- **Cantrips (at will)**: acid splash, light, mage hand, minor illusion, prestidigitation\n- **1st Level** (4 slots): charm person, expeditious retreat, magic missile, unseen servant\n- **2nd Level** (3 slots): blur, hold person, see invisibility\n- **3rd Level** (3 slots): haste, lightning bolt, protection from energy\n- **4th Level** (3 slots): dimension door, stoneskin, wall of fire\n- **5th Level** (2 slots): polymorph, teleportation circle\n- **6th Level** (1 slot): guards and wards\n- **7th Level** (1 slot): forcecage\n- **8th Level** (1 slot): antimagic field",
     "name": "Spellcasting",
     "parent": "tob_ancient-mithral-dragon",
     "type": null
@@ -1901,7 +1901,7 @@
 },
 {
   "fields": {
-    "desc": "the chelicerae is an 8th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). It requires no material components to cast its spells. The chelicerae has the following wizard spells prepared:\n\ncantrips: acid splash, mage hand, minor illusion, true strike\n\n1st level: burning hands, detect magic, expeditious retreat, ray of sickness\n\n2nd level: hold person, invisibility, scorching ray\n\n3rd level: animate dead, haste, lightning bolt\n\n4th level: phantasmal killer",
+    "desc": "the chelicerae is an 8th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). It requires no material components to cast its spells. The chelicerae has the following wizard spells prepared:\n\ncantrips: acid splash, mage hand, minor illusion, true strike\n- **1st Level**: burning hands, detect magic, expeditious retreat, ray of sickness\n- **2nd Level**: hold person, invisibility, scorching ray\n- **3rd Level**: animate dead, haste, lightning bolt\n- **4th Level**: phantasmal killer",
     "name": "Spellcasting",
     "parent": "tob_chelicerae",
     "type": null
@@ -2731,7 +2731,7 @@
 },
 {
   "fields": {
-    "desc": "the derro is a 5th level spellcaster. Its spellcasting ability is Charisma (save DC 13, +5 to hit with spell attacks). The derro has the following paladin spells prepared:\n\n1st level (4 slots): hellish rebuke, inflict wounds, shield of faith, wrathful smite\n\n2nd level (2 slots): aid, crown of madness, darkness, magic weapon",
+    "desc": "the derro is a 5th level spellcaster. Its spellcasting ability is Charisma (save DC 13, +5 to hit with spell attacks). The derro has the following paladin spells prepared:\n- **1st Level** (4 slots): hellish rebuke, inflict wounds, shield of faith, wrathful smite\n- **2nd Level** (2 slots): aid, crown of madness, darkness, magic weapon",
     "name": "Spellcasting",
     "parent": "tob_derro-shadow-antipaladin",
     "type": null
@@ -2821,7 +2821,7 @@
 },
 {
   "fields": {
-    "desc": "the devilbound gnomish prince is a 15th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 18, +10 to hit with spell attacks). The devilbound gnomish prince has the following warlock spells prepared:\n\ncantrips (at will): chill touch, eldritch blast, minor illusion, prestidigitation\n\n5th level (3 slots):banishment, command, contact other plane, counterspell, dimension door, fireball, fly, flame strike, hallow, hex, hold monster, invisibility, scorching ray, scrying, wall of fire, witch bolt",
+    "desc": "the devilbound gnomish prince is a 15th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 18, +10 to hit with spell attacks). The devilbound gnomish prince has the following warlock spells prepared:\n\n- **Cantrips (at will)**: chill touch, eldritch blast, minor illusion, prestidigitation\n- **5th Level** (3 slots):banishment, command, contact other plane, counterspell, dimension door, fireball, fly, flame strike, hallow, hex, hold monster, invisibility, scorching ray, scrying, wall of fire, witch bolt",
     "name": "Spellcasting",
     "parent": "tob_devilbound-gnomish-prince",
     "type": null
@@ -3251,7 +3251,7 @@
 },
 {
   "fields": {
-    "desc": "the mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The mage has the following wizard spells prepared:\n\ncantrips (at will): fire bolt, mage hand, shocking grasp, true strike\n\n1st level (4 slots): expeditious retreat, magic missile, shield, thunderwave\n\n2nd level (3 slots): misty step, web\n\n3rd level (3 slots): counterspell, fireball, fly\n\n4th level (3 slots): greater invisibility, ice storm\n\n5th level (1 slot): cone of cold",
+    "desc": "the mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The mage has the following wizard spells prepared:\n\n- **Cantrips (at will)**: fire bolt, mage hand, shocking grasp, true strike\n- **1st Level** (4 slots): expeditious retreat, magic missile, shield, thunderwave\n- **2nd Level** (3 slots): misty step, web\n- **3rd Level** (3 slots): counterspell, fireball, fly\n- **4th Level** (3 slots): greater invisibility, ice storm\n- **5th Level** (1 slot): cone of cold",
     "name": "Spellcasting",
     "parent": "tob_dwarven-ringmage",
     "type": null
@@ -3261,7 +3261,7 @@
 },
 {
   "fields": {
-    "desc": "the eater of dust's innate spellcasting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). It can innately cast the following spells, requiring no material components:\n\n3/day each: freedom of movement, inflict wounds, true strike\n\n1/day each: cure wounds (as 3rd level), magic weapon (as 6th level), misty step",
+    "desc": "the eater of dust's innate spellcasting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). It can innately cast the following spells, requiring no material components:\n\n3/day each: freedom of movement, inflict wounds, true strike\n\n1/day each: cure wounds (as - **3rd Level**), magic weapon (as 6th level), misty step",
     "name": "Innate Spellcasting",
     "parent": "tob_eater-of-dust-yakat-shi",
     "type": null
@@ -3641,7 +3641,7 @@
 },
 {
   "fields": {
-    "desc": "the Emerald Order cult leader is a 10th-level spellcaster. His spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The cult leader has the following cleric spells prepared:\n\ncantrips (at will): guidance, light, sacred flame, spare the dying, thaumaturgy\n\n1st level (4 slots): cure wounds, identify, guiding bolt\n\n2nd level (3 slots): lesser restoration, silence, spiritual weapon\n\n3rd level (3 slots): dispel magic, mass healing word, spirit guardians\n\n4th level (3 slots): banishment, death ward, guardian of faith\n\n5th level (2 slots): flame strike",
+    "desc": "the Emerald Order cult leader is a 10th-level spellcaster. His spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). The cult leader has the following cleric spells prepared:\n\n- **Cantrips (at will)**: guidance, light, sacred flame, spare the dying, thaumaturgy\n- **1st Level** (4 slots): cure wounds, identify, guiding bolt\n- **2nd Level** (3 slots): lesser restoration, silence, spiritual weapon\n- **3rd Level** (3 slots): dispel magic, mass healing word, spirit guardians\n- **4th Level** (3 slots): banishment, death ward, guardian of faith\n- **5th Level** (2 slots): flame strike",
     "name": "Spellcasting",
     "parent": "tob_emerald-order-cult-leader",
     "type": null
@@ -4771,7 +4771,7 @@
 },
 {
   "fields": {
-    "desc": "the sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:\n\ncantrips: (at will): mage hand, mending, minor illusion, poison spray\n\n1st level (4 slots): comprehend languages, detect magic, identify\n\n2nd level (3 slots): blur, darkness, locate object\n\n3rd level (3 slots): dispel magic, glyph of warding, major image\n\n4th level (3 slots): blight, greater invisibility\n\n5th level (1 slot): cloudkill",
+    "desc": "the sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:\n\ncantrips: (at will): mage hand, mending, minor illusion, poison spray\n- **1st Level** (4 slots): comprehend languages, detect magic, identify\n- **2nd Level** (3 slots): blur, darkness, locate object\n- **3rd Level** (3 slots): dispel magic, glyph of warding, major image\n- **4th Level** (3 slots): blight, greater invisibility\n- **5th Level** (1 slot): cloudkill",
     "name": "Spellcasting",
     "parent": "tob_gypsosphinx",
     "type": null
@@ -6031,7 +6031,7 @@
 },
 {
   "fields": {
-    "desc": "the greyfur is a 5th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The greyfur has the following wizard spells prepared:\n\ncantrips (at will): light, mage hand, minor illusion, poison spray, resistance\n\n1st Level (4 slots): mage armor, sleep\n\n2nd Level (3 slots): detect thoughts, misty step\n\n3rd Level (2 slots): lightning bolt",
+    "desc": "the greyfur is a 5th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The greyfur has the following wizard spells prepared:\n\n- **Cantrips (at will)**: light, mage hand, minor illusion, poison spray, resistance\n- **1st Level** (4 slots): mage armor, sleep\n- **2nd Level** (3 slots): detect thoughts, misty step\n- **3rd Level** (2 slots): lightning bolt",
     "name": "Spellcasting",
     "parent": "tob_lemurfolk-greyfur",
     "type": null
@@ -6271,7 +6271,7 @@
 },
 {
   "fields": {
-    "desc": "the lorelei is an 8th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 17, +9 to hit with spell attacks). She requires no material components to cast her spells. The lorelei has the following sorcerer spells prepared:\n\ncantrips (at will): detect magic, guidance, light, mending, poison spray, prestidigitation\n\n1st level (4 slots): comprehend languages, fog cloud, mage armor, ray of sickness\n\n2nd level (3 slots): hold person, misty step, suggestion\n\n3rd level (3 slots): hypnotic pattern, gaseous form, water walk\n\n4th level (2 slots): dominate beast, ice storm",
+    "desc": "the lorelei is an 8th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 17, +9 to hit with spell attacks). She requires no material components to cast her spells. The lorelei has the following sorcerer spells prepared:\n\n- **Cantrips (at will)**: detect magic, guidance, light, mending, poison spray, prestidigitation\n- **1st Level** (4 slots): comprehend languages, fog cloud, mage armor, ray of sickness\n- **2nd Level** (3 slots): hold person, misty step, suggestion\n- **3rd Level** (3 slots): hypnotic pattern, gaseous form, water walk\n- **4th Level** (2 slots): dominate beast, ice storm",
     "name": "Spellcasting",
     "parent": "tob_lorelei",
     "type": null
@@ -6411,7 +6411,7 @@
 },
 {
   "fields": {
-    "desc": "The malakbel generates a 30-foot-radius aura of searing light and heat. A creature that starts its turn in the aura, or who enters it for the first time on a turn, takes 11 (2d10) radiant damage. The area in the aura is brightly lit, and it sheds dim light for another 30 feet. The aura dispels magical darkness of 3rd level or lower where the areas overlap.",
+    "desc": "The malakbel generates a 30-foot-radius aura of searing light and heat. A creature that starts its turn in the aura, or who enters it for the first time on a turn, takes 11 (2d10) radiant damage. The area in the aura is brightly lit, and it sheds dim light for another 30 feet. The aura dispels magical darkness of - **3rd Level** or lower where the areas overlap.",
     "name": "Blistering Radiance",
     "parent": "tob_malakbel",
     "type": null
@@ -7061,7 +7061,7 @@
 },
 {
   "fields": {
-    "desc": "the naina is a 9th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 16, +8 to hit with spell attacks). The naina has the following sorcerer spells prepared:\n\ncantrips (at will): dancing lights, mage hand, mending, ray of frost, resistance, silent image\n\n1st level (4 slots): charm person, thunderwave, witch bolt\n\n2nd level (3 slots): darkness, invisibility, locate object\n\n3rd level (3 slots): dispel magic, hypnotic pattern\n\n4th level (3 slots): dimension door\n\n5th level (1 slot): dominate person",
+    "desc": "the naina is a 9th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 16, +8 to hit with spell attacks). The naina has the following sorcerer spells prepared:\n\n- **Cantrips (at will)**: dancing lights, mage hand, mending, ray of frost, resistance, silent image\n- **1st Level** (4 slots): charm person, thunderwave, witch bolt\n- **2nd Level** (3 slots): darkness, invisibility, locate object\n- **3rd Level** (3 slots): dispel magic, hypnotic pattern\n- **4th Level** (3 slots): dimension door\n- **5th Level** (1 slot): dominate person",
     "name": "Spellcasting",
     "parent": "tob_naina",
     "type": null
@@ -7341,7 +7341,7 @@
 },
 {
   "fields": {
-    "desc": "the noctiny is a 3rd-level spellcaster. Its spellcasting ability score is Charisma (save DC 13, +5 to hit with spell attacks). It knows the following warlock spells.\n\ncantrips (at will): chill touch, eldritch blast, poison spray\n\n1st level (4 slots): armor of agathys, charm person, hellish rebuke, hex\n\n2nd level (2 slots): crown of madness, misty step",
+    "desc": "the noctiny is a 3rd-level spellcaster. Its spellcasting ability score is Charisma (save DC 13, +5 to hit with spell attacks). It knows the following warlock spells.\n\n- **Cantrips (at will)**: chill touch, eldritch blast, poison spray\n- **1st Level** (4 slots): armor of agathys, charm person, hellish rebuke, hex\n- **2nd Level** (2 slots): crown of madness, misty step",
     "name": "Spellcasting",
     "parent": "tob_noctiny",
     "type": null
@@ -7971,7 +7971,7 @@
 },
 {
   "fields": {
-    "desc": "the hag is an 8th-level spellcaster. Her spellcasting ability is Wisdom (Spell save DC 17, +9 to hit with spell attacks). She requires no material components to cast her spells. The hag has the following druid spells prepared:\n\ncantrips (at will): animal friendship (red hags treat this as a cantrip), poison spray, thorn whip\n\n1st level (4 slots): cure wounds, entangle, speak with animals\n\n2nd level (3 slots): barkskin, flame blade, lesser restoration\n\n3rd level (3 slots): call lightning, conjure animals, dispel magic, meld into stone\n\n4th level (2 slots): control water, dominate beast, freedom of movement, hallucinatory terrain",
+    "desc": "the hag is an 8th-level spellcaster. Her spellcasting ability is Wisdom (Spell save DC 17, +9 to hit with spell attacks). She requires no material components to cast her spells. The hag has the following druid spells prepared:\n\n- **Cantrips (at will)**: animal friendship (red hags treat this as a cantrip), poison spray, thorn whip\n- **1st Level** (4 slots): cure wounds, entangle, speak with animals\n- **2nd Level** (3 slots): barkskin, flame blade, lesser restoration\n- **3rd Level** (3 slots): call lightning, conjure animals, dispel magic, meld into stone\n- **4th Level** (2 slots): control water, dominate beast, freedom of movement, hallucinatory terrain",
     "name": "Spellcasting",
     "parent": "tob_red-hag",
     "type": null
@@ -8831,7 +8831,7 @@
 },
 {
   "fields": {
-    "desc": "the shadow fey is a 10th-level spellcaster. Her spellcasting ability is Charisma (save DC 15, +7 to hit with spell attacks). She knows the following bard spells.\n\ncantrips (at will): blade ward, friends, message, vicious mockery\n\n1st level (4 slots): bane, charm person, faerie fire\n\n2nd level (3 slots): enthrall, hold person\n\n3rd level (3 slots): conjure fey, fear, hypnotic pattern\n\n4th level (3 slots): confusion, greater invisibility, phantasmal killer\n\n5th level (2 slots): animate objects, dominate person, hold monster",
+    "desc": "the shadow fey is a 10th-level spellcaster. Her spellcasting ability is Charisma (save DC 15, +7 to hit with spell attacks). She knows the following bard spells.\n\n- **Cantrips (at will)**: blade ward, friends, message, vicious mockery\n- **1st Level** (4 slots): bane, charm person, faerie fire\n- **2nd Level** (3 slots): enthrall, hold person\n- **3rd Level** (3 slots): conjure fey, fear, hypnotic pattern\n- **4th Level** (3 slots): confusion, greater invisibility, phantasmal killer\n- **5th Level** (2 slots): animate objects, dominate person, hold monster",
     "name": "Spellcasting",
     "parent": "tob_shadow-fey-enchantress",
     "type": null
@@ -9291,7 +9291,7 @@
 },
 {
   "fields": {
-    "desc": "As a bonus action, the golem targets any creature, object, or magical effect within 10 feet of it. The golem chooses a spell already cast on the target. If the spell is of 3rd level or lower, the golem absorbs the spell and it ends. If the spell is of 4th level or higher, the golem must make a check with a +9 modifier. The DC equals 10 + the spell's level. On a successful check, the golem absorbs the spell and it ends. The golem's body glows when it absorbs a spell, as if under the effect of a light spell. A smaragdine golem can only hold one absorbed spell at a time.",
+    "desc": "As a bonus action, the golem targets any creature, object, or magical effect within 10 feet of it. The golem chooses a spell already cast on the target. If the spell is of - **3rd Level** or lower, the golem absorbs the spell and it ends. If the spell is of 4th level or higher, the golem must make a check with a +9 modifier. The DC equals 10 + the spell's level. On a successful check, the golem absorbs the spell and it ends. The golem's body glows when it absorbs a spell, as if under the effect of a light spell. A smaragdine golem can only hold one absorbed spell at a time.",
     "name": "Absorb Magic",
     "parent": "tob_smaragdine-golem",
     "type": null
@@ -9361,7 +9361,7 @@
 },
 {
   "fields": {
-    "desc": "the son of Fenris is a 15th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. It has the following cleric spells prepared:\n\ncantrips (at will): guidance, light, sacred flame, spare the dying, thaumaturgy\n\n1st level (4 slots): bane, command, guiding bolt, sanctuary\n\n2nd level (3 slots): blindness/deafness, hold person, silence\n\n3rd level (3 slots): animate dead, bestow curse, dispel magic\n\n4th level (3 slots): banishment, death ward, locate creature\n\n5th level (2 slots): contagion, scrying\n\n6th level (1 slot): harm\n\n7th level (1 slot): plane shift\n\n8th level (1 slot): earthquake",
+    "desc": "the son of Fenris is a 15th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. It has the following cleric spells prepared:\n\n- **Cantrips (at will)**: guidance, light, sacred flame, spare the dying, thaumaturgy\n- **1st Level** (4 slots): bane, command, guiding bolt, sanctuary\n- **2nd Level** (3 slots): blindness/deafness, hold person, silence\n- **3rd Level** (3 slots): animate dead, bestow curse, dispel magic\n- **4th Level** (3 slots): banishment, death ward, locate creature\n- **5th Level** (2 slots): contagion, scrying\n- **6th Level** (1 slot): harm\n- **7th Level** (1 slot): plane shift\n- **8th Level** (1 slot): earthquake",
     "name": "Spellcasting",
     "parent": "tob_son-of-fenris",
     "type": null
@@ -9451,7 +9451,7 @@
 },
 {
   "fields": {
-    "desc": "some spectral guardians were not warriors in life, but powerful magic users. An arcane guardian has a challenge rating of 8 (3,900 XP) and the following added trait: Spellcasting. The arcane guardian is a 9th level spellcaster. Its spellcasting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). The guardian knows the following sorcerer spells, which do not require material components:\n\ncantrips (at will): acid splash, chill touch, dancing lights,minor illusion, ray of frost\n\n1st level (4 slots): mage armor, ray of sickness\n\n2nd level (3 slots): darkness, scorching ray\n\n3rd level (3 slots): fear, slow, stinking cloud\n\n4th level (3 slots): blight, ice storm\n\n5th level (1 slot): cone of cold",
+    "desc": "some spectral guardians were not warriors in life, but powerful magic users. An arcane guardian has a challenge rating of 8 (3,900 XP) and the following added trait: Spellcasting. The arcane guardian is a 9th level spellcaster. Its spellcasting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). The guardian knows the following sorcerer spells, which do not require material components:\n\n- **Cantrips (at will)**: acid splash, chill touch, dancing lights,minor illusion, ray of frost\n- **1st Level** (4 slots): mage armor, ray of sickness\n- **2nd Level** (3 slots): darkness, scorching ray\n- **3rd Level** (3 slots): fear, slow, stinking cloud\n- **4th Level** (3 slots): blight, ice storm\n- **5th Level** (1 slot): cone of cold",
     "name": "Variant: Arcane Guardian",
     "parent": "tob_spectral-guardian",
     "type": null

--- a/data/v2/kobold-press/tob2/CreatureTrait.json
+++ b/data/v2/kobold-press/tob2/CreatureTrait.json
@@ -1851,7 +1851,7 @@
 },
 {
   "fields": {
-    "desc": "The cave giant shaman is a 14th-level spellcaster. Its spellcasting ability is Charisma (save DC 18, +10 to hit with spell attacks). The shaman has the following wizard spells prepared:\nCantrips (at will): acid splash, mage hand, mending, prestidigitation, shocking grasp\n1st level (4 slots): burning hands, expeditious retreat, fog cloud, shield\n2nd level (3 slots): enlarge/reduce, shatter, spider climb, web\n3rd level (3 slots): gaseous form, haste, lightning bolt, water breathing\n4th level (3 slots): ice storm, polymorph, wall of fire\n5th level (2 slots): cloudkill, insect plague\n6th level (1 slots): disintegrate\n7th level (1 slots): reverse gravity",
+    "desc": "The cave giant shaman is a 14th-level spellcaster. Its spellcasting ability is Charisma (save DC 18, +10 to hit with spell attacks). The shaman has the following wizard spells prepared:\n\n- **Cantrips** (At Will): acid splash, mage hand, mending, prestidigitation, shocking grasp\n- **1st Level** (4 slots): burning hands, expeditious retreat, fog cloud, shield\n- **2nd Level** (3 slots): enlarge/reduce, shatter, spider climb, web\n- **3rd Level** (3 slots): gaseous form, haste, lightning bolt, water breathing\n- **4th Level** (3 slots): ice storm, polymorph, wall of fire\n- **5th Level** (2 slots): cloudkill, insect plague\n- **6th Level** (1 slots): disintegrate\n- **7th Level** (1 slots): reverse gravity",
     "name": "Spellcasting",
     "parent": "tob2_cave-giant-shaman",
     "type": null
@@ -2281,7 +2281,7 @@
 },
 {
   "fields": {
-    "desc": "The conjoined queen is a 9th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 16, +8 to hit with spell attacks). The queen has the following sorcerer spells prepared:\nCantrips (at will): acid splash, mage hand, prestidigitation, ray of frost\n1st Level (4 slots): burning hands, magic missile, shield, thunderwave\n2nd Level (3 slots): detect thoughts, misty step, web\n3rd Level (3 slots): clairvoyance, counterspell, haste\n4th Level (3 slots): banishment, confusion\n5th Level (1 slot): insect plague",
+    "desc": "The conjoined queen is a 9th-level spellcaster. Her spellcasting ability is Charisma (spell save DC 16, +8 to hit with spell attacks). The queen has the following sorcerer spells prepared:\n\n- **Cantrips** (At Will): acid splash, mage hand, prestidigitation, ray of frost\n- **1st Level** (4 slots): burning hands, magic missile, shield, thunderwave\n- **2nd Level** (3 slots): detect thoughts, misty step, web\n- **3rd Level** (3 slots): clairvoyance, counterspell, haste\n- **4th Level** (3 slots): banishment, confusion\n- **5th Level** (1 slot): insect plague",
     "name": "Spellcasting",
     "parent": "tob2_conjoined-queen",
     "type": null
@@ -3361,7 +3361,7 @@
 },
 {
   "fields": {
-    "desc": "The savant is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +8 to hit with spell attacks). The savant has the following wizard spells prepared: Cantrips (at will): fire bolt, light, mage hand, prestidigitation\n1st Level (4 slots): detect magic, mage armor, magic missile, sleep\n2nd Level (3 slots): enlarge/reduce, gust of wind, misty step\n3rd Level (3 slots): counterspell, fireball, fly\n4th Level (3 slots): arcane eye, confusion, dimension door\n5th Level (1 slot): arcane hand",
+    "desc": "The savant is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +8 to hit with spell attacks). The savant has the following wizard spells prepared: Cantrips (at will): fire bolt, light, mage hand, prestidigitation\n- **1st Level** (4 slots): detect magic, mage armor, magic missile, sleep\n- **2nd Level** (3 slots): enlarge/reduce, gust of wind, misty step\n- **3rd Level** (3 slots): counterspell, fireball, fly\n- **4th Level** (3 slots): arcane eye, confusion, dimension door\n- **5th Level** (1 slot): arcane hand",
     "name": "Spellcasting",
     "parent": "tob2_eonic-savant",
     "type": null
@@ -4291,7 +4291,7 @@
 },
 {
   "fields": {
-    "desc": "The lunarchidna is a 4th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 11, +3 to hit with spell attacks). The lunarchidna has the following wizard spells prepared:\nCantrips (at will): minor illusion, mage hand, poison spray, ray of frost\n1st level (4 slots): detect magic, magic missile, shield\n2nd level (3 slots): alter self, suggestion",
+    "desc": "The lunarchidna is a 4th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 11, +3 to hit with spell attacks). The lunarchidna has the following wizard spells prepared:\n\n- **Cantrips** (At Will): minor illusion, mage hand, poison spray, ray of frost\n- **1st Level** (4 slots): detect magic, magic missile, shield\n- **2nd Level** (3 slots): alter self, suggestion",
     "name": "Spellcasting",
     "parent": "tob2_greater-lunarchidna",
     "type": null
@@ -5311,7 +5311,7 @@
 },
 {
   "fields": {
-    "desc": "The initiate of the elder elementals is a 5th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The initiate has the following wizard spells prepared:\nCantrips (at will): pummelstone, light, mage hand, ray of frost\n1st level (4 slots): burning hands, mage armor, tidal barrier\n2nd level (3 slots): gust of wind, misty step, scorching ray\n3rd level (2 slots): lightning bolt, frozen razors",
+    "desc": "The initiate of the elder elementals is a 5th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). The initiate has the following wizard spells prepared:\n\n- **Cantrips** (At Will): pummelstone, light, mage hand, ray of frost\n- **1st Level** (4 slots): burning hands, mage armor, tidal barrier\n- **2nd Level** (3 slots): gust of wind, misty step, scorching ray\n- **3rd Level** (2 slots): lightning bolt, frozen razors",
     "name": "Spellcasting",
     "parent": "tob2_initiate-of-the-elder-elementals",
     "type": null
@@ -5391,7 +5391,7 @@
 },
 {
   "fields": {
-    "desc": "The kachlian is a 7th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The kachlian has the following wizard spells prepared:\nCantrips (at will): chill touch, minor illusion, ray of frost, shocking grasp\n1st level (4 slots): detect magic, hideous laughter, identify, magic missile\n2nd level (3 slots): blindness/deafness, darkness, see invisibility\n3rd level (3 slots): counterspell, slow\n4th level (1 slots): confusion",
+    "desc": "The kachlian is a 7th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The kachlian has the following wizard spells prepared:\n\n- **Cantrips** (At Will): chill touch, minor illusion, ray of frost, shocking grasp\n- **1st Level** (4 slots): detect magic, hideous laughter, identify, magic missile\n- **2nd Level** (3 slots): blindness/deafness, darkness, see invisibility\n- **3rd Level** (3 slots): counterspell, slow\n- **4th Level** (1 slots): confusion",
     "name": "Spellcasting",
     "parent": "tob2_kachlian",
     "type": null
@@ -5691,7 +5691,7 @@
 },
 {
   "fields": {
-    "desc": "The kobold spellclerk is a 2nd-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). It has the following wizard spells prepared:\nCantrips (at will): fire bolt, message, minor illusion\n1st level (3 slots): comprehend languages, feather fall, grease, illusory script, sleep",
+    "desc": "The kobold spellclerk is a 2nd-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 13, +5 to hit with spell attacks). It has the following wizard spells prepared:\n\n- **Cantrips** (At Will): fire bolt, message, minor illusion\n- **1st Level** (3 slots): comprehend languages, feather fall, grease, illusory script, sleep",
     "name": "Spellcasting",
     "parent": "tob2_kobold-spellclerk",
     "type": null
@@ -8281,7 +8281,7 @@
 },
 {
   "fields": {
-    "desc": "The servant of the Unsated God is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). It has the following cleric spells prepared:\nCantrips (at will): guidance, mending, resistance, thaumaturgy\n1st level (4 slots): bane, command, inflict wounds, protection from evil and good\n2nd level (3 slots): blindness/deafness, hold person, spiritual weapon",
+    "desc": "The servant of the Unsated God is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). It has the following cleric spells prepared:\n\n- **Cantrips** (At Will): guidance, mending, resistance, thaumaturgy\n- **1st Level** (4 slots): bane, command, inflict wounds, protection from evil and good\n- **2nd Level** (3 slots): blindness/deafness, hold person, spiritual weapon",
     "name": "Spellcasting",
     "parent": "tob2_servant-of-the-unsated-god",
     "type": null
@@ -9081,7 +9081,7 @@
 },
 {
   "fields": {
-    "desc": "The swamp naga is an 8th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It knows the following sorcerer spells:\nCantrips (at will): dancing lights, mage hand, message, poison spray\n1st level (4 slots): charm person, fog cloud, silent image, sleep\n2nd level (3 slots): blindness/deafness, hold person, suggestion\n3rd level (3 slots): hypnotic pattern, stinking cloud, water breathing\n4th level (2 slots): blight",
+    "desc": "The swamp naga is an 8th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It knows the following sorcerer spells:\n\n- **Cantrips** (At Will): dancing lights, mage hand, message, poison spray\n- **1st Level** (4 slots): charm person, fog cloud, silent image, sleep\n- **2nd Level** (3 slots): blindness/deafness, hold person, suggestion\n- **3rd Level** (3 slots): hypnotic pattern, stinking cloud, water breathing\n- **4th Level** (2 slots): blight",
     "name": "Spellcasting",
     "parent": "tob2_swamp-naga",
     "type": null
@@ -9421,7 +9421,7 @@
 },
 {
   "fields": {
-    "desc": "The lunarchidna is a 8th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The lunarchidna has the following wizard spells prepared:\nCantrips (at will): minor illusion, mage hand, poison spray, ray of frost\n1st level (4 slots): color spray, detect magic, magic missile, shield\n2nd level (3 slots): alter self, suggestion, web\n3rd level (3 slots): counterspell, fireball, major image\n4th level (2 slots): black tentacles, confusion",
+    "desc": "The lunarchidna is a 8th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 15, +7 to hit with spell attacks). The lunarchidna has the following wizard spells prepared:\n\n- **Cantrips** (At Will): minor illusion, mage hand, poison spray, ray of frost\n- **1st Level** (4 slots): color spray, detect magic, magic missile, shield\n- **2nd Level** (3 slots): alter self, suggestion, web\n- **3rd Level** (3 slots): counterspell, fireball, major image\n- **4th Level** (2 slots): black tentacles, confusion",
     "name": "Spellcasting",
     "parent": "tob2_transcendent-lunarchida",
     "type": null
@@ -9881,7 +9881,7 @@
 },
 {
   "fields": {
-    "desc": "The virtuoso lich is a 12th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 17, +9 to hit with spell attacks). It has the following bard spells prepared:\nCantrips (at will): mage hand, message, true strike, vicious mockery\n1st level (4 slots): bane, hideous laughter, thunderwave\n2nd level (3 slots): enthrall, hold person, invisibility, shatter\n3rd level (3 slots): dispel magic, fear, speak with dead\n4th level (3 slots): compulsion, confusion, dimension door\n5th level (2 slots): dominate person, mislead\n6th level (1 slot): irresistible dance, programmed illusion",
+    "desc": "The virtuoso lich is a 12th-level spellcaster. Its spellcasting ability is Charisma (spell save DC 17, +9 to hit with spell attacks). It has the following bard spells prepared:\n\n- **Cantrips** (At Will): mage hand, message, true strike, vicious mockery\n- **1st Level** (4 slots): bane, hideous laughter, thunderwave\n- **2nd Level** (3 slots): enthrall, hold person, invisibility, shatter\n- **3rd Level** (3 slots): dispel magic, fear, speak with dead\n- **4th Level** (3 slots): compulsion, confusion, dimension door\n- **5th Level** (2 slots): dominate person, mislead\n- **6th Level** (1 slot): irresistible dance, programmed illusion",
     "name": "Spellcasting",
     "parent": "tob2_virtuoso-lich",
     "type": null

--- a/data/v2/kobold-press/tob3/CreatureTrait.json
+++ b/data/v2/kobold-press/tob3/CreatureTrait.json
@@ -661,7 +661,7 @@
 },
 {
   "fields": {
-    "desc": "Wis (DC 21) no material components: At will: detect evil and good invisibility (self only) legend lore thaumaturgy3/day ea: dispel evil and good geas (as an action)1/day ea: antimagic field plane shift",
+    "desc": "Wis (DC 21) no material components:\n\n- **At Will:** Detect Evil and Good, Invisibility (self only), Legend Lore, Thaumaturgy\n- **3/Day Each**: Dispel Evil and Good, Geas (as an action)\n- **1/Day Each**: Antimagic Field, Plane Shift",
     "name": "Spellcasting",
     "parent": "tob3_angel-zirnitran",
     "type": null

--- a/data/v2/wizards-of-the-coast/srd-2024/CreatureAction.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/CreatureAction.json
@@ -182,9 +182,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks): - At Will: Detect Magic, Fear, Acid Arrow - 1e/Day Each: Speak with Dead, Vitriolic Sphere",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks):\n\n- **At Will:** Detect Magic, Fear, Acid Arrow\n- **1/Day Each:** Speak with Dead, Vitriolic Sphere",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 3,
     "parent": "srd-2024_adult-black-dragon",
@@ -272,9 +272,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18): - At Will: Detect Magic, Invisibility, Mage Hand, Shatter - 1e/Day Each: Scrying, Sending",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18):\n\n- **At Will:** Detect Magic, Invisibility, Mage Hand, Shatter\n- **1/Day Each:** Scrying, Sending",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 3,
     "parent": "srd-2024_adult-blue-dragon",
@@ -407,9 +407,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16): - At Will: Detect Magic, Minor Illusion, Scorching Ray, Shapechange, Speak with Animals - 1e/Day Each: Detect Thoughts, Control Weather",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16):\n\n- **At Will:** Detect Magic, Minor Illusion, Scorching Ray, Shapechange, Speak with Animals\n- **1/Day Each:** Detect Thoughts, Control Weather",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 4,
     "parent": "srd-2024_adult-brass-dragon",
@@ -512,9 +512,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +10 to hit with spell attacks): - At Will: Detect Magic, Guiding Bolt, Shapechange, Speak with Animals, Thaumaturgy - 1e/Day Each: Detect Thoughts, Water Breathing",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +10 to hit with spell attacks):\n\n- **At Will:** Detect Magic, Guiding Bolt, Shapechange, Speak with Animals, Thaumaturgy\n- **1/Day Each:** Detect Thoughts, Water Breathing",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 4,
     "parent": "srd-2024_adult-bronze-dragon",
@@ -647,9 +647,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): - At Will: Detect Magic, Mind Spike, Minor Illusion, Shapechange - 1e/Day Each: Greater Restoration, Major Image",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** Detect Magic, Mind Spike, Minor Illusion, Shapechange\n- **1/Day Each:** Greater Restoration, Major Image",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 4,
     "parent": "srd-2024_adult-copper-dragon",
@@ -752,9 +752,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks): - At Will: Detect Magic, Guiding Bolt, Shapechange - 1e/Day Each: Flame Strike, Zone of Truth",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks):\n\n- **At Will:** Detect Magic, Guiding Bolt, Shapechange\n- **1/Day Each:** Flame Strike, Zone of Truth",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 4,
     "parent": "srd-2024_adult-gold-dragon",
@@ -872,9 +872,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): - At Will: Detect Magic, Mind Spike - 1/Day Each: Geas",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):\n- **At Will:** Detect Magic, Mind Spike -\n**1/Day Each:** Geas",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 3,
     "parent": "srd-2024_adult-green-dragon",
@@ -977,9 +977,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20, +12 to hit with spell attacks): - At Will: Command, Detect Magic, Scorching Ray - 1/Day Each: Fireball",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20, +12 to hit with spell attacks):\n\n- **At Will:** Command, Detect Magic, Scorching Ray\n- **1/Day Each:** Fireball",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 3,
     "parent": "srd-2024_adult-red-dragon",
@@ -1097,9 +1097,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 19, +11 to hit with spell attacks): - At Will: Detect Magic, Hold Monster, Ice Knife, Shapechange - 1e/Day Each: Ice Storm, Zone of Truth",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 19, +11 to hit with spell attacks):\n\n- **At Will:** Detect Magic, Hold Monster, Ice Knife, Shapechange\n- **1/Day Each:** Ice Storm, Zone of Truth",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 4,
     "parent": "srd-2024_adult-silver-dragon",
@@ -1367,9 +1367,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks): - At Will: Detect Magic, Fear, Acid Arrow - 1e/Day Each: Create Undead, Speak with Dead, Vitriolic Sphere",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks):\n\n- **At Will:** Detect Magic, Fear, Acid Arrow\n- **1/Day Each:** Create Undead, Speak with Dead, Vitriolic Sphere",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 3,
     "parent": "srd-2024_ancient-black-dragon",
@@ -1457,9 +1457,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22): - At Will: Detect Magic, Invisibility, Mage Hand, Shatter - 1e/Day Each: Scrying, Sending",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22):\n\n- **At Will:** Detect Magic, Invisibility, Mage Hand, Shatter\n- **1/Day Each:** Scrying, Sending",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 3,
     "parent": "srd-2024_ancient-blue-dragon",
@@ -1592,7 +1592,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20): - At Will: Detect Magic, Minor Illusion, Scorching Ray, Shapechange, Speak with Animals - 1e/Day Each: Control Weather, Detect Thoughts",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20):\n\n- **At Will:** Detect Magic, Minor Illusion, Scorching Ray, Shapechange, Speak with Animals\n- **1/Day Each:** Control Weather, Detect Thoughts",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -1697,7 +1697,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22, +14 to hit with spell attacks): - At Will: Detect Magic, Guiding Bolt, Shapechange, Speak with Animals, Thaumaturgy - 1e/Day Each: Detect Thoughts, Control Water, Scrying, Water Breathing",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22, +14 to hit with spell attacks):\n\n- **At Will:** Detect Magic, Guiding Bolt, Shapechange, Speak with Animals, Thaumaturgy\n- **1/Day Each:** Detect Thoughts, Control Water, Scrying, Water Breathing",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -1832,7 +1832,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21): - At Will: Detect Magic, Mind Spike, Minor Illusion, Shapechange - 1e/Day Each: Greater Restoration, Major Image, Project Image",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21):\n\n- **At Will:** Detect Magic, Mind Spike, Minor Illusion, Shapechange\n- **1/Day Each:** Greater Restoration, Major Image, Project Image",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -1937,7 +1937,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 24, +16 to hit with spell attacks): - At Will: Detect Magic, Guiding Bolt, Shapechange - 1e/Day Each: Flame Strike, Word of Recall, Zone of Truth",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 24, +16 to hit with spell attacks):\n\n- **At Will:** Detect Magic, Guiding Bolt, Shapechange\n- **1/Day Each:** Flame Strike, Word of Recall, Zone of Truth",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -2057,7 +2057,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21): - At Will: Detect Magic, Mind Spike - 1e/Day Each: Geas, Modify Memory",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21):\n\n- **At Will:** Detect Magic, Mind Spike\n- **1/Day Each:** Geas, Modify Memory",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -2162,7 +2162,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks): - At Will: Command, Detect Magic, Scorching Ray - 1e/Day Each: Fireball, Scrying",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks):\n\n- **At Will:** Command, Detect Magic, Scorching Ray\n- **1/Day Each:** Fireball, Scrying",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -2282,7 +2282,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks): - At Will: Detect Magic, Hold Monster, Ice Knife, Shapechange - 1e/Day Each: Control Weather, Ice Storm, Teleport, Zone of Truth",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks):\n\n- **At Will:** Detect Magic, Hold Monster, Ice Knife, Shapechange\n- **1/Day Each:** Control Weather, Ice Storm, Teleport, Zone of Truth",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -2612,7 +2612,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The archmage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 17): - At Will: Detect Magic, Detect Thoughts, Disguise Self, Invisibility, Light, Mage Armor, Mage Hand, Prestidigitation - 2e/Day Each: Fly, Lightning Bolt - 1e/Day Each: Cone of Cold, Mind Blank, Scrying, Teleport",
+    "desc": "The archmage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 17):\n\n- **At Will:** Detect Magic, Detect Thoughts, Disguise Self, Invisibility, Light, Mage Armor, Mage Hand, Prestidigitation\n- **2/Day Each:** Fly, Lightning Bolt\n- **1/Day Each:** Cone of Cold, Mind Blank, Scrying, Teleport",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -3917,7 +3917,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The giant casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15): - At Will: Detect Magic, Fog Cloud, Light - 1e/Day Each: Control Weather, Gaseous Form, Telekinesis",
+    "desc": "The giant casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15):\n\n- **At Will:** Detect Magic, Fog Cloud, Light\n- **1/Day Each:** Control Weather, Gaseous Form, Telekinesis",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -4097,7 +4097,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The couatl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save DC 15): - At Will: Detect Evil and Good, Detect Magic, Detect Thoughts, Shapechange - 1e/Day Each: Create Food and Water, Dream, Greater Restoration, Scrying, Sleep",
+    "desc": "The couatl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save DC 15):\n\n- **At Will:** Detect Evil and Good, Detect Magic, Detect Thoughts, Shapechange\n- **1/Day Each:** Create Food and Water, Dream, Greater Restoration, Scrying, Sleep",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -4157,7 +4157,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The cultist casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks): - At Will: Light, Thaumaturgy - 1/Day Each: Hold Person - 2/Day Each: Command",
+    "desc": "The cultist casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks):\n\n- **At Will:** Light, Thaumaturgy\n- **1/Day Each:** Hold Person\n- **2/Day Each:** Command",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -4292,7 +4292,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The deva casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): - At Will: Detect Evil and Good, Shapechange - 1e/Day Each: Commune, Raise Dead",
+    "desc": "The deva casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** Detect Evil and Good, Shapechange\n- **1/Day Each:** Commune, Raise Dead",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -4352,7 +4352,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The djinni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): - At Will: Detect Evil and Good, Detect Magic - 2e/Day Each: Create Food and Water, Tongues, Wind Walk - 1e/Day Each: Creation, Gaseous Form, Invisibility, Major Image, Plane Shift",
+    "desc": "The djinni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):\n\n- **At Will:** Detect Evil and Good, Detect Magic\n- **2/Day Each:** Create Food and Water, Tongues, Wind Walk\n- **1/Day Each:** Creation, Gaseous Form, Invisibility, Major Image, Plane Shift",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -4412,7 +4412,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The doppelganger casts Detect Thoughts, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 12). - At Will: Detect Thoughts",
+    "desc": "The doppelganger casts Detect Thoughts, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 12).\n\n- **At Will:** Detect Thoughts",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Read Thoughts",
@@ -4622,7 +4622,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The druid casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13): - At Will: Druidcraft, Speak with Animals - 2e/Day Each: Entangle, Thunderwave - 1e/Day Each: Animal Messenger, Longstrider, Moonbeam",
+    "desc": "The druid casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13):\n\n- **At Will:** Druidcraft, Speak with Animals\n- **2/Day Each:** Entangle, Thunderwave\n- **1/Day Each:** Animal Messenger, Longstrider, Moonbeam",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -4682,7 +4682,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dryad casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14): - At Will: Animal Friendship, Charm Monster, Druidcraft - 1e/Day Each: Entangle, Pass without Trace",
+    "desc": "The dryad casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14):\n\n- **At Will:** Animal Friendship, Charm Monster, Druidcraft\n- **1/Day Each:** Entangle, Pass without Trace",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -4757,7 +4757,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mephit casts the Sleep spell, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 10). - At Will: - 1/Day Each: Sleep",
+    "desc": "The mephit casts the Sleep spell, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 10).",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Sleep",
@@ -4877,7 +4877,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The efreeti casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16): - At Will: Detect Magic, Elementalism - 1e/Day Each: Gaseous Form, Invisibility, Major Image, Plane Shift, Tongues, Wall of Fire",
+    "desc": "The efreeti casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16):\n\n- **At Will:** Detect Magic, Elementalism\n- **1/Day Each:** Gaseous Form, Invisibility, Major Image, Plane Shift, Tongues, Wall of Fire",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -5357,7 +5357,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The ghost casts the Etherealness spell, requiring no spell components and using Charisma as the spellcasting ability. The ghost is visible on the Material Plane while on the Border Ethereal and vice versa, but it can't affect or be affected by anything on the other plane. - At Will: Etherealness",
+    "desc": "The ghost casts the Etherealness spell, requiring no spell components and using Charisma as the spellcasting ability. The ghost is visible on the Material Plane while on the Border Ethereal and vice versa, but it can't affect or be affected by anything on the other plane.\n\n- **At Will:** Etherealness",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Etherealness",
@@ -5837,7 +5837,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The owl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability: - At Will: Detect Evil and Good, Detect Magic - 1/Day Each: Clairvoyance",
+    "desc": "The owl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability:\n\n- **At Will:** Detect Evil and Good, Detect Magic\n- **1/Day Each:** Clairvoyance",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -6182,7 +6182,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The glabrezu casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16): - At Will: Darkness, Detect Magic, Dispel Magic - 1e/Day Each: Confusion, Fly, Power Word Stun",
+    "desc": "The glabrezu casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16):\n\n- **At Will:** Darkness, Detect Magic, Dispel Magic\n- **1/Day Each:** Confusion, Fly, Power Word Stun",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -6557,7 +6557,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The hag casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks): - At Will: Dancing Lights, Disguise Self, Invisibility, Minor Illusion, Ray of Sickness",
+    "desc": "The hag casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks):\n\n- **At Will:** Dancing Lights, Disguise Self, Invisibility, Minor Illusion, Ray of Sickness",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -6767,7 +6767,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Wisdom as the spellcasting ability (spell save DC 16): - At Will: Thaumaturgy - 1e/Day Each: Clairvoyance, Cure Wounds, Flame Strike, Geas, True Seeing",
+    "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Wisdom as the spellcasting ability (spell save DC 16):\n\n- **At Will:** Thaumaturgy\n- **1/Day Each:** Clairvoyance, Cure Wounds, Flame Strike, Geas, True Seeing",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -7277,7 +7277,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The devil casts Wall of Ice (level 8 version), requiring no spell components and using Intelligence as the spellcasting ability (spell save DC 17). - At Will:",
+    "desc": "The devil casts Wall of Ice (level 8 version), requiring no spell components and using Intelligence as the spellcasting ability (spell save DC 17).\n\n- **At Will:**",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Ice Wall",
@@ -7337,7 +7337,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mephit casts Fog Cloud, requiring no spell components and using Charisma as the spellcasting ability. - At Will: - 1/Day Each: Fog Cloud",
+    "desc": "The mephit casts Fog Cloud, requiring no spell components and using Charisma as the spellcasting ability.\n\n- **At Will:**\n- **1/Day Each:** Fog Cloud",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Fog Cloud",
@@ -7367,7 +7367,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The imp casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability. - At Will: Invisibility",
+    "desc": "The imp casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability.\n\n- **At Will:** Invisibility",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Invisibility",
@@ -7442,7 +7442,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The incubus casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15): - At Will: Disguise Self, Etherealness - 1e/Day Each: Dream, Hypnotic Pattern",
+    "desc": "The incubus casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15):\n\n- **At Will:** Disguise Self, Etherealness\n- **1/Day Each:** Dream, Hypnotic Pattern",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -7802,7 +7802,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The lamia casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13): - At Will: Disguise Self, Minor Illusion - 1e/Day Each: Geas, Major Image, Scrying",
+    "desc": "The lamia casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13):\n\n- **At Will:** Disguise Self, Minor Illusion\n- **1/Day Each:** Geas, Major Image, Scrying",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -7922,7 +7922,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The lich casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 20): - At Will: Detect Magic, Detect Thoughts, Dispel Magic, Fireball, Invisibility, Lightning Bolt, Mage Hand, Prestidigitation - 2e/Day Each: Animate Dead, Dimension Door, Plane Shift - 1e/Day Each: Chain Lightning, Finger of Death, Power Word Kill, Scrying",
+    "desc": "The lich casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 20):\n\n- **At Will:** Detect Magic, Detect Thoughts, Dispel Magic, Fireball, Invisibility, Lightning Bolt, Mage Hand, Prestidigitation\n- **2/Day Each:** Animate Dead, Dimension Door, Plane Shift\n- **1/Day Each:** Chain Lightning, Finger of Death, Power Word Kill, Scrying",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -8027,7 +8027,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 14): - At Will: Detect Magic, Light, Mage Armor, Mage Hand, Prestidigitation - 2e/Day Each: Fireball, Invisibility - 1e/Day Each: Cone of Cold, Fly",
+    "desc": "The mage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 14):\n\n- **At Will:** Detect Magic, Light, Mage Armor, Mage Hand, Prestidigitation\n- **2/Day Each:** Fireball, Invisibility\n- **1/Day Each:** Cone of Cold, Fly",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -8567,7 +8567,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The mummy casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks): - At Will: Dispel Magic, Thaumaturgy - 1e/Day Each: Animate Dead, Harm, Insect Plague",
+    "desc": "The mummy casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks):\n\n- **At Will:** Dispel Magic, Thaumaturgy\n- **1/Day Each:** Animate Dead, Harm, Insect Plague",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -8702,7 +8702,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "While on the Ethereal Plane, the hag casts Dream, using the same spellcasting ability as Spellcasting. Only the hag can serve as the spell's messenger, and the target must be a creature the hag can see on the Material Plane. The spell fails and is wasted if the target is under the effect of the Protection from Evil and Good spell or within a Magic Circle spell. If the target takes damage from the Dream spell, the target's Hit Point maximum decreases by an amount equal to that damage. If the spell kills the target, its soul is trapped in the hag's soul bag, and the target can't be raised from the dead until its soul is released. - At Will: - 1/Day Each: Dream, Protection from Evil and Good, Magic Circle",
+    "desc": "While on the Ethereal Plane, the hag casts Dream, using the same spellcasting ability as Spellcasting. Only the hag can serve as the spell's messenger, and the target must be a creature the hag can see on the Material Plane. The spell fails and is wasted if the target is under the effect of the Protection from Evil and Good spell or within a Magic Circle spell. If the target takes damage from the Dream spell, the target's Hit Point maximum decreases by an amount equal to that damage. If the spell kills the target, its soul is trapped in the hag's soul bag, and the target can't be raised from the dead until its soul is released.\n\n- **At Will:**\n- **1/Day Each:** Dream, Protection from Evil and Good, Magic Circle",
     "form_condition": "Requires Soul Bag",
     "legendary_cost": null,
     "name": "Nightmare Haunting",
@@ -8717,7 +8717,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The hag casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 14): - At Will: Detect Magic, Etherealness, Magic Missile - 2e/Day Each: Phantasmal Killer, Plane Shift",
+    "desc": "The hag casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 14):\n\n- **At Will:** Detect Magic, Etherealness, Magic Missile\n- **2/Day Each:** Phantasmal Killer, Plane Shift",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -8897,7 +8897,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The oni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13): - At Will: - 1e/Day Each: Charm Person, Darkness, Gaseous Form, Sleep",
+    "desc": "The oni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13):\n\n- **At Will:**\n- **1/Day Each:** Charm Person, Darkness, Gaseous Form, Sleep",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -9227,7 +9227,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The pit fiend casts Fireball (level 5 version) twice, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21). It can replace one Fireball with Hold Monster (level 7 version) or Wall of Fire. - At Will:",
+    "desc": "The pit fiend casts Fireball (level 5 version) twice, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21). It can replace one Fireball with Hold Monster (level 7 version) or Wall of Fire.\n\n- **At Will:**",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Hellfire Spellcasting",
@@ -9302,7 +9302,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The planetar casts one of the following spells, requiring no Material components and using Charisma as spellcasting ability (spell save DC 20): - At Will: Detect Evil and Good - 1e/Day Each: Commune, Control Weather, Dispel Evil and Good, Raise Dead",
+    "desc": "The planetar casts one of the following spells, requiring no Material components and using Charisma as spellcasting ability (spell save DC 20):\n\n- **At Will:** Detect Evil and Good\n- **1/Day Each:** Commune, Control Weather, Dispel Evil and Good, Raise Dead",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -9407,7 +9407,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability: - At Will: Light, Thaumaturgy",
+    "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability:\n\n- **At Will:** Light, Thaumaturgy",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -9467,7 +9467,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability: - At Will: Light, Thaumaturgy - 1/Day Each: Spirit Guardians",
+    "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability:\n\n- **At Will:** Light, Thaumaturgy\n- **1/Day Each:** Spirit Guardians",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -9587,7 +9587,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The quasit casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability. - At Will: Invisibility",
+    "desc": "The quasit casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability.",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Invisibility",
@@ -9692,7 +9692,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The rakshasa casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18): - At Will: Detect Magic, Detect Thoughts, Disguise Self, Mage Hand, Minor Illusion - 1e/Day Each: Fly, Invisibility, Major Image, Plane Shift",
+    "desc": "The rakshasa casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18):\n\n- **At Will:** Detect Magic, Detect Thoughts, Disguise Self, Mage Hand, Minor Illusion\n- **1/Day Each:** Fly, Invisibility, Major Image, Plane Shift",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -10232,7 +10232,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The hag casts Disguise Self, using Constitution as the spellcasting ability (spell save DC 13). The spell's duration is 24 hours. - At Will: Disguise Self",
+    "desc": "The hag casts Disguise Self, using Constitution as the spellcasting ability (spell save DC 13). The spell's duration is 24 hours.",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Illusory Appearance",
@@ -10517,7 +10517,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The solar casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 25): - At Will: Detect Evil and Good - 1e/Day Each: Commune, Control Weather, Dispel Evil and Good, Resurrection",
+    "desc": "The solar casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 25):\n\n- **At Will:** Detect Evil and Good\n- **1/Day Each:** Commune, Control Weather, Dispel Evil and Good, Resurrection",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -10607,7 +10607,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The sphinx casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16): - At Will: Detect Magic, Identify, Mage Hand, Minor Illusion, Prestidigitation - 1e/Day Each: Dispel Magic, Legend Lore, Locate Object, Plane Shift, Remove Curse, Tongues",
+    "desc": "The sphinx casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16):\n\n- **At Will:** Detect Magic, Identify, Mage Hand, Minor Illusion, Prestidigitation\n- **1/Day Each:** Dispel Magic, Legend Lore, Locate Object, Plane Shift, Remove Curse, Tongues",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -10697,7 +10697,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The sphinx casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 20): - At Will: Detect Evil and Good, Thaumaturgy - 1e/Day Each: Detect Magic, Dispel Magic, Greater Restoration, Heroes' Feast, Zone of Truth",
+    "desc": "The sphinx casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 20):\n\n- **At Will:** Detect Evil and Good, Thaumaturgy\n- **1/Day Each:** Detect Magic, Dispel Magic, Greater Restoration, Heroes' Feast, Zone of Truth",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -10802,7 +10802,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Intelligence as the spellcasting ability (spell save DC 14): - At Will: Detect Magic, Mage Hand, Minor Illusion, Water Breathing - 2e/Day Each: Detect Thoughts, Dimension Door, Hold Person, Lightning Bolt",
+    "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Intelligence as the spellcasting ability (spell save DC 14):\n\n- **At Will:** Detect Magic, Mage Hand, Minor Illusion, Water Breathing\n- **2/Day Each:** Detect Thoughts, Dimension Door, Hold Person, Lightning Bolt",
     "form_condition": null,
     "legendary_cost": 1,
     "name": "Spellcasting",
@@ -10847,9 +10847,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The sprite casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability. - At Will: Invisibility",
+    "desc": "The sprite casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability.",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Invisibility",
     "order": 3,
     "parent": "srd-2024_sprite",
@@ -11072,9 +11072,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The giant casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 18): - At Will: Detect Magic, Light - 1/Day Each: Control Weather",
+    "desc": "The giant casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 18):\n\n- **At Will:** Detect Magic, Light\n- **1/Day Each:** Control Weather",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 4,
     "parent": "srd-2024_storm-giant",
@@ -11747,9 +11747,9 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The unicorn casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 14): - At Will: Detect Evil and Good, Druidcraft - 1e/Day Each: Calm Emotions, Dispel Evil and Good, Entangle, Pass without Trace, Word of Recall",
+    "desc": "The unicorn casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 14):\n\n- **At Will:** Detect Evil and Good, Druidcraft\n- **1/Day Each:** Calm Emotions, Dispel Evil and Good, Entangle, Pass without Trace, Word of Recall",
     "form_condition": null,
-    "legendary_cost": 1,
+    "legendary_cost": null,
     "name": "Spellcasting",
     "order": 3,
     "parent": "srd-2024_unicorn",

--- a/data/v2/wizards-of-the-coast/srd-2024/CreatureTrait.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/CreatureTrait.json
@@ -1391,7 +1391,7 @@
 },
 {
   "fields": {
-    "desc": "The mouther babbles incoherently while it doesn't have the Incapacitated condition. Wisdom Saving Throw: DC 10, any creature that starts its turn within 20 feet of the mouther while it is babbling. Failure: The target rolls 1d8 to determine what it does during the current turn: - 1-4: The target does nothing. - 5-6: The target takes no action or Bonus Action and uses all its movement to move in a random direction. - 7-8: The target makes a melee attack against a randomly determined creature within its reach or does nothing if it can't make such an attack.",
+    "desc": "The mouther babbles incoherently while it doesn't have the Incapacitated condition. Wisdom Saving Throw: DC 10, any creature that starts its turn within 20 feet of the mouther while it is babbling. Failure: The target rolls 1d8 to determine what it does during the current turn:\n\n- 1-4: The target does nothing.\n- 5-6: The target takes no action or Bonus Action and uses all its movement to move in a random direction.\n- 7-8: The target makes a melee attack against a randomly determined creature within its reach or does nothing if it can't make such an attack.",
     "name": "Gibbering",
     "parent": "srd-2024_gibbering-mouther",
     "type": null
@@ -2951,7 +2951,7 @@
 },
 {
   "fields": {
-    "desc": "The vampire has these weaknesses: - Forbiddance: The vampire can't enter a residence without an invitation from an occupant. - Running Water: The vampire takes 20 Acid damage if it ends its turn in running water. - Stake to the Heart: The vampire is destroyed if a weapon that deals Piercing damage is driven into the vampire's heart while the vampire has the Incapacitated condition. - Sunlight: The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks.",
+    "desc": "The vampire has these weaknesses:\n\n- **Forbiddance:** The vampire can't enter a residence without an invitation from an occupant.\n- **Running Water:** The vampire takes 20 Acid damage if it ends its turn in running water.\n- **Stake to the Heart:** The vampire is destroyed if a weapon that deals Piercing damage is driven into the vampire's heart while the vampire has the Incapacitated condition.\n- **Sunlight:** The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks.",
     "name": "Vampire Weakness",
     "parent": "srd-2024_vampire-spawn",
     "type": null
@@ -2991,7 +2991,7 @@
 },
 {
   "fields": {
-    "desc": "The vampire has these weaknesses: - Forbiddance: The vampire can't enter a residence without an invitation from an occupant. - Running Water: The vampire takes 20 Acid damage if it ends its turn in running water. - Stake to the Heart: If a weapon that deals Piercing damage is driven into the vampire's heart while the vampire has the Incapacitated condition in its resting place, the vampire has the Paralyzed condition until the weapon is removed. - Sunlight: The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks.",
+    "desc": "The vampire has these weaknesses:\n\n- **Forbiddance:** The vampire can't enter a residence without an invitation from an occupant.\n- **Running Water:** The vampire takes 20 Acid damage if it ends its turn in running water.\n- **Stake to the Heart:** If a weapon that deals Piercing damage is driven into the vampire's heart while the vampire has the Incapacitated condition in its resting place, the vampire has the Paralyzed condition until the weapon is removed.\n- **Sunlight:** The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks.",
     "name": "Vampire Weakness",
     "parent": "srd-2024_vampire",
     "type": null


### PR DESCRIPTION
## Description

This PR fixes many errors in the Markdown lists for Creatures with Spellcasting options lists stat-blocks. Typical issues included excessive or non-existant line-breaks, or the absence of any list syntax.

## Related Issue

Closes #854 (hopefuly I caught everything)

## How was this tested
- Spot checked on local Django development server
- `pytest` (all tests passing)