### PR TITLE
[DX] Added `django-debug-toolbar` as a dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "pytest-django",
     "approvaltests",
     "pytest-approvaltests",
+    "django-debug-toolbar>=6.3.0",
 ]
 
 [tool.uv]

--- a/server/settings.py
+++ b/server/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
+import sys
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -91,6 +92,11 @@ MIDDLEWARE = [
     "server.middleware.NewRelicMiddleware",
     "server.middleware.ResponseWarningHeaderMiddleware"
 ]
+
+if DEBUG:
+    INSTALLED_APPS = [*INSTALLED_APPS, "debug_toolbar"]
+    MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware", *MIDDLEWARE]
+
 
 ROOT_URLCONF = "server.urls"
 
@@ -250,3 +256,9 @@ SPECTACULAR_SETTINGS = {
         'tagsSorter': None,        
     }
 }
+
+INTERNAL_IPS = [
+    # ...
+    "127.0.0.1",
+    # ...
+]

--- a/server/urls.py
+++ b/server/urls.py
@@ -14,7 +14,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.conf.urls import include
 from django.urls import path
 from django.contrib import admin
 from django.conf import settings
@@ -37,3 +36,5 @@ urlpatterns+=[
 
 if settings.DEBUG is True:
     urlpatterns.append(path('admin/', admin.site.urls))
+    from debug_toolbar.toolbar import debug_toolbar_urls
+    urlpatterns += debug_toolbar_urls()

--- a/uv.lock
+++ b/uv.lock
@@ -142,6 +142,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-debug-toolbar"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "sqlparse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/ea/b62673424dd72d2dbf5adf4145281a421d5792f47380d9bc8e3b11e1a769/django_debug_toolbar-6.3.0.tar.gz", hash = "sha256:f830a86fe02e17f625a22cfbed24a5bd1500762e201ec959c50efb0f9327282b", size = 334079, upload-time = "2026-04-02T16:07:01.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9e/d8c3c845f4b5ccac7377c19f4049e7e00c6f121846a81f69a497b45734df/django_debug_toolbar-6.3.0-py3-none-any.whl", hash = "sha256:a199ce3d0f884739a9096835ad417479fede05f3b3c4824bc8b354721ba8f629", size = 298304, upload-time = "2026-04-02T16:06:59.617Z" },
+]
+
+[[package]]
 name = "django-filter"
 version = "25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -355,6 +368,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "approvaltests" },
+    { name = "django-debug-toolbar" },
     { name = "pytest" },
     { name = "pytest-approvaltests" },
     { name = "pytest-django" },
@@ -379,6 +393,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "approvaltests" },
+    { name = "django-debug-toolbar", specifier = ">=6.3.0" },
     { name = "pytest" },
     { name = "pytest-approvaltests" },
     { name = "pytest-django" },


### PR DESCRIPTION
## Description

This PR adds the Django Debug Toolbar to our list of development dependencies. This package has been extremely helpful in identifying N+1 errors on the API and is well worth having installed as default.

## How was this tested
- (Local) Changing `OPEN5E_DEBUG` environment variable to False to confirm that the toolbar *didn't* run outside of debug mode.
- (Local) Run `pytest` to make sure the toolbar didn't interfere with it.

Pending to see whether the the toolbar is able to get out of the way correctly during CI tests. Standby.