### PR TITLE
Bugfix: added missing dash to Black Flag Mechanist starting equpiment

### DIFF
--- a/data/v2/kobold-press/bfrd/ClassFeature.json
+++ b/data/v2/kobold-press/bfrd/ClassFeature.json
@@ -184,7 +184,7 @@
 },
 {
   "fields": {
-    "desc": "You start with the following equipment, in addition to the equipment granted by your background:\n\n- **(a)** a martial weapon and a shield or **(b)** two simple weapons\n- Light crossbow and 20 bolts\n**(a)** scale mail or **(b)** leather armor\nTinker tools and a dungeoneer’s pack",
+    "desc": "You start with the following equipment, in addition to the equipment granted by your background:\n\n- **(a)** a martial weapon and a shield or **(b)** two simple weapons\n- Light crossbow and 20 bolts\n- **(a)** scale mail or **(b)** leather armor\n- Tinker tools and a dungeoneer’s pack",
     "document": "bfrd",
     "feature_type": "STARTING_EQUIPMENT",
     "name": "Starting Equipment",


### PR DESCRIPTION
## Description

This PR fixes a minor bug in the Mechanist class data from the Black Flag Resource Document.

In the Starting Equipment `ClassFeature`, the final list item in the list of class equipment options is missing the preceding dash, which is required for the list to be parsed correctly by a Markdown renderer.

## How was this tested
- Spot checked on local Django development server
- `pytest` (all tests are green)