### PR TITLE
[BUGFIX] Fixed EagerLoadingMixin early return error

### DIFF
--- a/api_v2/views/mixins/eager_loading_mixin.py
+++ b/api_v2/views/mixins/eager_loading_mixin.py
@@ -28,26 +28,24 @@ class EagerLoadingMixin:
   prefetch_related_fields = []
 
   def get_queryset(self):
-    """Override DRF's default get_queryset() method to apply eager loading"""
-    
     queryset = super().get_queryset()
     requested_fields = self.request.query_params.get('fields', '').split(',')
-    
+    filtered_select_fields = self.filter_fields(self.select_related_fields, requested_fields)
+    filtered_prefetch_fields = self.filter_fields(self.prefetch_related_fields, requested_fields)
+
+    return queryset \
+      .select_related(*filtered_select_fields) \
+      .prefetch_related(*filtered_prefetch_fields)
+
+  def filter_fields(self, related_fields, requested_fields):
+    """
+    Filters'related_fields' according to whether they are included in 
+    'requested_fields'. Used to remove fields from eager loading if they are
+    not requested (and thus not returned by API), avoiding unnecessary DB calls
+    """
     if not any(requested_fields):
-      return queryset \
-          .select_related(*self.select_related_fields) \
-          .prefetch_related(*self.prefetch_related_fields)
-        
-    # filter selected fields against fields requested by user via query params 
-    # this stops Django prefetching data that isn't even returned by this view
-    select_fields = []
-    for field_to_select in self.select_related_fields:
-      if any(field_in_request in field_to_select for field_in_request in requested_fields):
-        select_fields.append(field_to_select)
-    
-    # filter prefetch fields against fields requested by user via query params
-    # this stops Django prefetching data that isn't even returned by this view
-    prefetch_fields = []
-    for field_to_prefetch in self.prefetch_related_fields:
-      if any(field_in_request in field_to_prefetch for field_in_request in requested_fields):
-        prefetch_fields.append(field_to_prefetch)
+      return related_fields
+    return [
+      related_field for related_field in related_fields
+      if any(related_field == req or related_field.startswith(req + '__') for req in requested_fields)
+    ]

--- a/api_v2/views/mixins/eager_loading_mixin.py
+++ b/api_v2/views/mixins/eager_loading_mixin.py
@@ -14,35 +14,30 @@ class EagerLoadingMixin:
   
   ## Usage Example
   ```
-    # EagerLoadingMixin inhertired before base-case
     class CreatureViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
       queryset = models.Creature.objects.all().order_by('pk')
       serializer_class = serializers.CreatureSerializer
       filterset_class = CreatureFilterSet
-
       select_related_fields = []   # ForeignKey relations to optimise with select_related()      
       prefetch_related_fields = [] # ManyToMany/reverse relations to optimise with prefetch_related()
   ```
   """
 
   # Override these lists in child views 
-  select_related_fields = [] # ForeignKeys to optimise
-  prefetch_related_fields = [] # ManyToMany & reverse relationships to prefetch
+  select_related_fields = []
+  prefetch_related_fields = []
 
   def get_queryset(self):
     """Override DRF's default get_queryset() method to apply eager loading"""
-    queryset = super().get_queryset()
-
-    # Get query parameters from request
-    requested_fields = self.request.query_params.get('fields', '').split(',')
-    depth = int(self.request.query_params.get('depth', 0))
-
-    # if no fields are passed via query param, select/prefetch all fields defined on the view
-    if not requested_fields:
-      queryset = queryset.select_related(*self.select_related_fields)
-      queryset = queryset.prefetch_related(*self.prefetch_related_fields)
-      return queryset
     
+    queryset = super().get_queryset()
+    requested_fields = self.request.query_params.get('fields', '').split(',')
+    
+    if not any(requested_fields):
+      return queryset \
+          .select_related(*self.select_related_fields) \
+          .prefetch_related(*self.prefetch_related_fields)
+        
     # filter selected fields against fields requested by user via query params 
     # this stops Django prefetching data that isn't even returned by this view
     select_fields = []
@@ -56,8 +51,3 @@ class EagerLoadingMixin:
     for field_to_prefetch in self.prefetch_related_fields:
       if any(field_in_request in field_to_prefetch for field_in_request in requested_fields):
         prefetch_fields.append(field_to_prefetch)
-
-    # Apply filtered optimisations
-    queryset = queryset.select_related(*select_fields)
-    queryset = queryset.prefetch_related(*prefetch_fields)
-    return queryset


### PR DESCRIPTION
## Description
This PR fixes a bug in the `EagerLoadingMixin` where the follow conditional:

```
if not requested_fields:
```

Would never evaluate as True due to `requested_fields` being an array and arrays being Truthy in Python. This was replaced with a call to `any()` (which outputs true if any of the elements of an array is not false/falsey)

```
if not any(requested_fields):
```

The way that the fields were filtered in this mixin was also refactored to fix some additoinal bugs that taking a look at this issue exposed: specifically fields being filtered by sub-string matches, which might mess with nested fields with the same name, ie. a Creatures `name` matching to its `document__name`.


## Related Issue
Closes #897 

## How was this tested
- `pytest` (all tests passing)
- Spot checked on local Django develpoment server