### PR TITLE
[BUGFIX] Removed leading slashes from Image `"file_urls"`

### DIFF
--- a/data/v2/open5e/elderberry-inn-icons/Image.json
+++ b/data/v2/open5e/elderberry-inn-icons/Image.json
@@ -4,7 +4,7 @@
     "alt_text": "An icon representing the blinded condition in an RPG. A simple, abstract black-and-white icon of an eye with a line crossed through it.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/blinded.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/blinded.svg",
     "name": "Blinded",
     "type": "icon"
   },
@@ -16,7 +16,7 @@
     "alt_text": "An icon representing the charmed condition in an RPG. A simple black-and-white silhouette of a humanoid facing the viewer. There is a heart where their face should be.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/charmed.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/charmed.svg",
     "name": "Charmed",
     "type": "icon"
   },
@@ -28,7 +28,7 @@
     "alt_text": "An icon representing the deafened condition in an RPG. A simple black-and-white outline of an ear with a diagonal line passing through it, as if it were crossed out.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/deaftened.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/deaftened.svg",
     "name": "Deaftened",
     "type": "icon"
   },
@@ -40,7 +40,7 @@
     "alt_text": "An icon representing the Exhaustion (one level) condition. A simple black-and-white diagram of a standing figure hunched over in exhaustion with a large numeral '1'.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/exhaustion1.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/exhaustion1.svg",
     "name": "Exhaustion1",
     "type": "icon"
   },
@@ -52,7 +52,7 @@
     "alt_text": "An icon representing the Exhaustion (two levels) condition. A simple black-and-white diagram of a standing figure hunched over in exhaustion with a large numeral '2'.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/exhaustion2.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/exhaustion2.svg",
     "name": "Exhaustion2",
     "type": "icon"
   },
@@ -64,7 +64,7 @@
     "alt_text": "An icon representing the Exhaustion (three levels) condition. A simple black-and-white diagram of a standing figure hunched over in exhaustion with a large numeral '3'.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/exhaustion3.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/exhaustion3.svg",
     "name": "Exhaustion3",
     "type": "icon"
   },
@@ -76,7 +76,7 @@
     "alt_text": "An icon representing the Exhaustion (four levels) condition. A simple black-and-white diagram of a standing figure hunched over in exhaustion with a large numeral '4'.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/exhaustion4.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/exhaustion4.svg",
     "name": "Exhaustion4",
     "type": "icon"
   },
@@ -88,7 +88,7 @@
     "alt_text": "An icon representing the Exhaustion (five levels) condition. A simple black-and-white diagram of a standing figure hunched over in exhaustion with a large numeral '5'.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/exhaustion5.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/exhaustion5.svg",
     "name": "Exhaustion5",
     "type": "icon"
   },
@@ -100,7 +100,7 @@
     "alt_text": "An icon representing the Exhaustion (six levels) condition. A simple black-and-white diagram of a standing figure hunched over in exhaustion with a large numeral '6'.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/exhaustion6.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/exhaustion6.svg",
     "name": "Exhaustion6",
     "type": "icon"
   },
@@ -112,7 +112,7 @@
     "alt_text": "An icon representing the Frightened condition. A simple black-and-white silhouette figure from the shoulders up facing the viewer. Their hands are raised to their head and they are screaming.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/frightened.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/frightened.svg",
     "name": "Frightened",
     "type": "icon"
   },
@@ -124,7 +124,7 @@
     "alt_text": "An icon representing the Grappled condition. A simple black-and-white image of an arm staining against a chain and shackle attached to the wrist.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/grappled.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/grappled.svg",
     "name": "Grappled",
     "type": "icon"
   },
@@ -136,7 +136,7 @@
     "alt_text": "An icon representing the Incapacitated condition. A black-and-white silhouetted figure visible from the shoulders up faces the viewer. There is an X where thier face should be, and a shirling figure over thier head.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/incapacitated.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/incapacitated.svg",
     "name": "Incapacitated",
     "type": "icon"
   },
@@ -148,7 +148,7 @@
     "alt_text": "An icon representing the Inconscious condition. A black-and-white silhouetted figure visible from the shoulders up faces the viewer. Where its eyes should be are swirls",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/inconscious.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/inconscious.svg",
     "name": "Inconscious",
     "type": "icon"
   },
@@ -160,7 +160,7 @@
     "alt_text": "An icon representing the Invisible condition. A black-and-white silhouette of a figure visible from the shoulders up faces the viewer. They are drawn with a dashed outline to indicate that they are invisible.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/invisible.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/invisible.svg",
     "name": "Invisible",
     "type": "icon"
   },
@@ -172,7 +172,7 @@
     "alt_text": "An icon representing the Paralyzed condition. A black-and-white silhouette of a figure visible from the shoulders up faces the viewer. They are surrounded by a chain.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/paralyzed.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/paralyzed.svg",
     "name": "Paralyzed",
     "type": "icon"
   },
@@ -184,7 +184,7 @@
     "alt_text": "An icon representing the Petrified condition. A black-and-white silhouette of a figure visible from the shoulders up faces the viewer. They are covered in numerous broad cracks as if they were an old, crumbling statue.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/petrified.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/petrified.svg",
     "name": "Petrified",
     "type": "icon"
   },
@@ -196,7 +196,7 @@
     "alt_text": "An icon representing the Poisoned condition. A simple black-and-white drawing of a bottle with a stopper and a skull on its front.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/poisoned.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/poisoned.svg",
     "name": "Poisoned",
     "type": "icon"
   },
@@ -208,7 +208,7 @@
     "alt_text": "An icon representing the Prone condition.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/prone.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/prone.svg",
     "name": "Prone",
     "type": "icon"
   },
@@ -220,7 +220,7 @@
     "alt_text": "An icon representing the Restrained condition. A simple black-and-white silouetted figure is on all fours, as if crawling. Three large arrows above the figure point downward.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/restrained.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/restrained.svg",
     "name": "Restrained",
     "type": "icon"
   },
@@ -232,7 +232,7 @@
     "alt_text": "An icon representing the Stunned condition. A black-and-white silhouette of a figure visible from the shoulders up faces the viewer. They are surrounded by stars that sit on rings which suggest orbits.",
     "attribution": "Designed with love by Anaislalovi (@anaislalovi) for Elderberry Inn.",
     "document": "elderberry-inn-icons",
-    "file_path": "/img/object_icons/elderberry-inn-icons/conditions/stunned.svg",
+    "file_path": "img/object_icons/elderberry-inn-icons/conditions/stunned.svg",
     "name": "Stunned",
     "type": "icon"
   },

--- a/data/v2/open5e/open5e/Image.json
+++ b/data/v2/open5e/open5e/Image.json
@@ -4,7 +4,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/aboleth.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/aboleth.png",
     "name": "Aboleth",
     "type": "illustration"
   },
@@ -16,7 +16,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/ankheg.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/ankheg.png",
     "name": "Ankheg",
     "type": "illustration"
   },
@@ -28,7 +28,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/basilisk.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/basilisk.png",
     "name": "Basilisk",
     "type": "illustration"
   },
@@ -40,7 +40,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/behir.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/behir.png",
     "name": "Behir",
     "type": "illustration"
   },
@@ -52,7 +52,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/bulette.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/bulette.png",
     "name": "Bulette",
     "type": "illustration"
   },
@@ -64,7 +64,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/chuul.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/chuul.png",
     "name": "Chuul",
     "type": "illustration"
   },
@@ -76,7 +76,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/cloaker.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/cloaker.png",
     "name": "Cloaker",
     "type": "illustration"
   },
@@ -88,7 +88,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/cockatrice.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/cockatrice.png",
     "name": "Cockatrice",
     "type": "illustration"
   },
@@ -100,7 +100,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/couatl.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/couatl.png",
     "name": "Couatl",
     "type": "illustration"
   },
@@ -112,7 +112,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/darkmantle.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/darkmantle.png",
     "name": "Darkmantle",
     "type": "illustration"
   },
@@ -124,7 +124,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/hezrou.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/hezrou.png",
     "name": "Hezrou",
     "type": "illustration"
   },
@@ -136,7 +136,7 @@
     "alt_text": "",
     "attribution": "",
     "document": "open5e",
-    "file_path": "/img/object_illustrations/open5e-illustrations/monsters/rust-monster.png",
+    "file_path": "img/object_illustrations/open5e-illustrations/monsters/rust-monster.png",
     "name": "Rust Monster",
     "type": "illustration"
   },


### PR DESCRIPTION
## Description
This PR fixes a bug (surfaced while working on #881) where file paths to static files in the `"file_url"` field of our `Image` data were causing some endpoint to fail on local Django development servers.

The leading slash in the URLs marks them as absolute paths. On the local Django dev server, these are sanitised by our WhiteNoise middleware, but the Django Debug Toolbar middleware appears to have interferred with this in some way. Not ideal, but this PR fixes the issue with the source data that required us leaning on the file path sanitation provided by our middleware.

## Related Issue
Closes #885

## How was this tested?
- Spot checked on local Django development server
- `pytest` (all tests passing)