### PR TITLE
[BUGFIX] Fixed crashes on Search

### DIFF
--- a/api_v2/models/document.py
+++ b/api_v2/models/document.py
@@ -145,9 +145,7 @@ class FromDocument(models.Model):
         return reverse(self.__name__, kwargs={"pk": self.pk})
 
     def search_result_extra_fields(self):
-        return {
-            "school":self.school.key,
-        }
+        return
 
     class Meta:
         abstract = True


### PR DESCRIPTION
## Description

This PR fixes a bug that was causing the v2 Search to crash when certain terms were searched for (see issue #922).

The bug appears to be in the code that adds additional contextually relevant fields to search results. adding a spell's school and level when the search returns a spell, for example.

The `Document` model's `search_result_extra_fields` method instructed the serializer to add the `"school"` field to any search result that inherits from the `FromDocument` model.  I can only assume that this bug only triggered on some search terms and not others was because in many cases the `search_result_extra_fields` is overloaded in the Class that inherited from the `FromDocument` abstract model, obscuring the bug. A quick peak at the error messages/stack trace reveals that it was the `Item` model which was giving the API issues, and investigating the Item model it looks like this method is not defined there. Surprise surprise.

This would normally be the type of bug that `pytest` would catch, but it looks like the Search is a blind-spot in our testing suite. Would be well worth adding this in!


## Related Issue

Closes #922 

## How was this tested?
- `pytest` (all tests green)
- Spot checked on local Django development server
- All CI tests passing