### PR TITLE
[BUGFIX  / DATA] srd-2014 Brass Dragons markdown fixes

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2014/CreatureAction.json
+++ b/data/v2/wizards-of-the-coast/srd-2014/CreatureAction.json
@@ -407,7 +407,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 45 (13d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+    "desc": "The dragon uses one of the following breath weapons:\n\n- **Fire Breath.** The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 45 (13d6) fire damage on a failed save, or half as much damage on a successful one.\n- **Sleep Breath.** The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Breath Weapons",
@@ -1847,7 +1847,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon uses one of the following breath weapons:\n**Fire Breath.** The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+    "desc": "The dragon uses one of the following breath weapons:\n\n- **Fire Breath.** The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.\n- **Sleep Breath.** The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Breath Weapons",
@@ -3977,7 +3977,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 14 (4d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+    "desc": "The dragon uses one of the following breath weapons:\n\n- **Fire Breath.** The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 14 (4d6) fire damage on a failed save, or half as much damage on a successful one.\n- **Sleep Breath.** The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Breath Weapons",
@@ -13682,7 +13682,7 @@
 {
   "fields": {
     "action_type": "ACTION",
-    "desc": "The dragon uses one of the following breath weapons.\n**Fire Breath.** The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 42 (12d6) fire damage on a failed save, or half as much damage on a successful one.\n**Sleep Breath.** The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+    "desc": "The dragon uses one of the following breath weapons:\n\n- **Fire Breath.** The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 42 (12d6) fire damage on a failed save, or half as much damage on a successful one.\n- **Sleep Breath.** The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
     "form_condition": null,
     "legendary_cost": null,
     "name": "Breath Weapons",


### PR DESCRIPTION
## Description
This issue fixes a small issue present in all the srd-2014 Brass Dragon stat-blocks where the Breath Weapon options were not being rendered as a list (list issue #911). The Markdown string for those creature actions has been updated so the data is rendered correctly as a list:

<img width="1670" height="877" alt="Screenshot from 2026-04-11 10-51-09" src="https://github.com/user-attachments/assets/16b6746b-2823-4544-9bf8-86fbe98a7bcd" />


## Related issue
Closes #911

## How was this tested
- Spot checked on local Django development server (consumed by FE running on local Nuxt development server)
- `pipenv run pytest` (all tests passing on local)
- CI tests passing