### PR TITLE
feat: commit openapi-schema.yml + add freshness gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+openapi-schema.yml text eol=lf merge=binary

--- a/.github/workflows/openapi-spec-freshness.yml
+++ b/.github/workflows/openapi-spec-freshness.yml
@@ -1,0 +1,34 @@
+name: OpenAPI spec freshness
+
+on:
+  pull_request:
+
+jobs:
+  verify-spec-fresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          prune-cache: false
+
+      - name: Install Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify openapi-schema.yml matches code
+        run: |
+          uv run python manage.py spectacular --file openapi-schema.yml
+          if ! git diff --exit-code -- openapi-schema.yml; then
+            echo "::error::openapi-schema.yml is out of date with the code on this branch."
+            echo "::error::Regenerate locally with:"
+            echo "::error::  uv run python manage.py spectacular --file openapi-schema.yml"
+            echo "::error::Then commit the updated file and push."
+            exit 1
+          fi
+          echo "openapi-schema.yml is up to date."

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ server/whoosh_index/
 api/tests/approved_files/*.recieved.*
 
 # Generated files
-openapi-schema.yml
-
 server/vector_index.pkl
 
 # Temporary files for magic items update

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All v1 content is still available for hosting your own version, if required
   * [Build](#build)
     + [Search Indexing](#search-indexing)
   * [Run](#run)
-  * [Building the OAS file](#building-the-oas-file)
+  * [OpenAPI Spec](#openapi-spec)
 - [Contributing](#contributing)
   * [Editing existing sources](#editing-existing-sources)
   * [Adding a new source](#adding-a-new-source)
@@ -118,12 +118,21 @@ gunicorn -b :8888 server.wsgi:application
 
 You can use our Dockerfile as inspiration, but it likely will not work without significant edits to your operating environment. We have customized our production environment to use it.
 
-## Building the OAS file
+## OpenAPI Spec
 
-After completing a build, you can generate an OAS file to be used by another application.
+`openapi-schema.yml` (at the repo root) is the canonical API contract for `/v2/`,
+generated from the serializers/views by drf-spectacular. It is committed to the
+repo so consumers and reviewers can read and diff the contract directly.
+
+CI verifies it stays in sync with the code on every PR into `staging-with-spec`.
+If you change a serializer, view, model, or schema-affecting setting, regenerate:
+
 ```bash
-uv run python manage.py spectacular --color --file openapi-schema.yml
+uv run python manage.py spectacular --file openapi-schema.yml
 ```
+
+Then commit the updated file. Do **not** hand-edit `openapi-schema.yml` — it is
+a build artifact.
 
 # Contributing
 See [contribution guide](.github/CONTRIBUTING.md).

--- a/openapi-schema.yml
+++ b/openapi-schema.yml
@@ -1,0 +1,9168 @@
+openapi: 3.0.3
+info:
+  title: Open5e
+  version: development
+  description: The Open5e API. See [https://github.com/open5e/open5e-api] for more
+    information.
+paths:
+  /v2/items/:
+    get:
+      operationId: items_list
+      description: |-
+        list: API endpoint for returning a list of items.
+
+        retrieve: API endpoint for returning a particular item.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: desc__icontains
+        schema:
+          type: string
+      - in: query
+        name: cost
+        schema:
+          type: number
+      - in: query
+        name: cost__range
+        schema:
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: cost__gt
+        schema:
+          type: number
+      - in: query
+        name: cost__gte
+        schema:
+          type: number
+      - in: query
+        name: cost__lt
+        schema:
+          type: number
+      - in: query
+        name: cost__lte
+        schema:
+          type: number
+      - in: query
+        name: weight
+        schema:
+          type: number
+      - in: query
+        name: weight__range
+        schema:
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: weight__gt
+        schema:
+          type: number
+      - in: query
+        name: weight__gte
+        schema:
+          type: number
+      - in: query
+        name: weight__lt
+        schema:
+          type: number
+      - in: query
+        name: weight__lte
+        schema:
+          type: number
+      - in: query
+        name: category__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: category
+        schema:
+          type: string
+        description: Unique key for the Item.
+      - in: query
+        name: document__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document
+        schema:
+          type: string
+        description: Unique key for the Document.
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: is_weapon
+        schema:
+          type: boolean
+        description: Weapons
+      - in: query
+        name: is_armor
+        schema:
+          type: boolean
+        description: Armor
+      - in: query
+        name: is_light
+        schema:
+          type: boolean
+        description: Light Weapons
+      - in: query
+        name: is_versatile
+        schema:
+          type: boolean
+        description: Versatile Weapons
+      - in: query
+        name: is_thrown
+        schema:
+          type: boolean
+        description: Thrown Weapons
+      - in: query
+        name: is_finesse
+        schema:
+          type: boolean
+        description: Finesse Weapons
+      - in: query
+        name: is_two_handed
+        schema:
+          type: boolean
+        description: Two-handed Weapons
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - items
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemList'
+          description: ''
+  /v2/items/{key}/:
+    get:
+      operationId: items_retrieve
+      description: |-
+        list: API endpoint for returning a list of items.
+
+        retrieve: API endpoint for returning a particular item.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - items
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+          description: ''
+  /v2/magicitems/:
+    get:
+      operationId: magicitems_list
+      description: |-
+        list: API endpoint for returning a list of magic items.
+
+        retrieve: API endpoint for returning a particular magic item.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: desc__icontains
+        schema:
+          type: string
+      - in: query
+        name: cost
+        schema:
+          type: number
+      - in: query
+        name: cost__range
+        schema:
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: cost__gt
+        schema:
+          type: number
+      - in: query
+        name: cost__gte
+        schema:
+          type: number
+      - in: query
+        name: cost__lt
+        schema:
+          type: number
+      - in: query
+        name: cost__lte
+        schema:
+          type: number
+      - in: query
+        name: weight
+        schema:
+          type: number
+      - in: query
+        name: weight__range
+        schema:
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: weight__gt
+        schema:
+          type: number
+      - in: query
+        name: weight__gte
+        schema:
+          type: number
+      - in: query
+        name: weight__lt
+        schema:
+          type: number
+      - in: query
+        name: weight__lte
+        schema:
+          type: number
+      - in: query
+        name: category__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: category
+        schema:
+          type: string
+        description: Unique key for the Item.
+      - in: query
+        name: document__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document
+        schema:
+          type: string
+        description: Unique key for the Document.
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: rarity
+        schema:
+          type: string
+        description: Unique key for the Item.
+      - in: query
+        name: rarity__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: requires_attunement
+        schema:
+          type: boolean
+        description: Requires Attunement
+      - in: query
+        name: is_weapon
+        schema:
+          type: boolean
+        description: Weapons
+      - in: query
+        name: is_armor
+        schema:
+          type: boolean
+        description: Armor
+      - in: query
+        name: is_light
+        schema:
+          type: boolean
+        description: Light Weapons
+      - in: query
+        name: is_versatile
+        schema:
+          type: boolean
+        description: Versatile Weapons
+      - in: query
+        name: is_thrown
+        schema:
+          type: boolean
+        description: Thrown Weapons
+      - in: query
+        name: is_finesse
+        schema:
+          type: boolean
+        description: Finesse Weapons
+      - in: query
+        name: is_two_handed
+        schema:
+          type: boolean
+        description: Two-handed Weapons
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - magicitems
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedMagicItemList'
+          description: ''
+  /v2/magicitems/{key}/:
+    get:
+      operationId: magicitems_retrieve
+      description: |-
+        list: API endpoint for returning a list of magic items.
+
+        retrieve: API endpoint for returning a particular magic item.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - magicitems
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MagicItem'
+          description: ''
+  /v2/itemsets/:
+    get:
+      operationId: itemsets_list
+      description: |-
+        list: API Endpoint for returning a set of itemsets.
+
+        retrieve: API endpoint for return a particular itemset.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - itemsets
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemSetList'
+          description: ''
+  /v2/itemsets/{key}/:
+    get:
+      operationId: itemsets_retrieve
+      description: |-
+        list: API Endpoint for returning a set of itemsets.
+
+        retrieve: API endpoint for return a particular itemset.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - itemsets
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemSet'
+          description: ''
+  /v2/itemcategories/:
+    get:
+      operationId: itemcategories_list
+      description: |-
+        list: API Endpoint for returning a set of item categories.
+
+        retrieve: API endpoint for return a particular item categories.
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - itemcategories
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemCategoryList'
+          description: ''
+  /v2/itemcategories/{key}/:
+    get:
+      operationId: itemcategories_retrieve
+      description: |-
+        list: API Endpoint for returning a set of item categories.
+
+        retrieve: API endpoint for return a particular item categories.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - itemcategories
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemCategory'
+          description: ''
+  /v2/documents/:
+    get:
+      operationId: documents_list
+      description: |-
+        list: API endpoint for returning a list of documents.
+        retrieve: API endpoint for returning a particular document.
+      parameters:
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: desc
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: type
+        schema:
+          type: string
+          x-spec-enum-id: 995afaa0b151df94
+          enum:
+          - MISC
+          - SOURCE
+        description: |-
+          Whether this Document is a published data source, or general resources
+
+          * `SOURCE` - Source
+          * `MISC` - Miscellaneous
+      - in: query
+        name: licenses
+        schema:
+          type: array
+          items:
+            type: string
+        description: Unique key for the License.
+        explode: true
+        style: form
+      - in: query
+        name: publisher
+        schema:
+          type: string
+        description: Unique key for the publishing organization.
+      - in: query
+        name: gamesystem
+        schema:
+          type: string
+        description: Unique key for the gamesystem the document was published for.
+      - in: query
+        name: author
+        schema:
+          type: string
+      - in: query
+        name: display_name
+        schema:
+          type: string
+      - in: query
+        name: publication_date
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: permalink
+        schema:
+          type: string
+      - in: query
+        name: distance_unit
+        schema:
+          type: string
+          x-spec-enum-id: 6eaa2f2d15b5e114
+          nullable: true
+          enum:
+          - feet
+          - miles
+        description: |-
+          What distance unit the relevant field uses.
+
+          * `feet` - feet
+          * `miles` - miles
+      - in: query
+        name: weight_unit
+        schema:
+          type: string
+          x-spec-enum-id: 6eaa2f2d15b5e114
+          nullable: true
+          enum:
+          - feet
+          - miles
+        description: |-
+          What distance unit the relevant field uses.
+
+          * `feet` - feet
+          * `miles` - miles
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - documents
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedDocumentList'
+          description: ''
+  /v2/documents/{key}/:
+    get:
+      operationId: documents_retrieve
+      description: |-
+        list: API endpoint for returning a list of documents.
+        retrieve: API endpoint for returning a particular document.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Document.
+        required: true
+      tags:
+      - documents
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+          description: ''
+  /v2/licenses/:
+    get:
+      operationId: licenses_list
+      description: |-
+        list: API endpoint for returning a list of licenses.
+        retrieve: API endpoint for returning a particular license.
+      parameters:
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: desc
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - licenses
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedLicenseList'
+          description: ''
+  /v2/licenses/{key}/:
+    get:
+      operationId: licenses_retrieve
+      description: |-
+        list: API endpoint for returning a list of licenses.
+        retrieve: API endpoint for returning a particular license.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the License.
+        required: true
+      tags:
+      - licenses
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/License'
+          description: ''
+  /v2/publishers/:
+    get:
+      operationId: publishers_list
+      description: |-
+        list: API endpoint for returning a list of publishers.
+        retrieve: API endpoint for returning a particular publisher.
+      parameters:
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - publishers
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPublisherList'
+          description: ''
+  /v2/publishers/{key}/:
+    get:
+      operationId: publishers_retrieve
+      description: |-
+        list: API endpoint for returning a list of publishers.
+        retrieve: API endpoint for returning a particular publisher.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the publishing organization.
+        required: true
+      tags:
+      - publishers
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Publisher'
+          description: ''
+  /v2/weapons/:
+    get:
+      operationId: weapons_list
+      description: |-
+        list: API endpoint for returning a list of weapons.
+        retrieve: API endpoint for returning a particular weapon.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: damage_dice__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: damage_dice__iexact
+        schema:
+          type: string
+      - in: query
+        name: is_light
+        schema:
+          type: boolean
+        description: Is Light
+      - in: query
+        name: is_versatile
+        schema:
+          type: boolean
+        description: Is Versatile
+      - in: query
+        name: is_thrown
+        schema:
+          type: boolean
+        description: Is Thrown
+      - in: query
+        name: is_finesse
+        schema:
+          type: boolean
+        description: Is Finesse
+      - in: query
+        name: is_two_handed
+        schema:
+          type: boolean
+        description: Is Two-handed
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - weapons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedWeaponList'
+          description: ''
+  /v2/weapons/{key}/:
+    get:
+      operationId: weapons_retrieve
+      description: |-
+        list: API endpoint for returning a list of weapons.
+        retrieve: API endpoint for returning a particular weapon.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - weapons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Weapon'
+          description: ''
+  /v2/armor/:
+    get:
+      operationId: armor_list
+      description: |-
+        list: API endpoint for returning a list of armor.
+        retrieve: API endpoint for returning a particular armor.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - in: query
+        name: grants_stealth_disadvantage
+        schema:
+          type: boolean
+      - in: query
+        name: strength_score_required
+        schema:
+          type: integer
+      - in: query
+        name: strength_score_required__lt
+        schema:
+          type: integer
+      - in: query
+        name: strength_score_required__lte
+        schema:
+          type: integer
+      - in: query
+        name: strength_score_required__gt
+        schema:
+          type: integer
+      - in: query
+        name: strength_score_required__gte
+        schema:
+          type: integer
+      - in: query
+        name: ac_base
+        schema:
+          type: integer
+      - in: query
+        name: ac_base__lt
+        schema:
+          type: integer
+      - in: query
+        name: ac_base__lte
+        schema:
+          type: integer
+      - in: query
+        name: ac_base__gt
+        schema:
+          type: integer
+      - in: query
+        name: ac_base__gte
+        schema:
+          type: integer
+      - in: query
+        name: ac_add_dexmod
+        schema:
+          type: boolean
+      - in: query
+        name: ac_cap_dexmod
+        schema:
+          type: integer
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - armor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedArmorList'
+          description: ''
+  /v2/armor/{key}/:
+    get:
+      operationId: armor_retrieve
+      description: |-
+        list: API endpoint for returning a list of armor.
+        retrieve: API endpoint for returning a particular armor.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - armor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Armor'
+          description: ''
+  /v2/gamesystems/:
+    get:
+      operationId: gamesystems_list
+      description: |-
+        "
+        list: API Endpoint for returning a set of gamesystems.
+
+        retrieve: API endpoint for return a particular gamesystem.
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - gamesystems
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedGameSystemList'
+          description: ''
+  /v2/gamesystems/{key}/:
+    get:
+      operationId: gamesystems_retrieve
+      description: |-
+        "
+        list: API Endpoint for returning a set of gamesystems.
+
+        retrieve: API endpoint for return a particular gamesystem.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the gamesystem the document was published for.
+        required: true
+      tags:
+      - gamesystems
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GameSystem'
+          description: ''
+  /v2/backgrounds/:
+    get:
+      operationId: backgrounds_list
+      description: |-
+        list: API endpoint for returning a list of backgrounds.
+        retrieve: API endpoint for returning a particular background.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - backgrounds
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedBackgroundList'
+          description: ''
+  /v2/backgrounds/{key}/:
+    get:
+      operationId: backgrounds_retrieve
+      description: |-
+        list: API endpoint for returning a list of backgrounds.
+        retrieve: API endpoint for returning a particular background.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - backgrounds
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Background'
+          description: ''
+  /v2/feats/:
+    get:
+      operationId: feats_list
+      description: |-
+        list: API endpoint for returning a list of feats.
+        retrieve: API endpoint for returning a particular feat.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - feats
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedFeatList'
+          description: ''
+  /v2/feats/{key}/:
+    get:
+      operationId: feats_retrieve
+      description: |-
+        list: API endpoint for returning a list of feats.
+        retrieve: API endpoint for returning a particular feat.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - feats
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Feat'
+          description: ''
+  /v2/species/:
+    get:
+      operationId: species_list
+      description: |-
+        list: API endpoint for returning a list of species.
+        retrieve: API endpoint for returning a particular species.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - in: query
+        name: subspecies_of__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: subspecies_of__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: subspecies_of__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: subspecies_of__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - species
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSpeciesList'
+          description: ''
+  /v2/species/{key}/:
+    get:
+      operationId: species_retrieve
+      description: |-
+        list: API endpoint for returning a list of species.
+        retrieve: API endpoint for returning a particular species.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - species
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Species'
+          description: ''
+  /v2/creatures/:
+    get:
+      operationId: creatures_list
+      description: |-
+        list: API endpoint for returning a list of creatures.
+        retrieve: API endpoint for returning a particular creature.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - in: query
+        name: size
+        schema:
+          type: string
+        description: Unique key for the Item.
+      - in: query
+        name: category
+        schema:
+          type: string
+      - in: query
+        name: category__iexact
+        schema:
+          type: string
+      - in: query
+        name: subcategory
+        schema:
+          type: string
+      - in: query
+        name: subcategory__iexact
+        schema:
+          type: string
+      - in: query
+        name: type
+        schema:
+          type: string
+        description: Unique key for the Item.
+      - in: query
+        name: challenge_rating
+        schema:
+          type: number
+          format: float
+      - in: query
+        name: challenge_rating__lt
+        schema:
+          type: number
+          format: float
+      - in: query
+        name: challenge_rating__lte
+        schema:
+          type: number
+          format: float
+      - in: query
+        name: challenge_rating__gt
+        schema:
+          type: number
+          format: float
+      - in: query
+        name: challenge_rating__gte
+        schema:
+          type: number
+          format: float
+      - in: query
+        name: armor_class
+        schema:
+          type: integer
+      - in: query
+        name: armor_class__lt
+        schema:
+          type: integer
+      - in: query
+        name: armor_class__lte
+        schema:
+          type: integer
+      - in: query
+        name: armor_class__gt
+        schema:
+          type: integer
+      - in: query
+        name: armor_class__gte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_strength
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_strength__lt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_strength__lte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_strength__gt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_strength__gte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_dexterity
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_dexterity__lt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_dexterity__lte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_dexterity__gt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_dexterity__gte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_constitution
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_constitution__lt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_constitution__lte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_constitution__gt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_constitution__gte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_intelligence
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_intelligence__lt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_intelligence__lte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_intelligence__gt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_intelligence__gte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_wisdom
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_wisdom__lt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_wisdom__lte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_wisdom__gt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_wisdom__gte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_charisma
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_charisma__lt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_charisma__lte
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_charisma__gt
+        schema:
+          type: integer
+      - in: query
+        name: ability_score_charisma__gte
+        schema:
+          type: integer
+      - in: query
+        name: saving_throw_strength__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: saving_throw_dexterity__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: saving_throw_constitution__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: saving_throw_intelligence__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: saving_throw_wisdom__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: saving_throw_charisma__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_acrobatics__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_animal_handling__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_arcana__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_athletics__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_deception__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_history__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_insight__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_intimidation__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_investigation__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_medicine__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_nature__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_perception__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_performance__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_persuasion__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_religion__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_sleight_of_hand__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_stealth__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: skill_bonus_survival__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: passive_perception
+        schema:
+          type: integer
+      - in: query
+        name: passive_perception__lt
+        schema:
+          type: integer
+      - in: query
+        name: passive_perception__lte
+        schema:
+          type: integer
+      - in: query
+        name: passive_perception__gt
+        schema:
+          type: integer
+      - in: query
+        name: passive_perception__gte
+        schema:
+          type: integer
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - creatures
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCreatureList'
+          description: ''
+  /v2/creatures/{key}/:
+    get:
+      operationId: creatures_retrieve
+      description: |-
+        list: API endpoint for returning a list of creatures.
+        retrieve: API endpoint for returning a particular creature.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - creatures
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Creature'
+          description: ''
+  /v2/creaturetypes/:
+    get:
+      operationId: creaturetypes_list
+      description: |-
+        list: API endpoint for returning a list of creatures types.
+        retrieve: API endpoint for returning a particular creature type.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - creaturetypes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCreatureTypeList'
+          description: ''
+  /v2/creaturetypes/{key}/:
+    get:
+      operationId: creaturetypes_retrieve
+      description: |-
+        list: API endpoint for returning a list of creatures types.
+        retrieve: API endpoint for returning a particular creature type.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - creaturetypes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatureType'
+          description: ''
+  /v2/creaturesets/:
+    get:
+      operationId: creaturesets_list
+      description: |-
+        list: API endpoint for returning a list of creature sets, which is similar to tags.
+        retrieve: API endpoint for returning a particular creature set.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - creaturesets
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCreatureSetList'
+          description: ''
+  /v2/creaturesets/{key}/:
+    get:
+      operationId: creaturesets_retrieve
+      description: |-
+        list: API endpoint for returning a list of creature sets, which is similar to tags.
+        retrieve: API endpoint for returning a particular creature set.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - creaturesets
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatureSet'
+          description: ''
+  /v2/damagetypes/:
+    get:
+      operationId: damagetypes_list
+      description: |-
+        list: API endpoint for returning a list of damage types.
+        retrieve: API endpoint for returning a particular damage type.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - damagetypes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedDamageTypeList'
+          description: ''
+  /v2/damagetypes/{key}/:
+    get:
+      operationId: damagetypes_retrieve
+      description: |-
+        list: API endpoint for returning a list of damage types.
+        retrieve: API endpoint for returning a particular damage type.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - damagetypes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DamageType'
+          description: ''
+  /v2/languages/:
+    get:
+      operationId: languages_list
+      description: |-
+        list: API endpoint for returning a list of feats.
+        retrieve: API endpoint for returning a particular feat.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - in: query
+        name: is_exotic
+        schema:
+          type: boolean
+      - in: query
+        name: is_secret
+        schema:
+          type: boolean
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - languages
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedLanguageList'
+          description: ''
+  /v2/languages/{key}/:
+    get:
+      operationId: languages_retrieve
+      description: |-
+        list: API endpoint for returning a list of feats.
+        retrieve: API endpoint for returning a particular feat.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - languages
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Language'
+          description: ''
+  /v2/alignments/:
+    get:
+      operationId: alignments_list
+      description: |-
+        list: API endpoint for returning a list of alignments.
+        retrieve: API endpoint for returning a particular alignment.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - alignments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAlignmentList'
+          description: ''
+  /v2/alignments/{key}/:
+    get:
+      operationId: alignments_retrieve
+      description: |-
+        list: API endpoint for returning a list of alignments.
+        retrieve: API endpoint for returning a particular alignment.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - alignments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Alignment'
+          description: ''
+  /v2/conditions/:
+    get:
+      operationId: conditions_list
+      description: |-
+        list: API endpoint for returning a list of conditions.
+        retrieve: API endpoint for returning a particular condition.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - conditions
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedConditionList'
+          description: ''
+  /v2/conditions/{key}/:
+    get:
+      operationId: conditions_retrieve
+      description: |-
+        list: API endpoint for returning a list of conditions.
+        retrieve: API endpoint for returning a particular condition.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - conditions
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Condition'
+          description: ''
+  /v2/spells/:
+    get:
+      operationId: spells_list
+      description: |-
+        list: API endpoint for returning a list of spells.
+        retrieve: API endpoint for returning a particular spell.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - in: query
+        name: classes__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: classes__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: classes__key
+        schema:
+          type: string
+      - in: query
+        name: classes__name__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: level
+        schema:
+          type: integer
+      - in: query
+        name: level__range
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: level__gt
+        schema:
+          type: integer
+      - in: query
+        name: level__gte
+        schema:
+          type: integer
+      - in: query
+        name: level__lt
+        schema:
+          type: integer
+      - in: query
+        name: level__lte
+        schema:
+          type: integer
+      - in: query
+        name: range
+        schema:
+          type: integer
+      - in: query
+        name: range__range
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: range__gt
+        schema:
+          type: integer
+      - in: query
+        name: range__gte
+        schema:
+          type: integer
+      - in: query
+        name: range__lt
+        schema:
+          type: integer
+      - in: query
+        name: range__lte
+        schema:
+          type: integer
+      - in: query
+        name: school__key
+        schema:
+          type: string
+      - in: query
+        name: school__name__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: school__name__iexact
+        schema:
+          type: string
+      - in: query
+        name: school__name
+        schema:
+          type: string
+      - in: query
+        name: duration__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: duration__iexact
+        schema:
+          type: string
+      - in: query
+        name: duration
+        schema:
+          type: string
+          x-spec-enum-id: 423a48fe5b2eed66
+          enum:
+          - 1 day
+          - 1 hour
+          - 1 hour or until triggered
+          - 1 hour/caster level
+          - 1 minute
+          - 1 minute
+          - 1 minute or 1 hour
+          - 1 minute, or until expended
+          - 1 minute, until expended
+          - 1 round
+          - 1 turn
+          - 1 year
+          - 10 days
+          - 10 hours
+          - 10 minutes
+          - 10 rounds
+          - 12 hours
+          - 13 days
+          - 1d10 hours
+          - 1d4+2 rounds
+          - 2 hours
+          - 2 rounds
+          - 2-12 hours
+          - 24 hours
+          - 24 hours or until the target attempts a third death saving throw
+          - 3 days
+          - 3 hours
+          - 3 rounds
+          - 30 days
+          - 4 rounds
+          - 5 days
+          - 5 minutes
+          - 5 rounds
+          - 6 hours
+          - 6 rounds
+          - 7 days
+          - 8 hours
+          - concentration + 1 round
+          - instantaneous
+          - instantaneous or special
+          - permanent
+          - permanent until discharged
+          - permanent; one generation
+          - special
+          - until cured or dispelled
+          - until destroyed
+          - until dispelled
+          - until dispelled or destroyed
+          - until dispelled or triggered
+          - up to 1 hour
+          - up to 1 minute
+          - up to 8 hours
+        description: |-
+          Description of the duration of the effect such as "instantaneous" or "1 minute"
+
+          * `instantaneous` - instantaneous
+          * `instantaneous or special` - instantaneous or special
+          * `1 turn` - 1 turn
+          * `1 round` - 1 round
+          * `concentration + 1 round` - concentration + 1 round
+          * `2 rounds` - 2 rounds
+          * `3 rounds` - 3 rounds
+          * `4 rounds` - 4 rounds
+          * `1d4+2 rounds` - 1d4+2 rounds
+          * `5 rounds` - 5 rounds
+          * `6 rounds` - 6 rounds
+          * `10 rounds` - 10 rounds
+          * `up to 1 minute` - up to 1 minute
+          * `1 minute` - 1 minute
+          * `1 minute, or until expended` - 1 minute, or until expended
+          * `1 minute, until expended` - 1 minute, until expended
+          * `1 minute` - 1 minute
+          * `5 minutes` - 5 minutes
+          * `10 minutes` - 10 minutes
+          * `1 minute or 1 hour` - 1 minute or 1 hour
+          * `up to 1 hour` - up to 1 hour
+          * `1 hour` - 1 hour
+          * `1 hour or until triggered` - 1 hour or until triggered
+          * `2 hours` - 2 hours
+          * `3 hours` - 3 hours
+          * `1d10 hours` - 1d10 hours
+          * `6 hours` - 6 hours
+          * `2-12 hours` - 2-12 hours
+          * `up to 8 hours` - up to 8 hours
+          * `8 hours` - 8 hours
+          * `1 hour/caster level` - 1 hour/caster level
+          * `10 hours` - 10 hours
+          * `12 hours` - 12 hours
+          * `24 hours or until the target attempts a third death saving throw` - 24 hours or until the target attempts a third death saving throw
+          * `24 hours` - 24 hours
+          * `1 day` - 1 day
+          * `3 days` - 3 days
+          * `5 days` - 5 days
+          * `7 days` - 7 days
+          * `10 days` - 10 days
+          * `13 days` - 13 days
+          * `30 days` - 30 days
+          * `1 year` - 1 year
+          * `special` - special
+          * `until dispelled or destroyed` - until dispelled or destroyed
+          * `until destroyed` - until destroyed
+          * `until dispelled` - until dispelled
+          * `until cured or dispelled` - until cured or dispelled
+          * `until dispelled or triggered` - until dispelled or triggered
+          * `permanent until discharged` - permanent until discharged
+          * `permanent; one generation` - permanent; one generation
+          * `permanent` - permanent
+      - in: query
+        name: concentration
+        schema:
+          type: boolean
+      - in: query
+        name: verbal
+        schema:
+          type: boolean
+      - in: query
+        name: somatic
+        schema:
+          type: boolean
+      - in: query
+        name: material
+        schema:
+          type: boolean
+      - in: query
+        name: material_consumed
+        schema:
+          type: boolean
+      - in: query
+        name: casting_time__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: casting_time__iexact
+        schema:
+          type: string
+      - in: query
+        name: casting_time
+        schema:
+          type: string
+          x-spec-enum-id: dc42ed916ae87f90
+          enum:
+          - 10minutes
+          - 12hours
+          - 1hour
+          - 1minute
+          - 1week
+          - 24hours
+          - 4hours
+          - 5minutes
+          - 7hours
+          - 8hours
+          - 9hours
+          - action
+          - bonus-action
+          - reaction
+          - round
+          - turn
+        description: |-
+          Casting time key, such as 'action'
+
+          * `reaction` - Reaction
+          * `bonus-action` - 1 Bonus Action
+          * `action` - 1 Action
+          * `turn` - 1 Turn
+          * `round` - 1 Round
+          * `1minute` - 1 Minute
+          * `5minutes` - 5 Minutes
+          * `10minutes` - 10 Minutes
+          * `1hour` - 1 Hour
+          * `4hours` - 4 Hours
+          * `7hours` - 7 Hours
+          * `8hours` - 8 Hours
+          * `9hours` - 9 Hours
+          * `12hours` - 12 Hours
+          * `24hours` - 24 Hours
+          * `1week` - 1 Week
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - spells
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSpellList'
+          description: ''
+  /v2/spells/{key}/:
+    get:
+      operationId: spells_retrieve
+      description: |-
+        list: API endpoint for returning a list of spells.
+        retrieve: API endpoint for returning a particular spell.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - spells
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Spell'
+          description: ''
+  /v2/spellschools/:
+    get:
+      operationId: spellschools_list
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - spellschools
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSpellSchoolList'
+          description: ''
+  /v2/spellschools/{key}/:
+    get:
+      operationId: spellschools_retrieve
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - spellschools
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpellSchool'
+          description: ''
+  /v2/classes/:
+    get:
+      operationId: classes_list
+      description: |-
+        list: API endpoint for returning a list of classes.
+        retrieve: API endpoint for returning a particular class.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - in: query
+        name: subclass_of
+        schema:
+          type: string
+        description: Unique key for the Item.
+      - in: query
+        name: is_subclass
+        schema:
+          type: boolean
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - classes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCharacterClassList'
+          description: ''
+  /v2/classes/{key}/:
+    get:
+      operationId: classes_retrieve
+      description: |-
+        list: API endpoint for returning a list of classes.
+        retrieve: API endpoint for returning a particular class.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - classes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CharacterClass'
+          description: ''
+  /v2/sizes/:
+    get:
+      operationId: sizes_list
+      description: |-
+        list: API endpoint for returning a list of damage types.
+        retrieve: API endpoint for returning a particular damage type.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - sizes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSizeList'
+          description: ''
+  /v2/sizes/{key}/:
+    get:
+      operationId: sizes_retrieve
+      description: |-
+        list: API endpoint for returning a list of damage types.
+        retrieve: API endpoint for returning a particular damage type.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - sizes
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Size'
+          description: ''
+  /v2/itemrarities/:
+    get:
+      operationId: itemrarities_list
+      description: |-
+        list: API endpoint for returning a list of item rarities.
+
+        retrieve: API endpoint for returning a particular item rarity.
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - itemrarities
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedItemRarityList'
+          description: ''
+  /v2/itemrarities/{key}/:
+    get:
+      operationId: itemrarities_retrieve
+      description: |-
+        list: API endpoint for returning a list of item rarities.
+
+        retrieve: API endpoint for returning a particular item rarity.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - itemrarities
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemRarity'
+          description: ''
+  /v2/environments/:
+    get:
+      operationId: environments_list
+      description: |-
+        list: API endpoint for returning a list of environments.
+        retrieve: API endpoint for returning a particular environment.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - environments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEnvironmentList'
+          description: ''
+  /v2/environments/{key}/:
+    get:
+      operationId: environments_retrieve
+      description: |-
+        list: API endpoint for returning a list of environments.
+        retrieve: API endpoint for returning a particular environment.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - environments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Environment'
+          description: ''
+  /v2/abilities/:
+    get:
+      operationId: abilities_list
+      description: |-
+        list: API endpoint for returning a list of abilities.
+        retrieve: API endpoint for returning a particular ability.
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - abilities
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAbilityList'
+          description: ''
+  /v2/abilities/{key}/:
+    get:
+      operationId: abilities_retrieve
+      description: |-
+        list: API endpoint for returning a list of abilities.
+        retrieve: API endpoint for returning a particular ability.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - abilities
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ability'
+          description: ''
+  /v2/skills/:
+    get:
+      operationId: skills_list
+      description: |-
+        list: API endpoint for returning a list of skills.
+        retrieve: API endpoint for returning a particular skill.
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - skills
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSkillList'
+          description: ''
+  /v2/skills/{key}/:
+    get:
+      operationId: skills_retrieve
+      description: |-
+        list: API endpoint for returning a list of skills.
+        retrieve: API endpoint for returning a particular skill.
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - skills
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Skill'
+          description: ''
+  /v2/rules/:
+    get:
+      operationId: rules_list
+      description: |-
+        This Mixin supports dynamically excluding returned fields of serializers that
+        inherit from it via the `?exclude` query parameter.
+
+        Syntactically similar to the default `?field` DRF query parameter. Nested
+        fields are similarly excluded via the '__' operator (see Examples).
+
+        ## Usage
+        1. Make sure your ViewSet inherits from `ExcludeFieldsMixin` before its base
+        class (ie. ReadOnlyModelViewSet).
+        2. Pass exclude params in the request query string to remove fields from the response.
+
+        # Exclude top-level fields
+        GET /v2/creatures/?exclude=traits,actions
+
+        # Exclude nested fields
+        GET /v2/creatures/?actions__exclude=attacks
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - rules
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRuleList'
+          description: ''
+  /v2/rules/{key}/:
+    get:
+      operationId: rules_retrieve
+      description: |-
+        This Mixin supports dynamically excluding returned fields of serializers that
+        inherit from it via the `?exclude` query parameter.
+
+        Syntactically similar to the default `?field` DRF query parameter. Nested
+        fields are similarly excluded via the '__' operator (see Examples).
+
+        ## Usage
+        1. Make sure your ViewSet inherits from `ExcludeFieldsMixin` before its base
+        class (ie. ReadOnlyModelViewSet).
+        2. Pass exclude params in the request query string to remove fields from the response.
+
+        # Exclude top-level fields
+        GET /v2/creatures/?exclude=traits,actions
+
+        # Exclude nested fields
+        GET /v2/creatures/?actions__exclude=attacks
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Document.
+        required: true
+      tags:
+      - rules
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Rule'
+          description: ''
+  /v2/rulesets/:
+    get:
+      operationId: rulesets_list
+      description: |-
+        Mixin to apply eager loading optimisations to a ViewSet.
+
+        Handles the running of `select_related()` (for ForeignKey fields) and
+        `prefetch_related()` (from ManyToMany/reverse relationships) queryset methods
+        to allow developers to solve N+1 problems on Open5e endpoints.
+
+        ## Usage
+        1. Make sure your ViewSet inherits from `EagerLoadingMixin` before its base
+        class (ie. ReadOnlyModelViewSet).
+        2. Re-define `select_related_fields` and `prefetch_related_fields` lists on
+        the child ViewSet to specify relationships to select related / pre-fetch.
+
+        ## Usage Example
+        ```
+          class CreatureViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
+            queryset = models.Creature.objects.all().order_by('pk')
+            serializer_class = serializers.CreatureSerializer
+            filterset_class = CreatureFilterSet
+            select_related_fields = []   # ForeignKey relations to optimise with select_related()
+            prefetch_related_fields = [] # ManyToMany/reverse relations to optimise with prefetch_related()
+        ```
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__contains
+        schema:
+          type: string
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - rulesets
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRuleSetList'
+          description: ''
+  /v2/rulesets/{key}/:
+    get:
+      operationId: rulesets_retrieve
+      description: |-
+        Mixin to apply eager loading optimisations to a ViewSet.
+
+        Handles the running of `select_related()` (for ForeignKey fields) and
+        `prefetch_related()` (from ManyToMany/reverse relationships) queryset methods
+        to allow developers to solve N+1 problems on Open5e endpoints.
+
+        ## Usage
+        1. Make sure your ViewSet inherits from `EagerLoadingMixin` before its base
+        class (ie. ReadOnlyModelViewSet).
+        2. Re-define `select_related_fields` and `prefetch_related_fields` lists on
+        the child ViewSet to specify relationships to select related / pre-fetch.
+
+        ## Usage Example
+        ```
+          class CreatureViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
+            queryset = models.Creature.objects.all().order_by('pk')
+            serializer_class = serializers.CreatureSerializer
+            filterset_class = CreatureFilterSet
+            select_related_fields = []   # ForeignKey relations to optimise with select_related()
+            prefetch_related_fields = [] # ManyToMany/reverse relations to optimise with prefetch_related()
+        ```
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Document.
+        required: true
+      tags:
+      - rulesets
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuleSet'
+          description: ''
+  /v2/images/:
+    get:
+      operationId: images_list
+      description: |-
+        This Mixin supports dynamically excluding returned fields of serializers that
+        inherit from it via the `?exclude` query parameter.
+
+        Syntactically similar to the default `?field` DRF query parameter. Nested
+        fields are similarly excluded via the '__' operator (see Examples).
+
+        ## Usage
+        1. Make sure your ViewSet inherits from `ExcludeFieldsMixin` before its base
+        class (ie. ReadOnlyModelViewSet).
+        2. Pass exclude params in the request query string to remove fields from the response.
+
+        # Exclude top-level fields
+        GET /v2/creatures/?exclude=traits,actions
+
+        # Exclude nested fields
+        GET /v2/creatures/?actions__exclude=attacks
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - images
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedImageList'
+          description: ''
+  /v2/images/{key}/:
+    get:
+      operationId: images_retrieve
+      description: |-
+        This Mixin supports dynamically excluding returned fields of serializers that
+        inherit from it via the `?exclude` query parameter.
+
+        Syntactically similar to the default `?field` DRF query parameter. Nested
+        fields are similarly excluded via the '__' operator (see Examples).
+
+        ## Usage
+        1. Make sure your ViewSet inherits from `ExcludeFieldsMixin` before its base
+        class (ie. ReadOnlyModelViewSet).
+        2. Pass exclude params in the request query string to remove fields from the response.
+
+        # Exclude top-level fields
+        GET /v2/creatures/?exclude=traits,actions
+
+        # Exclude nested fields
+        GET /v2/creatures/?actions__exclude=attacks
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - images
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Image'
+          description: ''
+  /v2/weaponproperties/:
+    get:
+      operationId: weaponproperties_list
+      description: |-
+        Mixin to apply eager loading optimisations to a ViewSet.
+
+        Handles the running of `select_related()` (for ForeignKey fields) and
+        `prefetch_related()` (from ManyToMany/reverse relationships) queryset methods
+        to allow developers to solve N+1 problems on Open5e endpoints.
+
+        ## Usage
+        1. Make sure your ViewSet inherits from `EagerLoadingMixin` before its base
+        class (ie. ReadOnlyModelViewSet).
+        2. Re-define `select_related_fields` and `prefetch_related_fields` lists on
+        the child ViewSet to specify relationships to select related / pre-fetch.
+
+        ## Usage Example
+        ```
+          class CreatureViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
+            queryset = models.Creature.objects.all().order_by('pk')
+            serializer_class = serializers.CreatureSerializer
+            filterset_class = CreatureFilterSet
+            select_related_fields = []   # ForeignKey relations to optimise with select_related()
+            prefetch_related_fields = [] # ManyToMany/reverse relations to optimise with prefetch_related()
+        ```
+      parameters:
+      - in: query
+        name: key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: key__iexact
+        schema:
+          type: string
+      - in: query
+        name: key
+        schema:
+          type: string
+      - in: query
+        name: name__iexact
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: name__icontains
+        schema:
+          type: string
+      - in: query
+        name: type
+        schema:
+          type: string
+      - in: query
+        name: type__isnull
+        schema:
+          type: boolean
+      - in: query
+        name: document__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__key
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key__in
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: document__gamesystem__key__iexact
+        schema:
+          type: string
+      - in: query
+        name: document__gamesystem__key
+        schema:
+          type: string
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - weaponproperties
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedWeaponPropertyList'
+          description: ''
+  /v2/weaponproperties/{key}/:
+    get:
+      operationId: weaponproperties_retrieve
+      description: |-
+        Mixin to apply eager loading optimisations to a ViewSet.
+
+        Handles the running of `select_related()` (for ForeignKey fields) and
+        `prefetch_related()` (from ManyToMany/reverse relationships) queryset methods
+        to allow developers to solve N+1 problems on Open5e endpoints.
+
+        ## Usage
+        1. Make sure your ViewSet inherits from `EagerLoadingMixin` before its base
+        class (ie. ReadOnlyModelViewSet).
+        2. Re-define `select_related_fields` and `prefetch_related_fields` lists on
+        the child ViewSet to specify relationships to select related / pre-fetch.
+
+        ## Usage Example
+        ```
+          class CreatureViewSet(EagerLoadingMixin, viewsets.ReadOnlyModelViewSet):
+            queryset = models.Creature.objects.all().order_by('pk')
+            serializer_class = serializers.CreatureSerializer
+            filterset_class = CreatureFilterSet
+            select_related_fields = []   # ForeignKey relations to optimise with select_related()
+            prefetch_related_fields = [] # ManyToMany/reverse relations to optimise with prefetch_related()
+        ```
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - weaponproperties
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeaponProperty'
+          description: ''
+  /v2/services/:
+    get:
+      operationId: services_list
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - services
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedServiceList'
+          description: ''
+  /v2/services/{key}/:
+    get:
+      operationId: services_retrieve
+      parameters:
+      - in: path
+        name: key
+        schema:
+          type: string
+          description: Unique key for the Item.
+        required: true
+      tags:
+      - services
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: ''
+  /v2/enums/:
+    get:
+      operationId: enums_list
+      description: API endpoint for enums.
+      tags:
+      - enums
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: string
+          description: ''
+  /v2/search/:
+    get:
+      operationId: search_list
+      description: "\n        Search across all Open5e content and objects.\n\n        If
+        multiple search types are requested, the results are first sorted, then merged
+        & deduplicated in order of decreasing precision:\n        - Exact matches(name
+        first, then other fields)\n        - Fuzzy matches (similarity, descending)\n
+        \       - Vector matches (similarity, descending)\n\n        "
+      summary: Search across D&D 5E content
+      parameters:
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: query
+        schema:
+          type: string
+        description: The search term to find. Required parameter.
+        required: true
+        examples:
+          ExistingTerm:
+            value: fireball
+            summary: Existing term
+          TypoExample:
+            value: firbal
+            summary: Typo example
+          Multi-word:
+            value: magic weapon
+      - in: query
+        name: strict
+        schema:
+          type: boolean
+        description: 'Strict mode: only return explicitly requested search types.
+          When false (default), exact search always runs with fuzzy fallback if no
+          results found.'
+        examples:
+          StrictMode:
+            value: 'true'
+            summary: Strict mode
+          DefaultMode:
+            value: 'false'
+            summary: Default mode
+      - in: query
+        name: fuzzy
+        schema:
+          type: boolean
+        description: 'Include fuzzy individual word matches in name fields only. Default:
+          false (but used as fallback in default mode).'
+        examples:
+          EnableFuzzyMatching:
+            value: 'true'
+            summary: Enable fuzzy matching
+          DisableFuzzyMatching:
+            value: 'false'
+            summary: Disable fuzzy matching
+      - in: query
+        name: vector
+        schema:
+          type: boolean
+        description: 'Include vector search results against name + description. Finds
+          semantically similar content using TF-IDF similarity. Default: false.'
+        examples:
+          EnableVector:
+            value: 'true'
+            summary: Enable vector
+          DisableVector:
+            value: 'false'
+            summary: Disable vector
+      - in: query
+        name: object_model
+        schema:
+          type: string
+        description: 'Filter results to specific content type. Default: all types.'
+        examples:
+          SpellsOnly:
+            value: Spell
+            summary: Spells only
+          CreaturesOnly:
+            value: Creature
+            summary: Creatures only
+          ItemsOnly:
+            value: Item
+            summary: Items only
+          AllTypes:
+            value: '%'
+            summary: All types
+      - in: query
+        name: document_pk
+        schema:
+          type: string
+        description: 'Filter results to specific document. Use document key/slug.
+          Default: all documents.'
+        examples:
+          SRDOnly:
+            value: srd-2014
+            summary: SRD only
+          AllDocuments:
+            value: '%'
+            summary: All documents
+      - in: query
+        name: schema
+        schema:
+          type: string
+        description: 'API schema version to search. Default: ''v2''.'
+        examples:
+          APIV2:
+            value: v2
+            summary: API v2
+          APIV1:
+            value: v1
+            summary: API v1
+      tags:
+      - search
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSearchResultList'
+              examples:
+                DefaultSearch:
+                  value:
+                    count: 123
+                    next: http://api.example.org/accounts/?page=4
+                    previous: http://api.example.org/accounts/?page=2
+                    results:
+                    - query: fireball
+                  summary: Basic search with exact + fuzzy fallback
+                  description: Searches for 'fireball' using exact text search, with
+                    fuzzy fallback if no exact matches
+                FuzzySearchForTypo:
+                  value:
+                    count: 123
+                    next: http://api.example.org/accounts/?page=4
+                    previous: http://api.example.org/accounts/?page=2
+                    results:
+                    - query: firbal
+                      fuzzy: 'true'
+                  summary: Explicit fuzzy search for handling typos
+                  description: Searches for 'firbal' using fuzzy search to handle
+                    the typo and find 'fireball'
+                VectorSemanticSearch:
+                  value:
+                    count: 123
+                    next: http://api.example.org/accounts/?page=4
+                    previous: http://api.example.org/accounts/?page=2
+                    results:
+                    - query: healing
+                      vector: 'true'
+                  summary: Add semantic similarity search
+                  description: Finds exact matches for 'healing' and content semantically
+                    similar to 'healing' using vector search
+                StrictMode-VectorOnly:
+                  value:
+                    count: 123
+                    next: http://api.example.org/accounts/?page=4
+                    previous: http://api.example.org/accounts/?page=2
+                    results:
+                    - query: fire
+                      strict: 'true'
+                      vector: 'true'
+                  summary: 'Strict mode: vector only search'
+                  description: Returns only vector matches for 'fire' eg. 'heat',
+                    'flame', 'scorching'
+                CombinedSearchModes:
+                  value:
+                    count: 123
+                    next: http://api.example.org/accounts/?page=4
+                    previous: http://api.example.org/accounts/?page=2
+                    results:
+                    - query: magic
+                      fuzzy: 'true'
+                      vector: 'true'
+                  summary: Multiple search types combined
+                  description: Combines exact, fuzzy, and vector search for comprehensive
+                    results
+                FilteredSearch:
+                  value:
+                    count: 123
+                    next: http://api.example.org/accounts/?page=4
+                    previous: http://api.example.org/accounts/?page=2
+                    results:
+                    - query: dragon
+                      object_model: Creature
+                  summary: Search filtered to specific content type
+                  description: Search for dragons but only in creature content
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+                description: Unspecified response body
+          description: ''
+  /v2/search/{id}/:
+    get:
+      operationId: search_retrieve
+      description: Unified search across exact text, fuzzy, and vector search methods.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this search result.
+        required: true
+      tags:
+      - search
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResult'
+          description: ''
+components:
+  schemas:
+    Ability:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilityDescription'
+        skills:
+          type: array
+          items:
+            $ref: '#/components/schemas/Skill'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        short_desc:
+          type: string
+          description: Short description of the ability.
+          maxLength: 100
+        document:
+          type: string
+          description: Unique key for the Document.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - descriptions
+      - document
+      - key
+      - name
+      - short_desc
+      - skills
+    AbilityDescription:
+      type: object
+      properties:
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        gamesystem:
+          type: string
+          readOnly: true
+      required:
+      - document
+      - gamesystem
+    AbilitySummary:
+      type: object
+      description: |-
+        A slimmer AbilitySerializer, designed to serialize Ability FKs on other
+        serializers. ie. The `saving_throws` field on CharacterClassSerializer. Not
+        intended to be used directly with in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+      required:
+      - name
+    Alignment:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        morality:
+          type: string
+          readOnly: true
+        societal_attitude:
+          type: string
+          readOnly: true
+        short_name:
+          type: string
+          readOnly: true
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AlignmentDescription'
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - descriptions
+      - document
+      - key
+      - morality
+      - short_name
+      - societal_attitude
+    AlignmentDescription:
+      type: object
+      properties:
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        gamesystem:
+          type: string
+          readOnly: true
+      required:
+      - document
+      - gamesystem
+    Armor:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        ac_display:
+          type: string
+          description: Display text for armor class.
+          readOnly: true
+        category:
+          type: string
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        grants_stealth_disadvantage:
+          type: boolean
+          description: If the armor results in disadvantage on stealth checks.
+        strength_score_required:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+          description: Strength score required to wear the armor without penalty.
+        ac_base:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          description: Integer representing the armor class without modifiers.
+        ac_add_dexmod:
+          type: boolean
+          description: If the final armor class includes dexterity modifier.
+        ac_cap_dexmod:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+          description: Integer representing the dexterity modifier cap.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - ac_base
+      - ac_display
+      - category
+      - crossreferences
+      - document
+      - key
+      - name
+    ArmorSummary:
+      type: object
+      description: |-
+        A slightly slimmer ArmorSerializer, designed to serialize Armor FKs on
+        other serializers. ie. The `armor` field on the ItemSerializer. Not
+        intended to be used directly in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+        category:
+          type: string
+          readOnly: true
+        ac_base:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          description: Integer representing the armor class without modifiers.
+        ac_display:
+          type: string
+          description: Display text for armor class.
+          readOnly: true
+        ac_add_dexmod:
+          type: boolean
+          description: If the final armor class includes dexterity modifier.
+        ac_cap_dexmod:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+          description: Integer representing the dexterity modifier cap.
+        grants_stealth_disadvantage:
+          type: boolean
+          description: If the armor results in disadvantage on stealth checks.
+        strength_score_required:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+          description: Strength score required to wear the armor without penalty.
+      required:
+      - ac_base
+      - ac_display
+      - category
+      - key
+      - name
+    Background:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        benefits:
+          type: array
+          items:
+            $ref: '#/components/schemas/BackgroundBenefit'
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - benefits
+      - crossreferences
+      - document
+      - key
+      - name
+    BackgroundBenefit:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        type:
+          enum:
+          - ability_score
+          - skill_proficiency
+          - tool_proficiency
+          - language
+          - equipment
+          - feature
+          - feat
+          - suggested_characteristics
+          - adventures_and_advancement
+          - connection_and_memento
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: 7747984849b6a5da
+          nullable: true
+          description: |-
+            Modification type.
+
+            * `ability_score` - Ability Score Increase or Decrease
+            * `skill_proficiency` - Skill Proficiency
+            * `tool_proficiency` - Tool Proficiency
+            * `language` - Language
+            * `equipment` - Equipment
+            * `feature` - Feature
+            * `feat` - Feat
+            * `suggested_characteristics` - Suggested Characteristics
+            * `adventures_and_advancement` - Adventures and Advancement
+            * `connection_and_memento` - Connection and Memento
+      required:
+      - name
+    CharacterClass:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClassFeature'
+          readOnly: true
+        hit_points:
+          allOf:
+          - $ref: '#/components/schemas/hit_points'
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        saving_throws:
+          type: array
+          items:
+            $ref: '#/components/schemas/AbilitySummary'
+        subclass_of:
+          $ref: '#/components/schemas/CharacterClassSummary'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        hit_dice:
+          enum:
+          - D4
+          - D6
+          - D8
+          - D10
+          - D12
+          - D20
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: bae7780c5a3b2e5c
+          nullable: true
+          description: |-
+            Dice notation hit dice option.
+
+            * `D4` - d4
+            * `D6` - d6
+            * `D8` - d8
+            * `D10` - d10
+            * `D12` - d12
+            * `D20` - d20
+        caster_type:
+          enum:
+          - FULL
+          - HALF
+          - NONE
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: fbfa5cfded934145
+          nullable: true
+          description: |-
+            Type of caster. Options are full, half, none.
+
+            * `FULL` - Full
+            * `HALF` - Half
+            * `NONE` - None
+        primary_abilities:
+          type: array
+          items:
+            type: string
+          description: Primary abilities for thie class
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - features
+      - hit_points
+      - key
+      - name
+      - primary_abilities
+      - saving_throws
+      - subclass_of
+    CharacterClassSummary:
+      type: object
+      description: |-
+        A slimmer CharacterClassSerializer, designed to serialize Class FKs on
+        other serializers. ie. The `subclass_of` field on the
+        CharacterClassSerializer serializer. Not intended to be used directly in a
+        ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+      required:
+      - key
+      - name
+    ClassFeature:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        feature_type:
+          enum:
+          - CORE_TRAITS_TABLE
+          - CLASS_LEVEL_FEATURE
+          - CLASS_FEATURE_OPTION_LIST
+          - CLASS_TABLE_DATA
+          - PROFICIENCIES
+          - PROFICIENCY_BONUS
+          - STARTING_EQUIPMENT
+          - SPELL_SLOTS
+          type: string
+          x-spec-enum-id: b61e497ab02b41bf
+          description: |-
+            The type that best represents this Class Feature
+
+            * `CORE_TRAITS_TABLE` - CORE_TRAITS_TABLE
+            * `CLASS_LEVEL_FEATURE` - CLASS_LEVEL_FEATURE
+            * `CLASS_FEATURE_OPTION_LIST` - CLASS_FEATURE_OPTION_LIST
+            * `CLASS_TABLE_DATA` - CLASS_TABLE_DATA
+            * `PROFICIENCIES` - PROFICIENCIES
+            * `PROFICIENCY_BONUS` - PROFICIENCY_BONUS
+            * `STARTING_EQUIPMENT` - STARTING_EQUIPMENT
+            * `SPELL_SLOTS` - SPELL_SLOTS
+        feature_items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClassFeaturePrefetch'
+          readOnly: true
+      required:
+      - feature_items
+      - key
+      - name
+    ClassFeaturePrefetch:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        level:
+          type: integer
+          maximum: 20
+          minimum: 0
+        detail:
+          type: string
+          nullable: true
+          maxLength: 100
+        column_value:
+          type: string
+          nullable: true
+          description: The value that should be displayed in the table column (where
+            applicable).
+          maxLength: 20
+      required:
+      - level
+    Condition:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        icon:
+          $ref: '#/components/schemas/ImageSummary'
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConditionDescription'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - descriptions
+      - document
+      - icon
+      - key
+      - name
+    ConditionDescription:
+      type: object
+      properties:
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        gamesystem:
+          type: string
+          readOnly: true
+      required:
+      - document
+      - gamesystem
+    ConditionSummary:
+      type: object
+      description: |-
+        A slimmer ConditionSerializer, designed to serialize Condition FKs on
+        other serializers. ie. The `condition_immunities` field on the Creature
+        serializer. Not intended to be used directly with in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+      required:
+      - key
+      - name
+    Creature:
+      type: object
+      description: The serializer for the Creature object.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        type:
+          $ref: '#/components/schemas/CreatureTypeSummary'
+        size:
+          $ref: '#/components/schemas/SizeSummary'
+        challenge_rating:
+          type: number
+          format: double
+          maximum: 30
+          minimum: 0
+          description: Challenge Rating field as a decimal number.
+        proficiency_bonus:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+          description: The Creauture's Proficiency Bonus
+        speed:
+          allOf:
+          - $ref: '#/components/schemas/speed'
+          readOnly: true
+        speed_all:
+          allOf:
+          - $ref: '#/components/schemas/speed_all'
+          readOnly: true
+        category:
+          type: string
+          description: What category this creature belongs to.
+          maxLength: 100
+        subcategory:
+          type: string
+          nullable: true
+          description: What subcategory this creature belongs to.
+          maxLength: 100
+        alignment:
+          type: string
+          description: The creature's allowed alignments.
+          maxLength: 100
+        languages:
+          $ref: '#/components/schemas/CreatureLanguage'
+        armor_class:
+          type: integer
+          maximum: 100
+          minimum: 0
+          description: Integer representing the armor class of the object.
+        armor_detail:
+          type: string
+          nullable: true
+          description: Represents parathetical text that follows an objects AC
+          maxLength: 64
+        hit_points:
+          type: integer
+          maximum: 10000
+          minimum: 0
+          description: Integer representing the hit points of the object.
+        hit_dice:
+          type: string
+          nullable: true
+          description: Dice string representing a way to calculate hit points.
+        experience_points:
+          type: integer
+          readOnly: true
+        ability_scores:
+          allOf:
+          - $ref: '#/components/schemas/ability_scores'
+          readOnly: true
+        modifiers:
+          allOf:
+          - $ref: '#/components/schemas/ability_modifiers'
+          readOnly: true
+        initiative_bonus:
+          type: integer
+          readOnly: true
+        saving_throws:
+          allOf:
+          - $ref: '#/components/schemas/saving_throws'
+          readOnly: true
+        saving_throws_all:
+          allOf:
+          - $ref: '#/components/schemas/saving_throws_all'
+          readOnly: true
+        skill_bonuses:
+          allOf:
+          - $ref: '#/components/schemas/skill_bonuses'
+          readOnly: true
+        skill_bonuses_all:
+          allOf:
+          - $ref: '#/components/schemas/skill_bonuses_all'
+          readOnly: true
+        passive_perception:
+          type: integer
+          maximum: 40
+          minimum: 0
+          description: Integer representing the passive perception ability.
+        resistances_and_immunities:
+          $ref: '#/components/schemas/CreatureResistancesAndImmunities'
+        normal_sight_range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        darkvision_range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        blindsight_range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        tremorsense_range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        truesight_range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreatureAction'
+        traits:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreatureTrait'
+          readOnly: true
+        creaturesets:
+          type: array
+          items:
+            type: string
+            description: Unique key for the Item.
+        environments:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnvironmentSummary'
+        illustration:
+          $ref: '#/components/schemas/ImageSummary'
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - ability_scores
+      - actions
+      - alignment
+      - category
+      - challenge_rating
+      - creaturesets
+      - crossreferences
+      - document
+      - environments
+      - experience_points
+      - illustration
+      - initiative_bonus
+      - key
+      - languages
+      - modifiers
+      - name
+      - resistances_and_immunities
+      - saving_throws
+      - saving_throws_all
+      - size
+      - skill_bonuses
+      - skill_bonuses_all
+      - speed
+      - speed_all
+      - traits
+      - type
+    CreatureAction:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        attacks:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreatureActionAttack'
+          readOnly: true
+        action_type:
+          enum:
+          - ACTION
+          - REACTION
+          - BONUS_ACTION
+          - LEGENDARY_ACTION
+          - LAIR_ACTION
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: 6a4d09c1d9077429
+          nullable: true
+          description: |-
+            The type of action used.
+
+            * `ACTION` - Action
+            * `REACTION` - Reaction
+            * `BONUS_ACTION` - Bonus Action
+            * `LEGENDARY_ACTION` - Legendary Action
+            * `LAIR_ACTION` - Lair Action
+        order_in_statblock:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+          description: The position in the list of features that a feature appears
+            in its source statblock
+        legendary_action_cost:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+          description: null if not legendary, else, the number of legendary actions
+            this costs.
+        limited_to_form:
+          type: string
+          nullable: true
+          description: Description of form-based conditions for this action.
+          maxLength: 100
+        usage_limits:
+          type: object
+          additionalProperties: {}
+          readOnly: true
+      required:
+      - attacks
+      - name
+      - usage_limits
+    CreatureActionAttack:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        attack_type:
+          enum:
+          - SPELL
+          - WEAPON
+          type: string
+          x-spec-enum-id: bdba17d813adb52a
+          description: |-
+            Whether this is a Weapon or Spell attack.
+
+            * `SPELL` - Spell
+            * `WEAPON` - Weapon
+        to_hit_mod:
+          type: integer
+          maximum: 20
+          minimum: -5
+          description: Attack roll modifier.
+        reach:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        long_range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        target_creature_only:
+          type: boolean
+          description: If an attack can target creatures only and not objects.
+        damage_die_count:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: The number of dice to roll for damage.
+        damage_die_type:
+          enum:
+          - D4
+          - D6
+          - D8
+          - D10
+          - D12
+          - D20
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: bae7780c5a3b2e5c
+          nullable: true
+          description: |-
+            What kind of die to roll for damage.
+
+            * `D4` - d4
+            * `D6` - d6
+            * `D8` - d8
+            * `D10` - d10
+            * `D12` - d12
+            * `D20` - d20
+        damage_bonus:
+          type: integer
+          maximum: 20
+          minimum: -5
+          nullable: true
+          description: Damage roll modifier.
+        damage_type:
+          $ref: '#/components/schemas/DamageTypeSummary'
+        extra_damage_die_count:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: The number of dice to roll for damage.
+        extra_damage_die_type:
+          enum:
+          - D4
+          - D6
+          - D8
+          - D10
+          - D12
+          - D20
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: bae7780c5a3b2e5c
+          nullable: true
+          description: |-
+            What kind of die to roll for damage.
+
+            * `D4` - d4
+            * `D6` - d6
+            * `D8` - d8
+            * `D10` - d10
+            * `D12` - d12
+            * `D20` - d20
+        extra_damage_bonus:
+          type: integer
+          maximum: 20
+          minimum: -5
+          nullable: true
+          description: Damage roll modifier.
+        extra_damage_type:
+          $ref: '#/components/schemas/DamageTypeSummary'
+        distance_unit:
+          type: string
+          readOnly: true
+      required:
+      - attack_type
+      - damage_type
+      - distance_unit
+      - extra_damage_type
+      - name
+      - target_creature_only
+      - to_hit_mod
+    CreatureLanguage:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        as_string:
+          type: string
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/LanguageSummary'
+      required:
+      - as_string
+      - data
+    CreatureResistancesAndImmunities:
+      type: object
+      description: This serializer formats a Creature's damage modifier as a single
+        obj
+      properties:
+        damage_immunities_display:
+          type: string
+        damage_immunities:
+          type: array
+          items:
+            $ref: '#/components/schemas/DamageTypeSummary'
+        damage_resistances_display:
+          type: string
+        damage_resistances:
+          type: array
+          items:
+            $ref: '#/components/schemas/DamageTypeSummary'
+        damage_vulnerabilities_display:
+          type: string
+        damage_vulnerabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/DamageTypeSummary'
+        condition_immunities_display:
+          type: string
+        condition_immunities:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConditionSummary'
+      required:
+      - condition_immunities
+      - condition_immunities_display
+      - damage_immunities
+      - damage_immunities_display
+      - damage_resistances
+      - damage_resistances_display
+      - damage_vulnerabilities
+      - damage_vulnerabilities_display
+    CreatureSet:
+      type: object
+      description: Serializer for the Creature Set object
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        creatures:
+          type: array
+          items:
+            $ref: '#/components/schemas/Creature'
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        document:
+          type: string
+          description: Unique key for the Document.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - creatures
+      - crossreferences
+      - document
+      - key
+      - name
+    CreatureTrait:
+      type: object
+      description: Serializer for the Creature Trait object
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+      required:
+      - name
+    CreatureType:
+      type: object
+      description: Serializer for the Creature Type object
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreatureTypeDescription'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        document:
+          type: string
+          description: Unique key for the Document.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - descriptions
+      - document
+      - key
+      - name
+    CreatureTypeDescription:
+      type: object
+      properties:
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        gamesystem:
+          type: string
+          readOnly: true
+      required:
+      - document
+      - gamesystem
+    CreatureTypeSummary:
+      type: object
+      description: |-
+        A slimmer CreatureTypeSerializer, designed to serialize CreatureType FKs on
+        other serializers . Not intended to be used directly with in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+      required:
+      - key
+      - name
+    CrossReferences:
+      type: object
+      properties:
+        to:
+          type: array
+          items:
+            $ref: '#/components/schemas/_CrossReferenceLink'
+      required:
+      - to
+    DamageType:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/DamageTypeDescription'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        document:
+          type: string
+          description: Unique key for the Document.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - descriptions
+      - document
+      - key
+      - name
+    DamageTypeDescription:
+      type: object
+      properties:
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        gamesystem:
+          type: string
+          readOnly: true
+      required:
+      - document
+      - gamesystem
+    DamageTypeSummary:
+      type: object
+      description: |-
+        A slimmer DamageTypeSerializer, designed to serialize DamageType FKs on
+        other serializers. Not intended to be used directly with in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+      required:
+      - key
+      - name
+    Document:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Document.
+          readOnly: true
+        licenses:
+          type: array
+          items:
+            $ref: '#/components/schemas/LicenseSummary'
+          readOnly: true
+        publisher:
+          allOf:
+          - $ref: '#/components/schemas/PublisherSummary'
+          readOnly: true
+        gamesystem:
+          allOf:
+          - $ref: '#/components/schemas/GameSystemSummary'
+          readOnly: true
+        display_name:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        type:
+          enum:
+          - SOURCE
+          - MISC
+          type: string
+          x-spec-enum-id: 995afaa0b151df94
+          description: |-
+            Whether this Document is a published data source, or general resources
+
+            * `SOURCE` - Source
+            * `MISC` - Miscellaneous
+        author:
+          type: string
+          description: Author or authors.
+        publication_date:
+          type: string
+          format: date-time
+          description: Date of publication, or null if unknown.
+        permalink:
+          type: string
+          format: uri
+          description: Link to the document.
+          maxLength: 200
+        distance_unit:
+          enum:
+          - feet
+          - miles
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: 6eaa2f2d15b5e114
+          nullable: true
+          description: |-
+            What distance unit the relevant field uses.
+
+            * `feet` - feet
+            * `miles` - miles
+        weight_unit:
+          enum:
+          - feet
+          - miles
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: 6eaa2f2d15b5e114
+          nullable: true
+          description: |-
+            What distance unit the relevant field uses.
+
+            * `feet` - feet
+            * `miles` - miles
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - author
+      - crossreferences
+      - display_name
+      - gamesystem
+      - key
+      - licenses
+      - name
+      - permalink
+      - publication_date
+      - publisher
+    DocumentSummary:
+      type: object
+      description: |-
+        A slimmer DocumentSerializer, designed to serialize Documents FKs on other
+        serializers. Not intended to be used directly with in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Document.
+          maxLength: 100
+        type:
+          enum:
+          - SOURCE
+          - MISC
+          type: string
+          x-spec-enum-id: 995afaa0b151df94
+          description: |-
+            Whether this Document is a published data source, or general resources
+
+            * `SOURCE` - Source
+            * `MISC` - Miscellaneous
+        display_name:
+          type: string
+          readOnly: true
+        publisher:
+          $ref: '#/components/schemas/PublisherSummary'
+        gamesystem:
+          $ref: '#/components/schemas/GameSystemSummary'
+        permalink:
+          type: string
+          format: uri
+          description: Link to the document.
+          maxLength: 200
+      required:
+      - display_name
+      - gamesystem
+      - key
+      - name
+      - permalink
+      - publisher
+    Environment:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        aquatic:
+          type: boolean
+          description: Whether or not aquatic environment rules apply to this environment.
+        planar:
+          type: boolean
+          description: Whether or not this environment is a plane of existence.
+        interior:
+          type: boolean
+          description: Whether or not this environment is an interior space.
+        document:
+          type: string
+          description: Unique key for the Document.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - key
+      - name
+    EnvironmentSummary:
+      type: object
+      description: |-
+        A slimmer EnvironmentSerializer, designed to serialize Enviroment FKs on
+        other serializers. ie. The `environments` field on the CreatureSerializer.
+        Not intended to be used directly in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+      required:
+      - key
+      - name
+    Feat:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        has_prerequisite:
+          type: boolean
+          readOnly: true
+        benefits:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatBenefit'
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        prerequisite:
+          type: string
+          description: Prerequisite for the game content item.
+          maxLength: 200
+        type:
+          enum:
+          - GENERAL
+          - ORIGIN
+          - FIGHTING_STYLE
+          - EPIC_BOON
+          type: string
+          description: |-
+            * `GENERAL` - General
+            * `ORIGIN` - Origin
+            * `FIGHTING_STYLE` - Fighting Style
+            * `EPIC_BOON` - Epic Boon
+          x-spec-enum-id: f93c9c3e2d64eab8
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - benefits
+      - crossreferences
+      - document
+      - has_prerequisite
+      - key
+      - name
+    FeatBenefit:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+    GameSystem:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the gamesystem the document was published for.
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        content_prefix:
+          type: string
+          description: Short code prepended to content keys.
+          maxLength: 10
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - key
+      - name
+    GameSystemSummary:
+      type: object
+      description: |-
+        A slimmer GameSystemSerializer, designed to serialize GameSystem FKs on
+        other serializers. Not intended to be used directly with in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the gamesystem the document was published for.
+          maxLength: 100
+      required:
+      - key
+      - name
+    Image:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        file_url:
+          type: string
+          description: Returns a relative path to the related file.
+          readOnly: true
+        alt_text:
+          type: string
+          description: A short textual description of the image. Important for accessibility
+        attribution:
+          type: string
+          description: Attribution information for this image. Who drew it and where
+            we can find more of thier work?
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - alt_text
+      - attribution
+      - crossreferences
+      - document
+      - file_url
+      - key
+      - name
+    ImageSummary:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+        file_url:
+          type: string
+          description: Returns a relative path to the related file.
+          readOnly: true
+        alt_text:
+          type: string
+          description: A short textual description of the image. Important for accessibility
+        attribution:
+          type: string
+          description: Attribution information for this image. Who drew it and where
+            we can find more of thier work?
+      required:
+      - alt_text
+      - attribution
+      - file_url
+      - key
+      - name
+    Item:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        category:
+          $ref: '#/components/schemas/ItemCategorySummary'
+        weapon:
+          $ref: '#/components/schemas/WeaponSummary'
+        armor:
+          $ref: '#/components/schemas/ArmorSummary'
+        size:
+          $ref: '#/components/schemas/SizeSummary'
+        weight:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,7}(?:\.\d{0,3})?$
+          description: Number representing the weight of the object.
+        weight_unit:
+          type: string
+          readOnly: true
+        cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Number representing the cost of the object.
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - armor
+      - category
+      - crossreferences
+      - document
+      - key
+      - name
+      - size
+      - weapon
+      - weight_unit
+    ItemCategory:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - key
+      - name
+    ItemCategorySummary:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+      required:
+      - key
+      - name
+    ItemRarity:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+        rank:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          description: Ranking of the rarity, most common has the lowest values.
+      required:
+      - key
+      - name
+      - rank
+    ItemSet:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemSummary'
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - items
+      - key
+      - name
+    ItemSummary:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+        url:
+          type: string
+          format: uri
+          readOnly: true
+      required:
+      - key
+      - name
+      - url
+    Language:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        is_exotic:
+          type: boolean
+          description: Whether or not the language is exotic.
+        is_secret:
+          type: boolean
+          description: Whether or not the language is secret.
+        script_language:
+          type: string
+          description: Unique key for the Item.
+          nullable: true
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - key
+      - name
+    LanguageSummary:
+      type: object
+      description: |-
+        This serializer is used for FKs to the Language model from other
+        serializers. ie. for the languages spoken by creatures on the
+        CreatureSerializer.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+      required:
+      - key
+      - name
+    License:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the License.
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - key
+      - name
+    LicenseSummary:
+      type: object
+      description: |-
+        A slimmer LicenseSerializer, designed to serialize License FKs on other
+        serializers. Not intended to be used directly with in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the License.
+          maxLength: 100
+      required:
+      - key
+      - name
+    MagicItem:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        category:
+          $ref: '#/components/schemas/ItemCategorySummary'
+        rarity:
+          $ref: '#/components/schemas/ItemRarity'
+        is_magic_item:
+          type: string
+          readOnly: true
+        weapon:
+          $ref: '#/components/schemas/WeaponSummary'
+        armor:
+          $ref: '#/components/schemas/ArmorSummary'
+        size:
+          $ref: '#/components/schemas/SizeSummary'
+        weight:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,7}(?:\.\d{0,3})?$
+          description: Number representing the weight of the object.
+        weight_unit:
+          type: string
+          readOnly: true
+        cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Number representing the cost of the object.
+        requires_attunement:
+          type: boolean
+          description: If the item requires attunement.
+        attunement_detail:
+          type: string
+          nullable: true
+          maxLength: 128
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - armor
+      - category
+      - crossreferences
+      - document
+      - is_magic_item
+      - key
+      - name
+      - rarity
+      - size
+      - weapon
+      - weight_unit
+    PaginatedAbilityList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Ability'
+    PaginatedAlignmentList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Alignment'
+    PaginatedArmorList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Armor'
+    PaginatedBackgroundList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Background'
+    PaginatedCharacterClassList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterClass'
+    PaginatedConditionList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Condition'
+    PaginatedCreatureList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Creature'
+    PaginatedCreatureSetList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreatureSet'
+    PaginatedCreatureTypeList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreatureType'
+    PaginatedDamageTypeList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/DamageType'
+    PaginatedDocumentList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+    PaginatedEnvironmentList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Environment'
+    PaginatedFeatList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Feat'
+    PaginatedGameSystemList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/GameSystem'
+    PaginatedImageList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Image'
+    PaginatedItemCategoryList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemCategory'
+    PaginatedItemList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Item'
+    PaginatedItemRarityList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemRarity'
+    PaginatedItemSetList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemSet'
+    PaginatedLanguageList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Language'
+    PaginatedLicenseList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/License'
+    PaginatedMagicItemList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MagicItem'
+    PaginatedPublisherList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Publisher'
+    PaginatedRuleList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rule'
+    PaginatedRuleSetList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuleSet'
+    PaginatedSearchResultList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchResult'
+    PaginatedServiceList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Service'
+    PaginatedSizeList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Size'
+    PaginatedSkillList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Skill'
+    PaginatedSpeciesList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Species'
+    PaginatedSpellList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Spell'
+    PaginatedSpellSchoolList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpellSchool'
+    PaginatedWeaponList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Weapon'
+    PaginatedWeaponPropertyList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/WeaponProperty'
+    Publisher:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the publishing organization.
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - key
+      - name
+    PublisherSummary:
+      type: object
+      description: |-
+        A slimmer PublisherSerializer, designed to serialize Publisher FKs on other
+        serializers. Not intended to be used directly with in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the publishing organization.
+          maxLength: 100
+      required:
+      - key
+      - name
+    Rule:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Document.
+          maxLength: 100
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        index:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          description: A rule's position in the list of rules of the parent RuleSet
+        initialHeaderLevel:
+          enum:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          type: integer
+          x-spec-enum-id: b417a677fcd86df4
+          description: |-
+            The header level to set rule title to
+
+            * `1` - 1
+            * `2` - 2
+            * `3` - 3
+            * `4` - 4
+            * `5` - 5
+          minimum: -9223372036854775808
+          maximum: 9223372036854775807
+        document:
+          type: string
+          description: Unique key for the Document.
+        ruleset:
+          type: string
+          description: The RuleSet which this Rule belongs to
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - key
+      - name
+      - ruleset
+    RuleSet:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Document.
+          maxLength: 100
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rule'
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - key
+      - name
+      - rules
+    SearchResult:
+      type: object
+      description: |-
+        This method builds the search result object structure.
+        It does a lookup based on primary keys stored in the search table.
+      properties:
+        document:
+          allOf:
+          - $ref: '#/components/schemas/search_document'
+          readOnly: true
+        object_pk:
+          type: string
+          maxLength: 255
+        object_name:
+          type: string
+          maxLength: 100
+        object:
+          oneOf:
+          - $ref: '#/components/schemas/Item'
+          - $ref: '#/components/schemas/Creature'
+          - $ref: '#/components/schemas/Spell'
+          - $ref: '#/components/schemas/CharacterClass'
+          - $ref: '#/components/schemas/Race'
+        object_model:
+          type: string
+          maxLength: 255
+        schema_version:
+          type: string
+          maxLength: 100
+        route:
+          type: string
+          description: Route is a way to build the link to the object.
+          readOnly: true
+        text:
+          type: string
+          nullable: true
+        highlighted:
+          type: string
+          nullable: true
+        match_type:
+          type: string
+          readOnly: true
+        matched_term:
+          type: string
+          readOnly: true
+          nullable: true
+        match_score:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+      required:
+      - document
+      - match_score
+      - match_type
+      - matched_term
+      - object
+      - object_model
+      - object_name
+      - object_pk
+      - route
+      - schema_version
+    Service:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Number representing the cost of the object.
+        detail:
+          type: string
+          nullable: true
+          description: Additional contextual infomation about the service. ie. For
+            'Squalid Living' the detail would be '1 day'
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - key
+      - name
+    Size:
+      type: object
+      description: Serializer for the Size type
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        distance_unit:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        rank:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          description: Ranking of the size, smallest has the lowest values.
+        space_diameter:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        suggested_hit_dice:
+          enum:
+          - D4
+          - D6
+          - D8
+          - D10
+          - D12
+          - D20
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: bae7780c5a3b2e5c
+          nullable: true
+          description: |-
+            What kind of die to roll for damage.
+
+            * `D4` - d4
+            * `D6` - d6
+            * `D8` - d8
+            * `D10` - d10
+            * `D12` - d12
+            * `D20` - d20
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - distance_unit
+      - document
+      - key
+      - name
+      - rank
+    SizeSummary:
+      type: object
+      description: |-
+        A slimmer SizeSerializer, designed to serialize Size FKs on other
+        serializers. ie. The `size` field on the CreatureSerializer. Not intended
+        to be used directly in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+      required:
+      - key
+      - name
+    Skill:
+      type: object
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+        descriptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkillDescription'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        document:
+          type: string
+          description: Unique key for the Document.
+        ability:
+          type: string
+          description: The ability referenced by this skill.
+      required:
+      - ability
+      - descriptions
+      - document
+      - key
+      - name
+    SkillDescription:
+      type: object
+      properties:
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        gamesystem:
+          type: string
+          readOnly: true
+      required:
+      - document
+      - gamesystem
+    Species:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        is_subspecies:
+          type: boolean
+          description: Returns whether the object is a subspecies.
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        traits:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpeciesTrait'
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        subspecies_of:
+          type: string
+          description: Unique key for the Item.
+          nullable: true
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - is_subspecies
+      - key
+      - name
+      - traits
+    SpeciesTrait:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        type:
+          enum:
+          - ABILITY_MODS
+          - SIZE
+          - SPEED
+          - ''
+          - null
+          type: string
+          description: |-
+            * `ABILITY_MODS` - ABILITY_MODS
+            * `SIZE` - SIZE
+            * `SPEED` - SPEED
+          x-spec-enum-id: 899d2f35ae918829
+          nullable: true
+        order:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: -9223372036854775808
+          format: int64
+          nullable: true
+          description: The position in the list of features that a feature appears
+            in its source statblock
+      required:
+      - name
+    Spell:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        casting_options:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpellCastingOption'
+        school:
+          $ref: '#/components/schemas/SpellSchoolSummary'
+        classes:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterClassSummary'
+        range_unit:
+          type: string
+          readOnly: true
+        shape_size_unit:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        level:
+          type: integer
+          maximum: 9
+          minimum: 0
+          description: Integer representing the default slot level required by the
+            spell.
+        higher_level:
+          type: string
+          description: Description of casting the spell at a different level.
+        target_type:
+          enum:
+          - creature
+          - object
+          - point
+          - area
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: 571010a8aa19b0e0
+          nullable: true
+          description: |-
+            Spell target type key.
+
+            * `creature` - Creature
+            * `object` - Object
+            * `point` - Point
+            * `area` - Area
+        range_text:
+          enum:
+          - Self
+          - Touch
+          - Special
+          - 5 feet
+          - 10 feet
+          - 15 feet
+          - 20 feet
+          - 25 feet
+          - 30 feet
+          - 40 feet
+          - 50 feet
+          - 60 feet
+          - 90 feet
+          - 100 feet
+          - 120 feet
+          - 150 feet
+          - 180 feet
+          - 200 feet
+          - 300 feet
+          - 400 feet
+          - 500 feet
+          - 1000 feet
+          - Sight
+          - 1 mile
+          - 5 miles
+          - 10 miles
+          - 100 miles
+          - 150 miles
+          - 500 miles
+          - Unlimited
+          type: string
+          x-spec-enum-id: 1da9ca7f84a405b9
+          description: |-
+            Spell target range.
+
+            * `Self` - Self
+            * `Touch` - Touch
+            * `Special` - Special
+            * `5 feet` - 5 feet
+            * `10 feet` - 10 feet
+            * `15 feet` - 15 feet
+            * `20 feet` - 20 feet
+            * `25 feet` - 25 feet
+            * `30 feet` - 30 feet
+            * `40 feet` - 40 feet
+            * `50 feet` - 50 feet
+            * `60 feet` - 60 feet
+            * `90 feet` - 90 feet
+            * `100 feet` - 100 feet
+            * `120 feet` - 120 feet
+            * `150 feet` - 150 feet
+            * `180 feet` - 180 feet
+            * `200 feet` - 200 feet
+            * `300 feet` - 300 feet
+            * `400 feet` - 400 feet
+            * `500 feet` - 500 feet
+            * `1000 feet` - 1000 feet
+            * `Sight` - Sight
+            * `1 mile` - 1 mile
+            * `5 miles` - 5 miles
+            * `10 miles` - 10 miles
+            * `100 miles` - 100 miles
+            * `150 miles` - 150 miles
+            * `500 miles` - 500 miles
+            * `Unlimited` - Unlimited
+        range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        ritual:
+          type: boolean
+          description: Whether or not the spell can be cast as a ritual.
+        casting_time:
+          enum:
+          - reaction
+          - bonus-action
+          - action
+          - turn
+          - round
+          - 1minute
+          - 5minutes
+          - 10minutes
+          - 1hour
+          - 4hours
+          - 7hours
+          - 8hours
+          - 9hours
+          - 12hours
+          - 24hours
+          - 1week
+          type: string
+          x-spec-enum-id: dc42ed916ae87f90
+          description: |-
+            Casting time key, such as 'action'
+
+            * `reaction` - Reaction
+            * `bonus-action` - 1 Bonus Action
+            * `action` - 1 Action
+            * `turn` - 1 Turn
+            * `round` - 1 Round
+            * `1minute` - 1 Minute
+            * `5minutes` - 5 Minutes
+            * `10minutes` - 10 Minutes
+            * `1hour` - 1 Hour
+            * `4hours` - 4 Hours
+            * `7hours` - 7 Hours
+            * `8hours` - 8 Hours
+            * `9hours` - 9 Hours
+            * `12hours` - 12 Hours
+            * `24hours` - 24 Hours
+            * `1week` - 1 Week
+        reaction_condition:
+          type: string
+          nullable: true
+          description: The conditions describing when a reaction spell can be cast
+        verbal:
+          type: boolean
+          description: Whether or not casting the spell requires a verbal component.
+        somatic:
+          type: boolean
+          description: Whether or not casting the spell requires a verbal component.
+        material:
+          type: boolean
+          description: Whether or not casting the spell requires a verbal component.
+        material_specified:
+          type: string
+          description: Description of the material specified for the spell.
+        material_cost:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+          nullable: true
+          description: Number representing the cost of the materials of the spell.
+        material_consumed:
+          type: boolean
+          description: Whether or the material component is consumed during the casting.
+        target_count:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Integer representing the count of targets.
+        saving_throw_ability:
+          type: string
+          description: Given the spell requires a saving throw, which ability is targeted.
+            Empty string if no saving throw.
+        attack_roll:
+          type: boolean
+          description: Whether or not the spell effect requires an attack roll.
+        damage_roll:
+          type: string
+          description: The damage roll for the field in dice notation. Empty string
+            if no roll.
+        damage_types:
+          description: The types of damage done by the spell in a list.
+        duration:
+          enum:
+          - instantaneous
+          - instantaneous or special
+          - 1 turn
+          - 1 round
+          - concentration + 1 round
+          - 2 rounds
+          - 3 rounds
+          - 4 rounds
+          - 1d4+2 rounds
+          - 5 rounds
+          - 6 rounds
+          - 10 rounds
+          - up to 1 minute
+          - 1 minute
+          - 1 minute, or until expended
+          - 1 minute, until expended
+          - 5 minutes
+          - 10 minutes
+          - 1 minute or 1 hour
+          - up to 1 hour
+          - 1 hour
+          - 1 hour or until triggered
+          - 2 hours
+          - 3 hours
+          - 1d10 hours
+          - 6 hours
+          - 2-12 hours
+          - up to 8 hours
+          - 8 hours
+          - 1 hour/caster level
+          - 10 hours
+          - 12 hours
+          - 24 hours or until the target attempts a third death saving throw
+          - 24 hours
+          - 1 day
+          - 3 days
+          - 5 days
+          - 7 days
+          - 10 days
+          - 13 days
+          - 30 days
+          - 1 year
+          - special
+          - until dispelled or destroyed
+          - until destroyed
+          - until dispelled
+          - until cured or dispelled
+          - until dispelled or triggered
+          - permanent until discharged
+          - permanent; one generation
+          - permanent
+          type: string
+          x-spec-enum-id: 423a48fe5b2eed66
+          description: |-
+            Description of the duration of the effect such as "instantaneous" or "1 minute"
+
+            * `instantaneous` - instantaneous
+            * `instantaneous or special` - instantaneous or special
+            * `1 turn` - 1 turn
+            * `1 round` - 1 round
+            * `concentration + 1 round` - concentration + 1 round
+            * `2 rounds` - 2 rounds
+            * `3 rounds` - 3 rounds
+            * `4 rounds` - 4 rounds
+            * `1d4+2 rounds` - 1d4+2 rounds
+            * `5 rounds` - 5 rounds
+            * `6 rounds` - 6 rounds
+            * `10 rounds` - 10 rounds
+            * `up to 1 minute` - up to 1 minute
+            * `1 minute` - 1 minute
+            * `1 minute, or until expended` - 1 minute, or until expended
+            * `1 minute, until expended` - 1 minute, until expended
+            * `5 minutes` - 5 minutes
+            * `10 minutes` - 10 minutes
+            * `1 minute or 1 hour` - 1 minute or 1 hour
+            * `up to 1 hour` - up to 1 hour
+            * `1 hour` - 1 hour
+            * `1 hour or until triggered` - 1 hour or until triggered
+            * `2 hours` - 2 hours
+            * `3 hours` - 3 hours
+            * `1d10 hours` - 1d10 hours
+            * `6 hours` - 6 hours
+            * `2-12 hours` - 2-12 hours
+            * `up to 8 hours` - up to 8 hours
+            * `8 hours` - 8 hours
+            * `1 hour/caster level` - 1 hour/caster level
+            * `10 hours` - 10 hours
+            * `12 hours` - 12 hours
+            * `24 hours or until the target attempts a third death saving throw` - 24 hours or until the target attempts a third death saving throw
+            * `24 hours` - 24 hours
+            * `1 day` - 1 day
+            * `3 days` - 3 days
+            * `5 days` - 5 days
+            * `7 days` - 7 days
+            * `10 days` - 10 days
+            * `13 days` - 13 days
+            * `30 days` - 30 days
+            * `1 year` - 1 year
+            * `special` - special
+            * `until dispelled or destroyed` - until dispelled or destroyed
+            * `until destroyed` - until destroyed
+            * `until dispelled` - until dispelled
+            * `until cured or dispelled` - until cured or dispelled
+            * `until dispelled or triggered` - until dispelled or triggered
+            * `permanent until discharged` - permanent until discharged
+            * `permanent; one generation` - permanent; one generation
+            * `permanent` - permanent
+        shape_type:
+          enum:
+          - cone
+          - cube
+          - cylinder
+          - line
+          - sphere
+          - ''
+          - null
+          type: string
+          x-spec-enum-id: a59b0a38f2674303
+          nullable: true
+          description: |-
+            The shape of the area of effect.
+
+            * `cone` - Cone
+            * `cube` - Cube
+            * `cylinder` - Cylinder
+            * `line` - Line
+            * `sphere` - sphere
+        shape_size:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        concentration:
+          type: boolean
+          description: Whether the effect requires concentration to be maintained.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - casting_options
+      - casting_time
+      - classes
+      - crossreferences
+      - document
+      - duration
+      - key
+      - level
+      - name
+      - range_text
+      - range_unit
+      - school
+      - shape_size_unit
+    SpellCastingOption:
+      type: object
+      properties:
+        type:
+          enum:
+          - default
+          - ritual
+          - player_level_1
+          - player_level_2
+          - player_level_3
+          - player_level_4
+          - player_level_5
+          - player_level_6
+          - player_level_7
+          - player_level_8
+          - player_level_9
+          - player_level_10
+          - player_level_11
+          - player_level_12
+          - player_level_13
+          - player_level_14
+          - player_level_15
+          - player_level_16
+          - player_level_17
+          - player_level_18
+          - player_level_19
+          - player_level_20
+          - slot_level_1
+          - slot_level_2
+          - slot_level_3
+          - slot_level_4
+          - slot_level_5
+          - slot_level_6
+          - slot_level_7
+          - slot_level_8
+          - slot_level_9
+          type: string
+          description: |-
+            * `default` - Default
+            * `ritual` - Ritual
+            * `player_level_1` - Player Level 1
+            * `player_level_2` - Player Level 2
+            * `player_level_3` - Player Level 3
+            * `player_level_4` - Player Level 4
+            * `player_level_5` - Player Level 5
+            * `player_level_6` - Player Level 6
+            * `player_level_7` - Player Level 7
+            * `player_level_8` - Player Level 8
+            * `player_level_9` - Player Level 9
+            * `player_level_10` - Player Level 10
+            * `player_level_11` - Player Level 11
+            * `player_level_12` - Player Level 12
+            * `player_level_13` - Player Level 13
+            * `player_level_14` - Player Level 14
+            * `player_level_15` - Player Level 15
+            * `player_level_16` - Player Level 16
+            * `player_level_17` - Player Level 17
+            * `player_level_18` - Player Level 18
+            * `player_level_19` - Player Level 19
+            * `player_level_20` - Player Level 20
+            * `slot_level_1` - Spell Slot Level 1
+            * `slot_level_2` - Spell SlotLevel 2
+            * `slot_level_3` - Spell Slot Level 3
+            * `slot_level_4` - Spell Slot Level 4
+            * `slot_level_5` - Spell Slot Level 5
+            * `slot_level_6` - Spell Slot Level 6
+            * `slot_level_7` - Spell Slot Level 7
+            * `slot_level_8` - Spell Slot Level 8
+            * `slot_level_9` - Spell Slot Level 9
+          x-spec-enum-id: 710c2d36661f4916
+        damage_roll:
+          type: string
+          nullable: true
+          description: The damage roll for the field in dice notation. Empty string
+            if no roll.
+        target_count:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Integer representing the count of targets.
+        duration:
+          type: string
+          nullable: true
+          description: Description of the duration of the effect such as "instantaneous"
+            or "Up to 1 minute"
+        range:
+          type: string
+          nullable: true
+          description: Description of the range of the spell.
+        concentration:
+          type: boolean
+          nullable: true
+          description: Whether the effect requires concentration to be maintained.
+        shape_size:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        desc:
+          type: string
+          nullable: true
+          description: Description of complex casting option effects that cannot be
+            captured in other fields.
+      required:
+      - type
+    SpellSchool:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - key
+      - name
+    SpellSchoolSummary:
+      type: object
+      description: |-
+        A slimmer SpellSchoolSerializer, designed to serialize Spell School FKs on
+        other serializers. ie. The `school` field on the SpellSerializer. Not
+        intended to be used directly in a ModelViewset.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+      required:
+      - key
+      - name
+    Weapon:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          readOnly: true
+        document:
+          $ref: '#/components/schemas/DocumentSummary'
+        properties:
+          type: string
+          readOnly: true
+        damage_type:
+          $ref: '#/components/schemas/DamageTypeSummary'
+        ranged_attack_possible:
+          type: string
+          readOnly: true
+        range_melee:
+          type: string
+          readOnly: true
+        distance_unit:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        damage_dice:
+          type: string
+          description: The damage dice when used making an attack.
+          maxLength: 100
+        range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        long_range:
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+          nullable: true
+          description: Used to measure distance.
+        is_simple:
+          type: boolean
+          description: If the weapon category is simple.
+        is_improvised:
+          type: boolean
+          description: If the weapon is improvised.
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - damage_dice
+      - damage_type
+      - distance_unit
+      - document
+      - key
+      - name
+      - properties
+      - range_melee
+      - ranged_attack_possible
+    WeaponProperty:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+        document:
+          type: string
+          description: Unique key for the Document.
+        type:
+          type: string
+          nullable: true
+          description: 'Weapon property type: ie. Weapon Mastery, etc.'
+          maxLength: 32
+        crossreferences:
+          allOf:
+          - $ref: '#/components/schemas/CrossReferences'
+          readOnly: true
+      required:
+      - crossreferences
+      - document
+      - key
+      - name
+    WeaponPropertyAssignment:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        property:
+          $ref: '#/components/schemas/WeaponPropertySummary'
+        detail:
+          type: string
+          nullable: true
+          maxLength: 32
+      required:
+      - property
+    WeaponPropertySummary:
+      type: object
+      description: |-
+        Much of the logic included in the GameContentSerializer is intended to
+        support manipulating data returned by the serializer via query parameters.
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        type:
+          type: string
+          nullable: true
+          description: 'Weapon property type: ie. Weapon Mastery, etc.'
+          maxLength: 32
+        desc:
+          type: string
+          description: Description of the game content item. Markdown.
+      required:
+      - name
+    WeaponSummary:
+      type: object
+      description: |-
+        A (slightly) more slender version of the WeaponSerializer. Designed for
+        serializing FKs to the Weapons table in other serializers – ie. the
+        `"weapon"` field on the ItemSerializer
+      properties:
+        name:
+          type: string
+          description: Name of the item.
+          maxLength: 100
+        key:
+          type: string
+          description: Unique key for the Item.
+          maxLength: 100
+        damage_type:
+          $ref: '#/components/schemas/DamageTypeSummary'
+        damage_dice:
+          type: string
+          description: The damage dice when used making an attack.
+          maxLength: 100
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/WeaponPropertyAssignment'
+          readOnly: true
+        is_melee:
+          type: string
+          readOnly: true
+        is_simple:
+          type: boolean
+          description: If the weapon category is simple.
+        is_martial:
+          type: boolean
+          readOnly: true
+        is_improvised:
+          type: boolean
+          description: If the weapon is improvised.
+        distance_unit:
+          type: string
+          readOnly: true
+      required:
+      - damage_dice
+      - damage_type
+      - distance_unit
+      - is_martial
+      - is_melee
+      - key
+      - name
+      - properties
+    _CrossReferenceLink:
+      type: object
+      description: One link in crossreferences.to; defines API shape and serialization.
+      properties:
+        anchor:
+          type: string
+        url:
+          type: string
+          format: uri
+      required:
+      - anchor
+      - url
+    ability_modifiers:
+      type: object
+      properties:
+        strength:
+          type: integer
+        dexterity:
+          type: integer
+        constitution:
+          type: integer
+        intelligence:
+          type: integer
+        wisdom:
+          type: integer
+        charisma:
+          type: integer
+      required:
+      - charisma
+      - constitution
+      - dexterity
+      - intelligence
+      - strength
+      - wisdom
+    ability_scores:
+      type: object
+      properties:
+        strength:
+          type: integer
+        dexterity:
+          type: integer
+        constitution:
+          type: integer
+        intelligence:
+          type: integer
+        wisdom:
+          type: integer
+        charisma:
+          type: integer
+      required:
+      - charisma
+      - constitution
+      - dexterity
+      - intelligence
+      - strength
+      - wisdom
+    hit_points:
+      type: object
+      properties:
+        hit_dice:
+          type: integer
+        hit_dice_name:
+          type: string
+          readOnly: true
+        hit_points_at_1st_level:
+          type: integer
+        hit_points_at_higher_levels:
+          type: integer
+      required:
+      - hit_dice
+      - hit_dice_name
+      - hit_points_at_1st_level
+      - hit_points_at_higher_levels
+    saving_throws:
+      type: object
+      properties:
+        strength:
+          type: integer
+        dexterity:
+          type: integer
+        constitution:
+          type: integer
+        intelligence:
+          type: integer
+        wisdom:
+          type: integer
+        charisma:
+          type: integer
+      required:
+      - charisma
+      - constitution
+      - dexterity
+      - intelligence
+      - strength
+      - wisdom
+    saving_throws_all:
+      type: object
+      properties:
+        strength:
+          type: integer
+        dexterity:
+          type: integer
+        constitution:
+          type: integer
+        intelligence:
+          type: integer
+        wisdom:
+          type: integer
+        charisma:
+          type: integer
+      required:
+      - charisma
+      - constitution
+      - dexterity
+      - intelligence
+      - strength
+      - wisdom
+    search_document:
+      type: object
+      properties:
+        key:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+      required:
+      - key
+      - name
+    skill_bonuses:
+      type: object
+      properties:
+        acrobatics:
+          type: integer
+        animal_handling:
+          type: integer
+        arcana:
+          type: integer
+        athletics:
+          type: integer
+        deception:
+          type: integer
+        history:
+          type: integer
+        insight:
+          type: integer
+        intimidation:
+          type: integer
+        investigation:
+          type: integer
+        medicine:
+          type: integer
+        nature:
+          type: integer
+        perception:
+          type: integer
+        performance:
+          type: integer
+        persuasion:
+          type: integer
+        religion:
+          type: integer
+        sleight_of_hand:
+          type: integer
+        stealth:
+          type: integer
+        survival:
+          type: integer
+      required:
+      - acrobatics
+      - animal_handling
+      - arcana
+      - athletics
+      - deception
+      - history
+      - insight
+      - intimidation
+      - investigation
+      - medicine
+      - nature
+      - perception
+      - performance
+      - persuasion
+      - religion
+      - sleight_of_hand
+      - stealth
+      - survival
+    skill_bonuses_all:
+      type: object
+      properties:
+        acrobatics:
+          type: integer
+        animal_handling:
+          type: integer
+        arcana:
+          type: integer
+        athletics:
+          type: integer
+        deception:
+          type: integer
+        history:
+          type: integer
+        insight:
+          type: integer
+        intimidation:
+          type: integer
+        investigation:
+          type: integer
+        medicine:
+          type: integer
+        nature:
+          type: integer
+        perception:
+          type: integer
+        performance:
+          type: integer
+        persuasion:
+          type: integer
+        religion:
+          type: integer
+        sleight_of_hand:
+          type: integer
+        stealth:
+          type: integer
+        survival:
+          type: integer
+      required:
+      - acrobatics
+      - animal_handling
+      - arcana
+      - athletics
+      - deception
+      - history
+      - insight
+      - intimidation
+      - investigation
+      - medicine
+      - nature
+      - perception
+      - performance
+      - persuasion
+      - religion
+      - sleight_of_hand
+      - stealth
+      - survival
+    speed:
+      type: object
+      properties:
+        walk:
+          type: string
+          readOnly: true
+        fly:
+          type: string
+          readOnly: true
+        swim:
+          type: string
+          readOnly: true
+        climb:
+          type: string
+          readOnly: true
+        burrow:
+          type: string
+          readOnly: true
+        hover:
+          type: boolean
+      required:
+      - burrow
+      - climb
+      - fly
+      - hover
+      - swim
+      - walk
+    speed_all:
+      type: object
+      properties:
+        unit:
+          type: string
+          readOnly: true
+        walk:
+          type: integer
+        crawl:
+          type: integer
+        hover:
+          type: boolean
+        fly:
+          type: integer
+          nullable: true
+        burrow:
+          type: integer
+          nullable: true
+        climb:
+          type: integer
+          nullable: true
+        swim:
+          type: integer
+          nullable: true
+      required:
+      - burrow
+      - climb
+      - crawl
+      - fly
+      - hover
+      - swim
+      - unit
+      - walk
+servers:
+- url: https://api.open5e.com
+  description: Production server
+- url: https://api-beta.open5e.com
+  description: Beta server
+- url: http://localhost:8000
+  description: Localhost


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/open5e/open5e-api/issues/950

### Description (What does it do?)

This PR implements the proposal in LINK_TO_ISSUE. The OpenAPI spec is committed, and its freshness is guarded by:
1. A CI check (`openapi-spec-freshness.yml`) that genereates the spec itself and diffs with the committed version. An out-of-date spec fails the check.
2. Adds `openapi-schema.yml text eol=lf merge=binary` in order to:
    - eol=lf normalizes line endings across platforms, important for the CI check;
    - merge=binary prevents textual merging. If `pr-branch` has modified the spec, and base branch has modified the spec, too, then there will be a conflict. `pr-branch` must regenerate.

### How can this be tested?

I've opened a few PRs against this branch on my own fork. You can see the CI check failing/passing there:
- https://github.com/ChristopherChudzicki/open5e-api/pull/1 This PR has two commits:
    1. First commit changes a `drf-spectacular` decorator, but does NOT regenerate the spec => CI check fails.
    2. Second commit regenerates the spec => CI check passes. 
- https://github.com/ChristopherChudzicki/open5e-api/pull/4 This PR just shows a spec bugfix, and how it's a lot easier to see how the drf-spectacular change affects the spec.