### PR TITLE
[BUGFIX] Fixed typo in srd-2024 Adult Green Dragon Spellcasting action

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2024/CreatureAction.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/CreatureAction.json
@@ -872,7 +872,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):\n- **At Will:** Detect Magic, Mind Spike -\n**1/Day Each:** Geas",
+    "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):\n- **At Will:** Detect Magic, Mind Spike\n- **1/Day Each:** Geas",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Spellcasting",


### PR DESCRIPTION
## Description
This PR fixes a small typo I encountered while working on the front-end. If you look at the [srd-2024 Adult Green Dragon](https://beta.open5e.com/monsters/srd-2024_adult-green-dragon) statblock on the beta site, you'll see that the Markdown underneath the `Spellcasting` action doesn't parse correctly:

<img width="366" height="229" alt="Screenshot 2026-03-15 at 10 32 56" src="https://github.com/user-attachments/assets/d0f9a611-f5cd-4a24-b194-f34dad4e36c4" />

Instead of **1/Day Each: Geas** having its own bullet-point, we see an errant hyphen on the line above.

Investigating the data, it looks like a data entry bug. Swapping around the `\n` and `-` in the Markdown string fixed the issue:

<img width="389" height="152" alt="Screenshot 2026-03-15 at 10 37 03" src="https://github.com/user-attachments/assets/27bdfa91-ef2a-4de7-b2a4-aa98aeefaad6" />


## How was this tested
- Spoted checked on local Django developement server
- `pytest` (all tests passing on local)