### PR TITLE
spin up multiple workers to reduce timeouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,10 @@ COPY --from=builder /opt/services/open5e-api/db.sqlite3 ./db.sqlite3
 COPY --from=builder /opt/services/open5e-api/manage.py ./manage.py
 COPY --from=builder /opt/services/open5e-api/newrelic.ini ./newrelic.ini
 
-ENV PATH="/opt/services/open5e-api/.venv/bin:$PATH"
+ENV PATH="/opt/services/open5e-api/.venv/bin:$PATH" \
+    WEB_CONCURRENCY=3 \
+    GUNICORN_TIMEOUT=120
 
 RUN python -m gunicorn --version
 
-CMD ["python", "-m", "gunicorn", "-b", ":8888", "server.wsgi:application"]
+CMD ["sh", "-c", "python -m gunicorn -b :8888 -w ${WEB_CONCURRENCY} --timeout ${GUNICORN_TIMEOUT} server.wsgi:application"]

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ uv run python manage.py runserver
 If you would like to host the API yourself locally, we suggest using gunicorn as your wsgi server. Below is an equivalent command to what we use in production, which makes the server available at `http://localhost:8888`.
 
 ```bash
-gunicorn -b :8888 server.wsgi:application
+gunicorn -b :8888 -w 3 --timeout 120 server.wsgi:application
 ```
 
 You can use our Dockerfile as inspiration, but it likely will not work without significant edits to your operating environment. We have customized our production environment to use it.


### PR DESCRIPTION
This splits our server into 3 parallel gunicorn workers so that it doesn't timeout if someone makes a slow request