### PR TITLE
Remove `srd-2014` Mithral and Adamantine Hide Armor

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2014/Item.json
+++ b/data/v2/wizards-of-the-coast/srd-2014/Item.json
@@ -204,35 +204,6 @@
 },
 {
   "fields": {
-    "armor": "srd_hide",
-    "armor_class": 0,
-    "armor_detail": "",
-    "category": "armor",
-    "cost": null,
-    "damage_immunities": [
-      "poison",
-      "psychic"
-    ],
-    "damage_resistances": [],
-    "damage_vulnerabilities": [],
-    "desc": "This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit.",
-    "document": "srd-2014",
-    "hit_dice": null,
-    "hit_points": 0,
-    "name": "Adamantine Armor (Hide)",
-    "nonmagical_attack_immunity": false,
-    "nonmagical_attack_resistance": false,
-    "rarity": "uncommon",
-    "requires_attunement": false,
-    "size": "tiny",
-    "weapon": null,
-    "weight": "12.000"
-  },
-  "model": "api_v2.item",
-  "pk": "srd_adamantine-armor-hide"
-},
-{
-  "fields": {
     "armor": "srd_plate",
     "armor_class": 0,
     "armor_detail": "",
@@ -11487,35 +11458,6 @@
   },
   "model": "api_v2.item",
   "pk": "srd_mithral-armor-half-plate"
-},
-{
-  "fields": {
-    "armor": "srd_hide",
-    "armor_class": 0,
-    "armor_detail": "",
-    "category": "armor",
-    "cost": null,
-    "damage_immunities": [
-      "poison",
-      "psychic"
-    ],
-    "damage_resistances": [],
-    "damage_vulnerabilities": [],
-    "desc": "Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't.",
-    "document": "srd-2014",
-    "hit_dice": null,
-    "hit_points": 0,
-    "name": "Mithral Armor (Hide)",
-    "nonmagical_attack_immunity": false,
-    "nonmagical_attack_resistance": false,
-    "rarity": "uncommon",
-    "requires_attunement": false,
-    "size": "tiny",
-    "weapon": null,
-    "weight": "12.000"
-  },
-  "model": "api_v2.item",
-  "pk": "srd_mithral-armor-hide"
 },
 {
   "fields": {


### PR DESCRIPTION
## Description

This PR removes the Hide Armor variation for Mithral and Adamantine Armors (variations explicitly forbidden in the magic item text) from the V2 `srd-2014` dataset.

## Related Issue
Closes #829 

## How was this tested?
- Spot checked on local Django development server
- `pytest` (all tests passing)