### PR TITLE
Made cache clear dependent on the other workflow.

### DIFF
--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -1,7 +1,10 @@
 name: Clear Cloudflare Cache After Deployments
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build and deploy"]
+    types:
+      - completed
     branches:
       - main
       - staging


### PR DESCRIPTION
Changed the trigger on this one to be dependent on the Build and deploy action, only when completed. Then the cache can be cleared. Should be improved.