### PR TITLE
Add missing ClassFeatureItem for srd-2024 Fighter Two Extra Attacks action

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2024/ClassFeatureItem.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/ClassFeatureItem.json
@@ -7793,6 +7793,16 @@
   "fields": {
     "column_value": null,
     "detail": null,
+    "level": 11,
+    "parent": "srd-2024_fighter_two-extra-attacks"
+  },
+  "model": "api_v2.classfeatureitem",
+  "pk": "srd-2024_fighter_two-extra-attacks"
+},
+{
+  "fields": {
+    "column_value": null,
+    "detail": null,
     "level": 20,
     "parent": "srd-2024_fighter_three-extra-attacks"
   },


### PR DESCRIPTION
## Description
This PR adds in a missing `ClassFeatureItem` data for the srd-2024 FIghter's "Two Extra Attacks" `ClassFeature`. 

As of this change, the "Two Extra Attacks" feature is showing up correctly on the front-end:

<img width="1110" height="679" alt="Screenshot 2026-03-18 at 07 45 49" src="https://github.com/user-attachments/assets/532ee863-dde0-451e-b9fa-ee638f077f24" />

<img width="1108" height="681" alt="Screenshot 2026-03-18 at 07 45 57" src="https://github.com/user-attachments/assets/db42d3a4-437f-408a-b677-de3e94daee46" />


## Related Issue
Closes #894 

## How was this tested?
- `pytest` (all tests passing)
- Spot checked on local Django development server