### PR TITLE
[BUGFIX / DATA] srd-2014 skeleton resistances/immunities

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2014/Creature.json
+++ b/data/v2/wizards-of-the-coast/srd-2014/Creature.json
@@ -23096,12 +23096,12 @@
       "poisoned"
     ],
     "condition_immunities_display": "exhaustion, poisoned",
-    "damage_immunities": [],
-    "damage_immunities_display": "",
-    "damage_resistances": [
+    "damage_immunities": [
       "poison"
     ],
-    "damage_resistances_display": "poison",
+    "damage_immunities_display": "poison",
+    "damage_resistances": [],
+    "damage_resistances_display": "",
     "damage_vulnerabilities": [
       "bludgeoning"
     ],


### PR DESCRIPTION
## Description
This PR fixes a small bug in our Monster data where the SRD-2014 Skeleton was listed as having poison damage resistance. This should be an immunity to poison damage. The data fixtures have been updated to reflect this.

<img width="1257" height="1110" alt="Screenshot from 2026-04-08 12-23-29" src="https://github.com/user-attachments/assets/71dfe3a9-28bd-41f2-9dce-ecb2a47f6246" />


## Related Issue
Closes #903

## How was this tested
- Spot checked on local Django test server
- CI tests passing