### PR TITLE
Fix srd-2024 Fighter and Monk saving_throws to match their Core Traits tables

### DIFF
--- a/data/v2/wizards-of-the-coast/srd-2024/CharacterClass.json
+++ b/data/v2/wizards-of-the-coast/srd-2024/CharacterClass.json
@@ -155,7 +155,7 @@
     "name": "Fighter",
     "primary_abilities": [],
     "saving_throws": [
-      "dex",
+      "con",
       "str"
     ],
     "subclass_of": null
@@ -200,7 +200,7 @@
     "primary_abilities": [],
     "saving_throws": [
       "dex",
-      "wis"
+      "str"
     ],
     "subclass_of": null
   },


### PR DESCRIPTION
The structured `saving_throws` fields for two srd-2024 classes contradict the classes' own `core-traits` feature tables (and the SRD 5.2 Core Traits tables in the CC document):

| Class | `saving_throws` field | Core Traits table |
|---|---|---|
| Fighter | `["dex", "str"]` | "Strength and Constitution" |
| Monk | `["dex", "wis"]` | "Strength and Dexterity" |

This PR corrects both fields (`["con", "str"]` and `["dex", "str"]`, keeping the existing array ordering style). I swept all twelve srd-2024 classes against their own core-traits prose — the other ten fields already match.

Found while using the srd-2024 document as the verification source for a downstream 5e engine — thanks for maintaining this dataset; the verbatim rules text has been flawless in our audits.