### PR TITLE
Added missing subclass data to `srd-2024/ClassFeatureItem.json`

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2024/ClassFeatureItem.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/ClassFeatureItem.json
@@ -18058,5 +18058,45 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "srd-2024_fighter_champion_survivor"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "srd-2024_college-of-lore_bonus-proficiencies"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_college-of-lore_bonus-proficiencies"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "srd-2024_college-of-lore_cutting-words"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_college-of-lore_cutting-words"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 6,
+    "parent": "srd-2024_college-of-lore_magical-discoveries"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_college-of-lore_magical-discoveries"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 14,
+    "parent": "srd-2024_college-of-lore_peerless-skill"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_college-of-lore_peerless-skill"
 }
 ]

--- a/data/v2/wizards-of-the-coast/srd-2024/ClassFeatureItem.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/ClassFeatureItem.json
@@ -17998,5 +17998,65 @@
   },
   "model": "api_v2.classfeatureitem",
   "pk": "srd-2024_wizard_wizard-subclass"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "srd-2024_fighter_champion_improved-critical"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_fighter_champion_improved-critical"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 3,
+    "parent": "srd-2024_fighter_champion_remarkable-athlete"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_fighter_champion_remarkable-athlete"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 7,
+    "parent": "srd-2024_fighter_champion_additional-fighting-style"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_fighter_champion_additional-fighting-style"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 10,
+    "parent": "srd-2024_fighter_champion_heroic-warrior"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_fighter_champion_heroic-warrior"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 15,
+    "parent": "srd-2024_fighter_champion_superior-critical"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_fighter_champion_superior-critical"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
+    "level": 18,
+    "parent": "srd-2024_fighter_champion_survivor"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_fighter_champion_survivor"
 }
 ]


### PR DESCRIPTION
## Description
This PR adds in missing data for the Champion (fighter subclass) and College of Lore (bard subclass) from the 2024 SRD. These two subclasses were missing information from the `ClassFeatureItem.json` file, which defines at what level(s) a given `ClassFeature` is gained at.

## Related Issue
Closes #867 

## How was this tested?

- Spot checked on local Django development server. Results A/B tested against source document.
- `pytest` (all tests passing)