### PR TITLE
Add ability to filter monsters by environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ pipenv run python manage.py spectacular --color --file openapi-schema.yml` to bu
 ```
 
 # Contributing
-See [contribution guide](CONTRIBUTING.md).
+See [contribution guide](.github/CONTRIBUTING.md).
 # Tests
 
 Tests are located in the `api/tests` directory. These should be run before pushing new changes to the main repository. These tests require that the api is [running](##run) at `http://localhost:8000`.

--- a/api/filters.py
+++ b/api/filters.py
@@ -76,6 +76,10 @@ class SpellListFilter(CommonFilterSet):
 
 
 class MonsterFilter(CommonFilterSet):
+    environments = django_filters.CharFilter(
+        field_name="environments_json", lookup_expr="icontains"
+    )
+
     class Meta:
         model = models.Monster
         fields = {
@@ -91,6 +95,7 @@ class MonsterFilter(CommonFilterSet):
             "hit_points": ["exact", "range", "gt", "gte", "lt", "lte"],
             "armor_class": ["exact", "range", "gt", "gte", "lt", "lte"],
             "type": ["iexact", "exact", "in", "icontains"],
+            "environments_json": ["iexact", "exact", "in", "icontains"],
             "size": ["iexact", "exact", "in", "icontains"],
             "page_no": ["exact", "range", "gt", "gte", "lt", "lte"],
             "document__slug": [


### PR DESCRIPTION
This PR adds a filter to monsters on the field environments_json. It enabled filtering monsters by their environment.

Example API call now possible: `/v1/monsters/?limit=50&type=Dragon&environments=Mountain`

The filter uses simple substring matching, since the environments json data includes simple strings with some inconsistencies.