### PR TITLE
[BUGFIX] Resolved N+1 problem on `v2/creatures`

### DIFF
--- a/api_v2/views/creature.py
+++ b/api_v2/views/creature.py
@@ -70,6 +70,7 @@ class CreatureViewSet(EagerLoadingMixin, ExcludeFieldsMixin, viewsets.ReadOnlyMo
         'actions__attacks__damage_type',
         'actions__attacks__extra_damage_type',
         'creaturesets',
+        'crossreferences',
         'condition_immunities',
         'condition_immunities__icon',
         'damage_immunities',


### PR DESCRIPTION
## Description
This PR fixes a bug on the `/creatures` endpoint where the `crossreferences` field was showing classic signs on an N+1 error. The `crossreferences` table was being queried once per entry returned, so 50 times per page of 50 results. This was fixed by adding `crossreferences` to the fields to prefetch in the `EagerLoadingMixin`

## Related Issue
Closes #954